### PR TITLE
Prevent overwrite of HSITRIM default-value in SystemInit48HSI()

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -807,8 +807,8 @@ asm volatile(
 void SystemInit48HSI( void )
 {
 	// Values lifted from the EVT.  There is little to no documentation on what this does.
-	RCC->CTLR  = RCC_HSION | RCC_PLLON;               // Use HSI, but enable PLL.
 	RCC->CFGR0 = RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2; // PLLCLK = HSI * 2 = 48 MHz; HCLK = SYSCLK = APB1
+	RCC->CTLR  |= RCC_HSION | RCC_PLLON;              // Use HSI, but enable PLL.
 	FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;             // 1 Cycle Latency
 	RCC->INTR  = 0x009F0000;                          // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
 

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -807,10 +807,10 @@ asm volatile(
 void SystemInit48HSI( void )
 {
 	// Values lifted from the EVT.  There is little to no documentation on what this does.
-	RCC->CFGR0 = RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2; // PLLCLK = HSI * 2 = 48 MHz; HCLK = SYSCLK = APB1
-	RCC->CTLR  |= RCC_HSION | RCC_PLLON;              // Use HSI, but enable PLL.
-	FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;             // 1 Cycle Latency
-	RCC->INTR  = 0x009F0000;                          // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
+	RCC->CFGR0 = RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2;     // PLLCLK = HSI * 2 = 48 MHz; HCLK = SYSCLK = APB1
+	RCC->CTLR  |= RCC_HSION | RCC_PLLON | (3 << HSITRIM); // Use HSI, but enable PLL.
+	FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;                 // 1 Cycle Latency
+	RCC->INTR  = 0x009F0000;                              // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
 
 	// From SetSysClockTo_48MHZ_HSI
 	while((RCC->CTLR & RCC_PLLRDY) == 0);                                      // Wait till PLL is ready

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -808,7 +808,7 @@ void SystemInit48HSI( void )
 {
 	// Values lifted from the EVT.  There is little to no documentation on what this does.
 	RCC->CFGR0 = RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2;    // PLLCLK = HSI * 2 = 48 MHz; HCLK = SYSCLK = APB1
-	RCC->CTLR  = RCC_HSION | RCC_PLLON | (3 << HSITRIM); // Use HSI, but enable PLL.
+	RCC->CTLR  = RCC_HSION | RCC_PLLON | (HSITRIM << 3); // Use HSI, but enable PLL.
 	FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;                // 1 Cycle Latency
 	RCC->INTR  = 0x009F0000;                             // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
 

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -807,10 +807,10 @@ asm volatile(
 void SystemInit48HSI( void )
 {
 	// Values lifted from the EVT.  There is little to no documentation on what this does.
-	RCC->CFGR0 = RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2;    // PLLCLK = HSI * 2 = 48 MHz; HCLK = SYSCLK = APB1
-	RCC->CTLR  = RCC_HSION | RCC_PLLON | (HSITRIM << 3); // Use HSI, but enable PLL.
-	FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;                // 1 Cycle Latency
-	RCC->INTR  = 0x009F0000;                             // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
+	RCC->CFGR0 = RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2;      // PLLCLK = HSI * 2 = 48 MHz; HCLK = SYSCLK = APB1
+	RCC->CTLR  = RCC_HSION | RCC_PLLON | ((HSITRIM) << 3); // Use HSI, but enable PLL.
+	FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;                  // 1 Cycle Latency
+	RCC->INTR  = 0x009F0000;                               // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
 
 	// From SetSysClockTo_48MHZ_HSI
 	while((RCC->CTLR & RCC_PLLRDY) == 0);                                      // Wait till PLL is ready

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -807,10 +807,10 @@ asm volatile(
 void SystemInit48HSI( void )
 {
 	// Values lifted from the EVT.  There is little to no documentation on what this does.
-	RCC->CFGR0 = RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2;     // PLLCLK = HSI * 2 = 48 MHz; HCLK = SYSCLK = APB1
-	RCC->CTLR  |= RCC_HSION | RCC_PLLON | (3 << HSITRIM); // Use HSI, but enable PLL.
-	FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;                 // 1 Cycle Latency
-	RCC->INTR  = 0x009F0000;                              // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
+	RCC->CFGR0 = RCC_HPRE_DIV1 | RCC_PLLSRC_HSI_Mul2;    // PLLCLK = HSI * 2 = 48 MHz; HCLK = SYSCLK = APB1
+	RCC->CTLR  = RCC_HSION | RCC_PLLON | (3 << HSITRIM); // Use HSI, but enable PLL.
+	FLASH->ACTLR = FLASH_ACTLR_LATENCY_1;                // 1 Cycle Latency
+	RCC->INTR  = 0x009F0000;                             // Clear PLL, CSSC, HSE, HSI and LSI ready flags.
 
 	// From SetSysClockTo_48MHZ_HSI
 	while((RCC->CTLR & RCC_PLLRDY) == 0);                                      // Wait till PLL is ready

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -56,6 +56,9 @@ extern "C" {
 
 #define HSI_VALUE                 ((uint32_t)24000000) /* Value of the Internal oscillator in Hz */
 
+#ifndef HSITRIM
+    #define HSITRIM 0x10
+#endif
 
 /* Interrupt Number Definition, according to the selected device */
 typedef enum IRQn


### PR DESCRIPTION
When calling the `SystemInit48HSI()`-function to set the frequency to 48 MHz the` HSITRIM`-Value in `RCC->CTLR` is set to 0 and the clock is running slower than expected. 

The Datasheet states that the setting of the PLL has to be done before setting `PLLON`.

This PR fixes this problem for me and i moved the activation of the PLL one line down.