### PR TITLE
fix platformio uartdemo environment

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -43,6 +43,7 @@ build_src_filter = ${fun_base.build_src_filter} +<examples/sandbox>
 build_src_filter = ${fun_base.build_src_filter} +<examples/self_modify_code>
 
 [env:uartdemo]
+build_flags = ${fun_base.build_flags} -DSTDOUT_UART
 build_src_filter = ${fun_base.build_src_filter} +<examples/uartdemo>
 
 [env:ws2812bdemo]


### PR DESCRIPTION
```-DSTDOUT_UART``` is missing in the uartdemo environment for platformio