### PR TITLE
Support more types of OLED displays

### DIFF
--- a/examples/i2c_oled/README.md
+++ b/examples/i2c_oled/README.md
@@ -1,10 +1,10 @@
 # I2C OLED demonstration
 This example code demonstrates use of the CH32V003 I2C peripheral with an SSD1306
-OLED (128x32 pixel type). It provides a generic I2C port initialization and
-transmit (write-only) low level interface and a high-level graphics driver with
-pixels, lines, circles, rectangles and 8x8 character font rendering. Out of the
-box this demo cycles through a few different graphic screens to test out the
-various drawing primitives.
+OLED. Three different OLED sizes are supported - 64x32, 128x32, and 128x64.
+It provides a generic I2C port initialization and transmit (write-only) low level
+interface and a high-level graphics driver with pixels, lines, circles, rectangles
+and 8x8 character font rendering. Out of the box this demo cycles through a few
+different graphic screens to test out the various drawing primitives.
 
 
 https://user-images.githubusercontent.com/1132011/230734071-dee305de-5aad-4ca0-a422-5fb31d2bb0e0.mp4
@@ -27,13 +27,23 @@ mysterious effects and less error checking.
 * IRQ_DIAG - enables timing analysis via GPIO toggling. Don't enable this unless
 you know what you're doing.
 
+There are a few build-time options in the oled.h source:
+* OLED_ADDR - the I2C address of your OLED display. The default is 0x3c which
+should work for most devices. Use 0x3d if you've pulled the SA0 line high.
+* OLED_PSZ - the number of bytes to send per I2C data packet. The default value
+of 32 seems to work well. Smaller values are allowed but may result in slower
+refresh rates.
+* OLED_64X32, OLED_128X32, OLED_128X64 - choose only one of these depending on
+the type of OLED you've got.
+
 ## Use
 Connect an SSD1306-based OLED in I2C interface mode to pins PC1 (SDA) and PC2 (SCL)
 of the CH32V003 with proper I2C pullup resistors and observe the various graphic
 images that cycle at approximately 2 second intervals.
 
-Note - I used an Adafruit 0.91" 128x32 OLED breakout (stock #4440) for my testing
-and found that the built-in 10k pullup resistors were too weak for reliable I2C
-bus transactions. I had to add 2.2k resistors to the SCL and SDA pads to allow
-proper operation.
+Note - for part of my testing I used an Adafruit 0.91" 128x32 OLED breakout
+(stock #4440) and found that the built-in 10k pullup resistors were too weak for
+reliable I2C bus transactions. I had to add 2.2k resistors to the SCL and SDA
+pads to allow proper operation. Generic OLED boards from ebay had stronger pullups
+and did not need modification.
 

--- a/examples/i2c_oled/i2c_oled.c
+++ b/examples/i2c_oled/i2c_oled.c
@@ -31,7 +31,7 @@ int main()
 		printf("Looping on test modes...");
 		while(1)
 		{
-			for(uint8_t mode=0;mode<=6;mode++)
+			for(uint8_t mode=0;mode<(OLED_H>32?8:7);mode++)
 			{
 				// clear buffer for next mode
 				oled_setbuf(0);
@@ -39,53 +39,75 @@ int main()
 				switch(mode)
 				{
 					case 0:
+						printf("buffer fill with binary\n\r");
 						for(int i=0;i<sizeof(oled_buffer);i++)
 							oled_buffer[i] = i;
 						break;
 					
 					case 1:
+						printf("pixel plots\n\r");
 						for(int i=0;i<OLED_W;i++)
 						{
-							oled_drawPixel(i, i>>2, 1);
-							oled_drawPixel(i, OLED_H-1-(i>>2), 1);
+							oled_drawPixel(i, i/(OLED_W/OLED_H), 1);
+							oled_drawPixel(i, OLED_H-1-(i/(OLED_W/OLED_H)), 1);
 						}
 						break;
 					
 					case 2:
 						{
+							printf("Line plots\n\r");
 							uint8_t y= 0;
 							for(uint8_t x=0;x<OLED_W;x+=16)
 							{
 								oled_drawLine(x, 0, OLED_W, y, 1);
 								oled_drawLine(OLED_W-x, OLED_H, 0, OLED_H-y, 1);
-								y+= 4;
+								y+= OLED_H/8;
 							}
 						}
 						break;
 						
 					case 3:
+						printf("Circles empty and filled\n\r");
 						for(uint8_t x=0;x<OLED_W;x+=16)
 							if(x<64)
-								oled_drawCircle(x,16, 15, 1);
+								oled_drawCircle(x, OLED_H/2, 15, 1);
 							else
-								oled_fillCircle(x,16, 15, 1);
+								oled_fillCircle(x, OLED_H/2, 15, 1);
 						break;
 					
 					case 4:
+						printf("Unscaled Text\n\r");
 						oled_drawstr(0,0, "This is a test", 1);
 						oled_drawstr(0,8, "of the emergency", 1);
 						oled_drawstr(0,16,"broadcasting", 1);
 						oled_drawstr(0,24,"system.",1);
-						
-						oled_xorrect(64, 0, 64, 32);
+						if(OLED_H>32)
+						{
+							oled_drawstr(0,32, "Lorem ipsum", 1);
+							oled_drawstr(0,40, "dolor sit amet,", 1);
+							oled_drawstr(0,48,"consectetur", 1);
+							oled_drawstr(0,56,"adipiscing",1);
+						}
+						oled_xorrect(OLED_W/2, 0, OLED_W/2, OLED_W);
 						break;
+						
 					case 5:
+						printf("Scaled Text 1, 2\n\r");
 						oled_drawstr_sz(0,0, "sz 8x8", 1, fontsize_8x8);
 						oled_drawstr_sz(0,16, "16x16", 1, fontsize_16x16);
 						break;
+					
 					case 6:
+						printf("Scaled Text 4\n\r");
 						oled_drawstr_sz(0,0, "32x32", 1, fontsize_32x32);
 						break;
+					
+					
+					case 7:
+						printf("Scaled Text 8\n\r");
+						oled_drawstr_sz(0,0, "64", 1, fontsize_64x64);
+						break;
+
 					default:
 						break;
 				}


### PR DESCRIPTION
This PR expands support of OLED display dimensions from the original 128x32 to include 128x64 and 64x32 types commonly available with the same SSD1306 controller. Display type is selectable at compile time with preprocessor macros and the demo code automatically adapts to utilize the full display area.