### PR TITLE
Add putchar() to fix linker errors when using printf on single character strings

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -32,7 +32,11 @@ int printf(const char* format, ...)
 	return ret_status;
 }
 
-
+int putchar(int c)
+{
+	return _write( 0, (const char *)(&c), 1 );
+}
+	
 /* Some stuff from MUSL
 
 


### PR DESCRIPTION
This PR adds a putchar() function which is required to handle cases where single-character printf() calls are optimized by GCC. It has been tested and confirmed to work with both UART and Debug printing.