### PR TITLE
Redo reverted patches for MacOS 

### DIFF
--- a/minichlink/Makefile
+++ b/minichlink/Makefile
@@ -7,14 +7,27 @@ CFLAGS:=-O0 -g3 -Wall
 ifeq ($(OS),Windows_NT)
 	LDFLAGS:=-lpthread -lusb-1.0 -lsetupapi
 else
-	LDFLAGS:=-lpthread -lusb-1.0 -ludev
+	OS_NAME := $(shell uname -s | tr A-Z a-z)
+	ifeq ($(OS_NAME),linux)
+		LDFLAGS:=-lpthread -lusb-1.0 -ludev
+	endif
+	ifeq ($(OS_NAME),darwin)
+		LDFLAGS:=-lpthread -lusb-1.0 -framework CoreFoundation -framework IOKit
+		CFLAGS:=-O0 -Wall -Wno-asm-operand-widths -Wno-deprecated-declarations -Wno-deprecated-non-prototype -D__MACOSX__
+		INCLUDES:=-I /opt/homebrew/Cellar/libusb/1.0.26/include/libusb-1.0
+		LIBINCLUDES:=-L /opt/homebrew/Cellar/libusb/1.0.26/lib 
+		INCS:=$(INCLUDES) $(LIBINCLUDES)
+	endif
 endif
 
+
+
+
 minichlink : minichlink.c pgm-wch-linke.c pgm-esp32s2-ch32xx.c nhc-link042.c
-	gcc -o $@ $^ $(LDFLAGS) $(CFLAGS)
+	gcc -o $@ $^ $(LDFLAGS) $(CFLAGS) $(INCS)
 
 minichlink.so : minichlink.c pgm-wch-linke.c pgm-esp32s2-ch32xx.c nhc-link042.c
-	gcc -o $@ $^ $(LDFLAGS) $(CFLAGS) -shared -fPIC
+	gcc -o $@ $^ $(LDFLAGS) $(CFLAGS) $(INCS) -shared -fPIC
 
 install_udev_rules :
 	cp 99-WCH-LinkE.rules /etc/udev/rules.d/

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -794,7 +794,7 @@ static int DefaultWriteWord( void * dev, uint32_t address_to_write, uint32_t dat
 
 	iss->currentstateval += 4;
 
-	return 0;
+	return ret;
 }
 
 


### PR DESCRIPTION
I have tested the Makefile on MacOS and Linux. I assume it will still work on windows since that define is not changed.
