### PR TITLE
Add support for math using softfp library.

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -14,6 +14,10 @@
 
 int errno;
 
+int * __errno(void) {
+    return &errno;
+}
+
 int mini_vsnprintf(char *buffer, unsigned int buffer_len, const char *fmt, va_list va);
 int mini_vpprintf(int (*puts)(char* s, int len, void* buf), void* buf, const char *fmt, va_list va);
 

--- a/ch32v003fun/ch32v003fun.mk
+++ b/ch32v003fun/ch32v003fun.mk
@@ -12,6 +12,7 @@ CFLAGS+= \
 	-march=rv32ec \
 	-mabi=ilp32e \
 	-I$(CH32V003FUN) \
+	-I/usr/include/newlib \
 	-nostdlib \
 	-I. -Wall
 

--- a/ch32v003fun/ch32v003fun.mk
+++ b/ch32v003fun/ch32v003fun.mk
@@ -3,18 +3,22 @@ PREFIX:=riscv64-unknown-elf
 
 CH32V003FUN?=../../ch32v003fun
 MINICHLINK?=../../minichlink
+OPTFLAG?= -Os -flto
 
 CFLAGS+= \
-	-g -Os -flto -ffunction-sections \
+	-g $(OPTFLAG) -fdata-sections -ffunction-sections \
+	-fno-math-errno -ffast-math -ffinite-math-only \
 	-static-libgcc \
 	-march=rv32ec \
 	-mabi=ilp32e \
-	-I/usr/include/newlib \
 	-I$(CH32V003FUN) \
 	-nostdlib \
 	-I. -Wall
 
-LDFLAGS+=-T $(CH32V003FUN)/ch32v003fun.ld -Wl,--gc-sections -L$(CH32V003FUN)/../misc -lgcc
+LDFLAGS+= \
+    -T $(CH32V003FUN)/ch32v003fun.ld \
+	-Wl,--gc-sections \
+	-L$(CH32V003FUN)/../misc -lgcc -lm -lgcc
 
 SYSTEM_C:=$(CH32V003FUN)/ch32v003fun.c
 


### PR DESCRIPTION
Some math functions from libm complain about __errno() - added one.
Add magic incantation to the linked libs so it does not complain about missing symbols (yes list -lgcc twice)
Add new OPTFLAGS variable so user Makefiles can overwrite the optimization settings - useful for debugging

Note: removed /usr/include/newlib include path - I venture to guess most users would have compilers installed somewhere else, who knows whats in that folder and how compatible it is. Things seem to compile fine w/o it.