### PR TITLE
Add support for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ On WSL or Debian based OSes `apt-get install build-essential libnewlib-dev gcc-r
 
 On Windows, download and install (to system) this copy of GCC10. https://gnutoolchains.com/risc-v/
 
+On macOS install the RISC-V toolchain with homebrew following the instructions at https://github.com/riscv-software-src/homebrew-riscv
+
 You can use the pre-compiled minichlink or 
 
 ## Running

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -4822,8 +4822,13 @@ extern "C" {
 #define DELAY_US_TIME (SYSTEM_CORE_CLOCK / 8000000)
 #define DELAY_MS_TIME (SYSTEM_CORE_CLOCK / 8000)
 
+#if defined(__APPLE__) && defined(__MACH__)
+void handle_reset()            __attribute__((naked)) __attribute((section("__TEXT,.text.ha_re"))) __attribute__((used));
+void DefaultIRQHandler( void ) __attribute__((section("__TEXT,.text.ve_ha"))) __attribute__((naked)) __attribute__((used));
+#else
 void handle_reset()            __attribute__((naked)) __attribute((section(".text.handle_reset"))) __attribute__((used));
 void DefaultIRQHandler( void ) __attribute__((section(".text.vector_handler"))) __attribute__((naked)) __attribute__((used));
+#endif
 
 void DelaySysTick( uint32_t n );
 

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -4822,10 +4822,7 @@ extern "C" {
 #define DELAY_US_TIME (SYSTEM_CORE_CLOCK / 8000000)
 #define DELAY_MS_TIME (SYSTEM_CORE_CLOCK / 8000)
 
-#if defined(__APPLE__) && defined(__MACH__)
-void handle_reset()            __attribute__((naked)) __attribute((section("__TEXT,.text.ha_re"))) __attribute__((used));
-void DefaultIRQHandler( void ) __attribute__((section("__TEXT,.text.ve_ha"))) __attribute__((naked)) __attribute__((used));
-#else
+#if defined(__riscv)
 void handle_reset()            __attribute__((naked)) __attribute((section(".text.handle_reset"))) __attribute__((used));
 void DefaultIRQHandler( void ) __attribute__((section(".text.vector_handler"))) __attribute__((naked)) __attribute__((used));
 #endif

--- a/minichlink/Makefile.macos
+++ b/minichlink/Makefile.macos
@@ -1,0 +1,19 @@
+TOOLS:=minichlink
+
+all : $(TOOLS)
+
+CFLAGS:=-O0 -Wall -Wno-asm-operand-widths -Wno-deprecated-declarations -Wno-deprecated-non-prototype -D__MACOSX__
+LDFLAGS:=-lpthread -lusb-1.0 -framework CoreFoundation -framework IOKit
+
+INCLUDES=-I /opt/homebrew/Cellar/libusb/1.0.26/include/libusb-1.0
+LIBINCLUDES=-L /opt/homebrew/Cellar/libusb/1.0.26/lib
+
+minichlink : minichlink.c pgm-wch-linke.c pgm-esp32s2-ch32xx.c
+	gcc -o $@ $^ $(LDFLAGS) $(CFLAGS) $(INCLUDES) $(LIBINCLUDES)
+
+inspect_bootloader : minichlink
+	./minichlink -r test.bin launcher 0x780
+	riscv64-unknown-elf-objdump -S -D test.bin -b binary -m riscv:rv32 | less
+
+clean :
+	rm -rf $(TOOLS)

--- a/minichlink/README.md
+++ b/minichlink/README.md
@@ -8,6 +8,8 @@ On Windows, if you need to you can install the WinUSB driver over the WCH interf
 
 The exe here is about 12kB and contains everything except for the libusb driver.  In Linux you need `libusb-1.0-dev`.
 
+On macOS compile using `make -f Makefile.macos`, you need libusb installed which can be done with homebrew `brew install libusb`.
+
 ## Usage
 
 ```

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -720,7 +720,7 @@ static int DefaultWriteWord( void * dev, uint32_t address_to_write, uint32_t dat
 
 	iss->currentstateval += 4;
 
-	return 0;
+	return ret;
 }
 
 


### PR DESCRIPTION
Tested on a M1, but I haven't tried it on older Intel-based machines.

I turned off some warnings since the compiler spewed a lot of warnings which looks ugly. :) There's one warning still remaining, it's an easy fix but I didn't feel comfortable doing that since it might be a reason for the function DefaultWriteWord() to always return a hardcoded 0 instead of the ret -value.

```
minichlink.c:636:6: warning: variable 'ret' set but not used [-Wunused-but-set-variable]
        int ret = 0;
            ^
```
**-Wno-deprecated-non-prototype** takes care of warnings for main() 

**-Wno-deprecated-declarations** handlers a deprecation warning for kIOMasterPortDefault

**-Wno-asm-operand-widths** takes care of all the warnings below which I don't want to fix since it might affect the other architectures. @cnlohr definitely have a better understanding of this than me.
```
./../ch32v003fun/ch32v003fun.h:4333:45: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
  __asm volatile("csrr %0," "mstatus": "=r"(result));
                                            ^
./../ch32v003fun/ch32v003fun.h:4333:24: note: use constraint modifier "w"
  __asm volatile("csrr %0," "mstatus": "=r"(result));
                       ^~
                       %w0
./../ch32v003fun/ch32v003fun.h:4335:47: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
  __asm volatile ("csrw mstatus, %0" : : "r" (result) );
                                              ^
./../ch32v003fun/ch32v003fun.h:4335:34: note: use constraint modifier "w"
  __asm volatile ("csrw mstatus, %0" : : "r" (result) );
                                 ^~
                                 %w0
./../ch32v003fun/ch32v003fun.h:4349:45: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
  __asm volatile("csrr %0," "mstatus": "=r"(result));
                                            ^
./../ch32v003fun/ch32v003fun.h:4349:24: note: use constraint modifier "w"
  __asm volatile("csrr %0," "mstatus": "=r"(result));
                       ^~
                       %w0
./../ch32v003fun/ch32v003fun.h:4351:47: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
  __asm volatile ("csrw mstatus, %0" : : "r" (result) );
                                              ^
./../ch32v003fun/ch32v003fun.h:4351:34: note: use constraint modifier "w"
  __asm volatile ("csrw mstatus, %0" : : "r" (result) );
                                 ^~
                                 %w0
./../ch32v003fun/ch32v003fun.h:4566:47: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0," "mstatus": "=r"(result));
                                              ^
./../ch32v003fun/ch32v003fun.h:4566:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0," "mstatus": "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4581:47: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrw mstatus, %0" : : "r"(value));
                                              ^
./../ch32v003fun/ch32v003fun.h:4581:35: note: use constraint modifier "w"
    __ASM volatile("csrw mstatus, %0" : : "r"(value));
                                  ^~
                                  %w0
./../ch32v003fun/ch32v003fun.h:4595:44: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0,""misa" : "=r"(result));
                                           ^
./../ch32v003fun/ch32v003fun.h:4595:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0,""misa" : "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4610:44: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrw misa, %0" : : "r"(value));
                                           ^
./../ch32v003fun/ch32v003fun.h:4610:32: note: use constraint modifier "w"
    __ASM volatile("csrw misa, %0" : : "r"(value));
                               ^~
                               %w0
./../ch32v003fun/ch32v003fun.h:4624:45: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0," "mtvec": "=r"(result));
                                            ^
./../ch32v003fun/ch32v003fun.h:4624:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0," "mtvec": "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4639:43: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrw mtvec, %0":: "r"(value));
                                          ^
./../ch32v003fun/ch32v003fun.h:4639:33: note: use constraint modifier "w"
    __ASM volatile("csrw mtvec, %0":: "r"(value));
                                ^~
                                %w0
./../ch32v003fun/ch32v003fun.h:4653:49: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0," "mscratch" : "=r"(result));
                                                ^
./../ch32v003fun/ch32v003fun.h:4653:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0," "mscratch" : "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4668:48: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrw mscratch, %0" : : "r"(value));
                                               ^
./../ch32v003fun/ch32v003fun.h:4668:36: note: use constraint modifier "w"
    __ASM volatile("csrw mscratch, %0" : : "r"(value));
                                   ^~
                                   %w0
./../ch32v003fun/ch32v003fun.h:4682:45: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0," "mepc" : "=r"(result));
                                            ^
./../ch32v003fun/ch32v003fun.h:4682:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0," "mepc" : "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4695:44: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrw mepc, %0" : : "r"(value));
                                           ^
./../ch32v003fun/ch32v003fun.h:4695:32: note: use constraint modifier "w"
    __ASM volatile("csrw mepc, %0" : : "r"(value));
                               ^~
                               %w0
./../ch32v003fun/ch32v003fun.h:4709:46: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0," "mcause": "=r"(result));
                                             ^
./../ch32v003fun/ch32v003fun.h:4709:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0," "mcause": "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4722:44: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrw mcause, %0":: "r"(value));
                                           ^
./../ch32v003fun/ch32v003fun.h:4722:34: note: use constraint modifier "w"
    __ASM volatile("csrw mcause, %0":: "r"(value));
                                 ^~
                                 %w0
./../ch32v003fun/ch32v003fun.h:4736:48: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0,""mvendorid": "=r"(result));
                                               ^
./../ch32v003fun/ch32v003fun.h:4736:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0,""mvendorid": "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4751:46: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0,""marchid": "=r"(result));
                                             ^
./../ch32v003fun/ch32v003fun.h:4751:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0,""marchid": "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4766:45: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0,""mimpid": "=r"(result));
                                            ^
./../ch32v003fun/ch32v003fun.h:4766:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0,""mimpid": "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4781:46: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("csrr %0,""mhartid": "=r"(result));
                                             ^
./../ch32v003fun/ch32v003fun.h:4781:26: note: use constraint modifier "w"
    __ASM volatile("csrr %0,""mhartid": "=r"(result));
                         ^~
                         %w0
./../ch32v003fun/ch32v003fun.h:4796:39: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
    __ASM volatile("mv %0,""sp": "=r"(result):);
                                      ^
./../ch32v003fun/ch32v003fun.h:4796:24: note: use constraint modifier "w"
    __ASM volatile("mv %0,""sp": "=r"(result):);
                       ^~
                       %w0
```

