### PR TITLE
Added option so Arch Linux will pull in zicsr support

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -765,7 +765,8 @@ void handle_reset()
 .option norelax\n\
 	la gp, __global_pointer$\n\
 .option pop\n\
-	la sp, _eusrstack\n"
+	la sp, _eusrstack\n\
+.option arch, +zicsr\n"
 	// Setup the interrupt vector, processor status and INTSYSCR.
 "	li a0, 0x80\n\
 	csrw mstatus, a0\n\


### PR DESCRIPTION
Added '.option arch, +zicsr\n" ' so that Arch Linux will pull in support for zicsr. 