### PR TITLE
Add an example for the MCO function

### DIFF
--- a/examples/MCOtest/MCOtest.c
+++ b/examples/MCOtest/MCOtest.c
@@ -1,0 +1,66 @@
+#define SYSTEM_CORE_CLOCK 48000000
+#define APB_CLOCK SYSTEM_CORE_CLOCK
+
+#include "ch32v003fun.h"
+#include <stdio.h>
+
+int main()
+{
+	uint32_t count, regtemp;
+
+	SystemInit48HSI();
+        SetupUART( UART_BRR );
+
+	Delay_Ms(50);
+	printf("\r\r\n\nTesting MCO output options.\r\n");
+	count=0;
+
+	RCC->APB2PCENR |= RCC_APB2Periph_GPIOC;
+
+        // PC4 is T1CH4, 50MHz Output PP CNF = 10: Mux PP, MODE = 11: Out 50MHz
+        GPIOC->CFGLR &= ~(GPIO_CFGLR_MODE4 | GPIO_CFGLR_CNF4);
+        GPIOC->CFGLR |= GPIO_CFGLR_CNF4_1 | GPIO_CFGLR_MODE4_0 | GPIO_CFGLR_MODE4_1;
+
+	while(1)
+	{
+		switch(count)
+		{
+			case 0:
+				printf("\r\nNo signal on MCO\r\n");
+				regtemp = (RCC->CFGR0 & ~RCC_CFGR0_MCO);
+				printf("CFGR0 going from %08lX to %08lX\r\n", RCC->CFGR0, regtemp);
+				RCC->CFGR0 = regtemp;
+				count++;
+				break;
+			case 1:
+				printf("\r\nSYSCLK signal on MCO\r\n");
+				regtemp = (RCC->CFGR0 & ~RCC_CFGR0_MCO) | RCC_CFGR0_MCO_SYSCLK;
+				printf("CFGR0 going from %08lX to %08lX\r\n", RCC->CFGR0, regtemp);
+				RCC->CFGR0 = regtemp;
+				count++;
+				break;
+			case 2:
+				printf("\r\nHSI signal on MCO\r\n");
+				regtemp = (RCC->CFGR0 & ~RCC_CFGR0_MCO) | RCC_CFGR0_MCO_HSI;
+				printf("CFGR0 going from %08lX to %08lX\r\n", RCC->CFGR0, regtemp);
+				RCC->CFGR0 = regtemp;
+				count++;
+				break;
+			case 3:
+				printf("\r\nHSE signal on MCO\r\n");
+				regtemp = (RCC->CFGR0 & ~RCC_CFGR0_MCO) | RCC_CFGR0_MCO_HSE;
+				printf("CFGR0 going from %08lX to %08lX\r\n", RCC->CFGR0, regtemp);
+				RCC->CFGR0 = regtemp;
+				count++;
+				break;
+			case 4:
+				printf("\r\nPLLCLK signal on MCO\r\n");
+				regtemp = (RCC->CFGR0 & ~RCC_CFGR0_MCO) | RCC_CFGR0_MCO_PLL;
+				printf("CFGR0 going from %08lX to %08lX\r\n", RCC->CFGR0, regtemp);
+				RCC->CFGR0 = regtemp;
+				count=0;
+				break;
+		}
+		Delay_Ms(5000);
+	}
+}

--- a/examples/MCOtest/Makefile
+++ b/examples/MCOtest/Makefile
@@ -1,0 +1,51 @@
+TARGET:=MCOtest
+
+all : flash
+
+PREFIX:=riscv64-unknown-elf
+
+GPIO_Toggle:=EXAM/GPIO/GPIO_Toggle/User
+
+EVT:=../../ch32v003evt
+
+MINICHLINK:=../../minichlink
+
+ifeq ($(OS),Windows_NT)
+# On Windows, all the major RISC-V GCC installs are missing the -ec libgcc.
+LIB_GCC=../../misc/libgcc.a
+else
+LIB_GCC=-lgcc
+endif
+
+CH32V003FUN:=../../ch32v003fun
+
+CFLAGS:= \
+	-g -Os -flto -ffunction-sections \
+	-static-libgcc $(LIB_GCC) \
+	-march=rv32ec \
+	-mabi=ilp32e \
+	-I/usr/include/newlib \
+	-I$(CH32V003FUN) \
+	-nostdlib \
+	-I. -DSTDOUT_UART -DTINYVECTOR -Wall
+
+LDFLAGS:=-T $(CH32V003FUN)/ch32v003fun.ld -Wl,--gc-sections
+
+SYSTEM_C:=$(CH32V003FUN)/ch32v003fun.c
+
+$(TARGET).elf : $(SYSTEM_C) $(TARGET).c
+	$(PREFIX)-gcc -o $@ $^ $(CFLAGS) $(LDFLAGS)
+
+$(TARGET).bin : $(TARGET).elf
+	$(PREFIX)-size $^
+	$(PREFIX)-objdump -S $^ > $(TARGET).lst
+	$(PREFIX)-objdump -t $^ > $(TARGET).map
+	$(PREFIX)-objcopy -O binary $< $(TARGET).bin
+	$(PREFIX)-objcopy -O ihex $< $(TARGET).hex
+
+flash : $(TARGET).bin
+	$(MINICHLINK)/minichlink -w $< flash -b
+
+clean :
+	rm -rf $(TARGET).elf $(TARGET).bin $(TARGET).hex $(TARGET).lst $(TARGET).map $(TARGET).hex
+

--- a/examples/MCOtest/README.md
+++ b/examples/MCOtest/README.md
@@ -1,0 +1,11 @@
+This example demonstrates the MCO feature of the CH32V003.  This allows the device to output one of four internal
+clock signals to the PC4 pin.  It cycles through no signal and each of the four different clock signals.  Each
+signal is output for five seconds before moving on to the next.  The serial output displays the signals as they
+are selected.
+
+The different signals are:
+0) Nothing
+1) SYSCLK (48MHz)
+2) HSI (24MHz)
+3) HSE (depends on external XTAL)
+4) PLL clock output (48MHz)


### PR DESCRIPTION
I wrote a quick example of how to use the MCO function to output one of the internal clock signals to the MCO pin (PC4)