### PR TITLE
Add IRQ-driven operation and clocking to 800kHz

### DIFF
--- a/examples/i2c_oled/.gdbinit
+++ b/examples/i2c_oled/.gdbinit
@@ -1,0 +1,2 @@
+file i2c_oled.elf
+target extended-remote localhost:3333

--- a/examples/i2c_oled/README.md
+++ b/examples/i2c_oled/README.md
@@ -12,6 +12,7 @@ https://user-images.githubusercontent.com/1132011/230734071-dee305de-5aad-4ca0-a
 ## Build options
 There are a few build-time options in the i2c.h source:
 * I2C_CLKRATE - defines the I2C bus clock rate. Both 100kHz and 400kHz are supported.
+800kHz has been seen to work but 1MHz did not.
 * I2C_DUTY - for I2C_CLKRATE > 100kHz this specifies the duty cycle, either 33% or 36%.
 * TIMEOUT_MAX - the amount of tries in busy-wait loops before giving up. This value
 depends on the I2C_CLKRATE and should not affect normal operation.

--- a/examples/i2c_oled/README.md
+++ b/examples/i2c_oled/README.md
@@ -11,8 +11,8 @@ https://user-images.githubusercontent.com/1132011/230734071-dee305de-5aad-4ca0-a
 
 ## Build options
 There are a few build-time options in the i2c.h source:
-* I2C_CLKRATE - currently maxxed out at 100kHz but can be reduced if needed. Higher
-rate support will be added in the future.
+* I2C_CLKRATE - defines the I2C bus clock rate. Both 100kHz and 400kHz are supported.
+* I2C_DUTY - for I2C_CLKRATE > 100kHz this specifies the duty cycle, either 33% or 36%.
 * TIMEOUT_MAX - the amount of tries in busy-wait loops before giving up. This value
 depends on the I2C_CLKRATE and should not affect normal operation.
 * I2C_IRQ - chooses IRQ-based operation instead of busy-wait polling. Useful to

--- a/examples/i2c_oled/README.md
+++ b/examples/i2c_oled/README.md
@@ -9,6 +9,17 @@ various drawing primitives.
 
 https://user-images.githubusercontent.com/1132011/230734071-dee305de-5aad-4ca0-a422-5fb31d2bb0e0.mp4
 
+## Build options
+There are a few build-time options in the i2c.h source:
+* I2C_CLKRATE - currently maxxed out at 100kHz but can be reduced if needed. Higher
+rate support will be added in the future.
+* TIMEOUT_MAX - the amount of tries in busy-wait loops before giving up. This value
+depends on the I2C_CLKRATE and should not affect normal operation.
+* I2C_IRQ - chooses IRQ-based operation instead of busy-wait polling. Useful to
+free up CPU resources but should be used carefully since it has more potential
+mysterious effects and less error checking.
+* IRQ_DIAG - enables timing analysis via GPIO toggling. Don't enable this unless
+you know what you're doing.
 
 ## Use
 Connect an SSD1306-based OLED in I2C interface mode to pins PC1 (SCL) and PC2 (SDA)

--- a/examples/i2c_oled/README.md
+++ b/examples/i2c_oled/README.md
@@ -12,7 +12,12 @@ https://user-images.githubusercontent.com/1132011/230734071-dee305de-5aad-4ca0-a
 ## Build options
 There are a few build-time options in the i2c.h source:
 * I2C_CLKRATE - defines the I2C bus clock rate. Both 100kHz and 400kHz are supported.
-800kHz has been seen to work but 1MHz did not.
+800kHz has been seen to work when I2C_PRERATE is 1000000, but 1MHz did not. To
+use higher bus rates you must increase I2C_PRERATE at the expense of higher power
+consumption.
+* I2C_PRERATE - defines the I2C logic clock rate. Must be higher than I2C_CLKRATE.
+Keep this value as low as possible (but not lower than 1000000) to ensure low power
+operaton.
 * I2C_DUTY - for I2C_CLKRATE > 100kHz this specifies the duty cycle, either 33% or 36%.
 * TIMEOUT_MAX - the amount of tries in busy-wait loops before giving up. This value
 depends on the I2C_CLKRATE and should not affect normal operation.

--- a/examples/i2c_oled/debug.sh
+++ b/examples/i2c_oled/debug.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# before running this you should start OOCD server
+#../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/openocd -f ../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/wch-riscv.cfg
+ 
+../../../MRS_Toolchain_Linux_x64_V1.70/RISC-V\ Embedded\ GCC/bin/riscv-none-embed-gdb

--- a/examples/i2c_oled/i2c.h
+++ b/examples/i2c_oled/i2c.h
@@ -7,7 +7,7 @@
 #define _I2C_H
 
 // I2C clock rate
-#define I2C_CLKRATE 400000
+#define I2C_CLKRATE 800000
 
 // uncomment this for high-speed 36% duty cycle, otherwise 33%
 #define I2C_DUTY

--- a/examples/i2c_oled/i2c.h
+++ b/examples/i2c_oled/i2c.h
@@ -7,7 +7,10 @@
 #define _I2C_H
 
 // I2C clock rate
-#define I2C_CLKRATE 100000
+#define I2C_CLKRATE 400000
+
+// uncomment this for high-speed 36% duty cycle, otherwise 33%
+#define I2C_DUTY
 
 // I2C Timeout count
 #define TIMEOUT_MAX 100000
@@ -46,7 +49,16 @@ void i2c_setup(void)
 	// standard mode good to 100kHz
 	tempreg = (APB_CLOCK/(2*I2C_CLKRATE))&I2C_CKCFGR_CCR;
 #else
-	// fast mode not yet handled here
+	// fast mode over 100kHz
+#ifndef I2C_DUTY
+	// 33% duty cycle
+	tempreg = (APB_CLOCK/(3*I2C_CLKRATE))&I2C_CKCFGR_CCR;
+#else
+	// 36% duty cycle
+	tempreg = (APB_CLOCK/(25*I2C_CLKRATE))&I2C_CKCFGR_CCR;
+	tempreg |= I2C_CKCFGR_DUTY;
+#endif
+	tempreg |= I2C_CKCFGR_FS;
 #endif
 	I2C1->CKCFGR = tempreg;
 

--- a/examples/i2c_oled/i2c.h
+++ b/examples/i2c_oled/i2c.h
@@ -6,8 +6,11 @@
 #ifndef _I2C_H
 #define _I2C_H
 
-// I2C clock rate
-#define I2C_CLKRATE 800000
+// I2C Bus clock rate - must be lower the Logic clock rate
+#define I2C_CLKRATE 1000000
+
+// I2C Logic clock rate - must be higher than Bus clock rate
+#define I2C_PRERATE 2000000
 
 // uncomment this for high-speed 36% duty cycle, otherwise 33%
 #define I2C_DUTY
@@ -40,7 +43,7 @@ void i2c_setup(void)
 	// set freq
 	tempreg = I2C1->CTLR2;
 	tempreg &= ~I2C_CTLR2_FREQ;
-	tempreg |= (APB_CLOCK/1000000)&I2C_CTLR2_FREQ;
+	tempreg |= (APB_CLOCK/I2C_PRERATE)&I2C_CTLR2_FREQ;
 	I2C1->CTLR2 = tempreg;
 	
 	// Set clock config


### PR DESCRIPTION
This PR upgrades the I2C driver to operate with non-blocking IRQ-driven I/O and adds high-speed clocking which has been tested to 800kHz.