### PR TITLE
Add "Clear all code flash" option to revive "bricked" SOP8's

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -285,7 +285,7 @@ help:
 	fprintf( stderr, " -t Disable 3.3V\n" );
 	fprintf( stderr, " -f Disable 5V\n" );
 	fprintf( stderr, " -u Clear all code flash - by power off\n" );
-	fprintf( stderr, " -r Release from reest\n" );
+	fprintf( stderr, " -r Release from Reset\n" );
 	fprintf( stderr, " -R Place into Reset\n" );
 	fprintf( stderr, " -D Configure NRST as GPIO **WARNING** If you do this and you reconfig\n" );
 	fprintf( stderr, "      the SWIO pin (PD1) on boot, your part can never again be programmed!\n" );

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -73,6 +73,7 @@ keep_going:
 			case '5': wch_link_command( devh, "\x81\x0d\x01\x0b", 4, 0, 0, 0 ); break;
 			case 't': wch_link_command( devh, "\x81\x0d\x01\x0a", 4, 0, 0, 0 ); break;
 			case 'f': wch_link_command( devh, "\x81\x0d\x01\x0c", 4, 0, 0, 0 ); break;
+			case 'u': wch_link_command( devh, "\x81\x0d\x01\x0f\x09", 5, 0, 0, 0 ); break;
 			case 'r': 
 				// This is clearly not the "best" method to exit reset.  I don't know why this combination works.
 				wch_link_multicommands( devh, 3, 4, "\x81\x0b\x01\x01", 4, "\x81\x0d\x01\x02", 4, "\x81\x0d\x01\xff" );
@@ -283,6 +284,7 @@ help:
 	fprintf( stderr, " -5 Enable 5V\n" );
 	fprintf( stderr, " -t Disable 3.3V\n" );
 	fprintf( stderr, " -f Disable 5V\n" );
+	fprintf( stderr, " -u Clear all code flash - by power off\n" );
 	fprintf( stderr, " -r Release from reest\n" );
 	fprintf( stderr, " -R Place into Reset\n" );
 	fprintf( stderr, " -D Configure NRST as GPIO **WARNING** If you do this and you reconfig\n" );


### PR DESCRIPTION
When using D5 as serial out the chip can not be flashed anymore. For this case there is an option to erase the device. I sniffed the command with usbpcap on windows and added it to minichlink.

Example: The chips is sending data via D5 which stops D1 form working as SDIO:

```
# make program
openocd -f ./vendor/wch-riscv.cfg -c init -c halt -c "program ./build/firmware.bin" -c exit
Open On-Chip Debugger 0.11.0+dev-02215-gcc0ecfb6d-dirty (2022-11-05-14:36)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : only one transport option; autoselect 'jtag'
Ready for Remote Connections
Info : WCH-LinkE-CH32V307  mod:RV version 2.8 
Error:  WCH-Link failed to connect with riscvchip
Error:  1.Make sure the two-line debug interface has been opened. If not, set board to boot mode then use ISP tool to open it
Error:  2.Please check your physical link connection

make: *** [program] Error 1
```
The flashing failed.

Now we use the new option to "unbrick" the chip:
```
17:10:05 - paul@mrbook:~/dev/wch/CH32V003-boilerplate
# minichlink -u
Part Type (A): 0xffff (This is the capacity code, in KB)
Part UUID    : ff-ff-ff-ff-ff-ff-ff-ff
PFlags       : ff-ff-ff-ff
Part Type (B): ff-ff-ff-ff
17:10:13 - paul@mrbook:~/dev/wch/CH32V003-boilerplate
```
... and we can flash again (once):

```
# make program
openocd -f ./vendor/wch-riscv.cfg -c init -c halt -c "program ./build/firmware.bin" -c exit
Open On-Chip Debugger 0.11.0+dev-02215-gcc0ecfb6d-dirty (2022-11-05-14:36)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : only one transport option; autoselect 'jtag'
Ready for Remote Connections
Info : WCH-LinkE-CH32V307  mod:RV version 2.8 
Info : wlink_init ok
Info : This adapter doesn't support configurable speed
Info : JTAG tap: riscv.cpu tap/device found: 0x00000001 (mfg: 0x000 (<invalid>), part: 0x0000, ver: 0x0)
Warn : Bypassing JTAG setup events due to errors
Info : [riscv.cpu.0] datacount=2 progbufsize=8
Info : Examined RISC-V core; found 1 harts
Info :  hart 0: XLEN=32, misa=0x40800014
[riscv.cpu.0] Target successfully examined.
Info : starting gdb server for riscv.cpu.0 on 3333
Info : Listening on port 3333 for gdb connections
Info : JTAG tap: riscv.cpu tap/device found: 0x00000001 (mfg: 0x000 (<invalid>), part: 0x0000, ver: 0x0)
Warn : Bypassing JTAG setup events due to errors
** Programming Started **
Info : device id = 0x6e1fabcd
Info : flash size = 16kbytes
Info : Hart 0 unexpectedly reset!
** Programming Finished **
17:10:18 - paul@mrbook:~/dev/wch/CH32V003-boilerplate
```

Background:
D5 and D1 are shared on SOP8.Pin8
<img width="274" alt="Screenshot 2023-03-02 at 17 13 44" src="https://user-images.githubusercontent.com/930238/222485955-f6ea25bb-689c-46f2-a229-4329c5d5a645.png">
