### PR TITLE
Fix error when using C++ virtual methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .pio
 .vscode
+.idea
 *.elf
 *.hex
 *.lst

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -660,6 +660,10 @@ mini_pprintf(int (*puts)(char*s, int len, void* buf), void* buf, const char *fmt
 	Copyright 2023 Charles Lohr, under the MIT-x11 or NewBSD licenses, you choose.
 */
 
+#ifdef CPLUSPLUS
+// Method to call the C++ constructors
+void __libc_init_array(void);
+#endif
 
 int main() __attribute__((used));
 void SystemInit( void ) __attribute__((used));
@@ -801,6 +805,12 @@ asm volatile(
 	addi a1, a1, 4\n\
 	bne a1, a2, 1b\n\
 2:\n" );
+
+#ifdef CPLUSPLUS
+    asm volatile(
+        "call %0 \n\t"        // Call __libc_init_array function
+        : : "i" (__libc_init_array) : );
+#endif
 
 	SETUP_SYSTICK_HCLK
 
@@ -973,3 +983,29 @@ void DelaySysTick( uint32_t n )
 	while( ((int32_t)( SysTick->CNT - targend )) < 0 );
 }
 
+// C++ Support
+
+#ifdef CPLUSPLUS
+// This is required to allow pure virtual functions to be defined.
+extern void __cxa_pure_virtual() { while (1); }
+
+// These magic symbols are provided by the linker.
+extern void (*__preinit_array_start[]) (void) __attribute__((weak));
+extern void (*__preinit_array_end[]) (void) __attribute__((weak));
+extern void (*__init_array_start[]) (void) __attribute__((weak));
+extern void (*__init_array_end[]) (void) __attribute__((weak));
+
+void __libc_init_array(void)
+{
+    size_t count;
+    size_t i;
+
+    count = __preinit_array_end - __preinit_array_start;
+    for (i = 0; i < count; i++)
+        __preinit_array_start[i]();
+
+    count = __init_array_end - __init_array_start;
+    for (i = 0; i < count; i++)
+        __init_array_start[i]();
+}
+#endif

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -804,13 +804,13 @@ asm volatile(
 	addi a0, a0, 4\n\
 	addi a1, a1, 4\n\
 	bne a1, a2, 1b\n\
-2:\n" );
-
+2:\n"
 #ifdef CPLUSPLUS
-    asm volatile(
-        "call %0 \n\t"        // Call __libc_init_array function
-        : : "i" (__libc_init_array) : );
+	// Call __libc_init_array function
+"	call %0 \n\t"
+: : "i" (__libc_init_array) :
 #endif
+);
 
 	SETUP_SYSTICK_HCLK
 
@@ -997,15 +997,15 @@ extern void (*__init_array_end[]) (void) __attribute__((weak));
 
 void __libc_init_array(void)
 {
-    size_t count;
-    size_t i;
+	size_t count;
+	size_t i;
 
-    count = __preinit_array_end - __preinit_array_start;
-    for (i = 0; i < count; i++)
-        __preinit_array_start[i]();
+	count = __preinit_array_end - __preinit_array_start;
+	for (i = 0; i < count; i++)
+		__preinit_array_start[i]();
 
-    count = __init_array_end - __init_array_start;
-    for (i = 0; i < count; i++)
-        __init_array_start[i]();
+	count = __init_array_end - __init_array_start;
+	for (i = 0; i < count; i++)
+		__init_array_start[i]();
 }
 #endif

--- a/ch32v003fun/ch32v003fun.mk
+++ b/ch32v003fun/ch32v003fun.mk
@@ -17,8 +17,9 @@ CFLAGS+= \
 LDFLAGS+=-T $(CH32V003FUN)/ch32v003fun.ld -Wl,--gc-sections -L$(CH32V003FUN)/../misc -lgcc
 
 SYSTEM_C:=$(CH32V003FUN)/ch32v003fun.c
+TARGET_EXT?=c
 
-$(TARGET).elf : $(SYSTEM_C) $(TARGET).c $(ADDITIONAL_C_FILES)
+$(TARGET).elf : $(SYSTEM_C) $(TARGET).$(TARGET_EXT) $(ADDITIONAL_C_FILES)
 	$(PREFIX)-gcc -o $@ $^ $(CFLAGS) $(LDFLAGS)
 
 $(TARGET).bin : $(TARGET).elf

--- a/examples/cpp_virtual_methods/Makefile
+++ b/examples/cpp_virtual_methods/Makefile
@@ -1,0 +1,26 @@
+all : flash
+
+TARGET:=cpp_virtual_methods
+TARGET_EXT:=cpp
+
+ADDITIONAL_C_FILES+=example.cpp
+
+include ../../ch32v003fun/ch32v003fun.mk
+
+# Removing compiler optimization to small file size
+# because it optimizes the virtual functions out
+# which are tested here.
+CFLAGS:= \
+	-g -flto -ffunction-sections \
+	-static-libgcc \
+	-march=rv32ec \
+	-mabi=ilp32e \
+	-I/usr/include/newlib \
+	-I$(CH32V003FUN) \
+	-nostdlib \
+	-I. -Wall
+
+CFLAGS+=-fno-rtti -DSTDOUT_UART -DCPLUSPLUS
+
+flash : cv_flash
+clean : cv_clean

--- a/examples/cpp_virtual_methods/README.md
+++ b/examples/cpp_virtual_methods/README.md
@@ -12,7 +12,7 @@ vtable for 'ExampleClass' @ 0x0 (subobject @ 0x20000004):
 
 In this case, a call to a virtual method will result to an invalid call
 and the program won't work as expected.
-Here, the program will also print out `Begin example`, but does not print any values.
+Here, the program will only print out `Begin example`, but does not print any values.
 It seems like the MCU resets here.
 
 In other environments like with the Arduino Core, the hard fault handler is called

--- a/examples/cpp_virtual_methods/README.md
+++ b/examples/cpp_virtual_methods/README.md
@@ -1,0 +1,29 @@
+# C++ Virtual Methods Example
+
+This example tests the usage of classes with virtual methods in C++.
+
+Without the usage of `__libc_init_array`, the virtual table of the class instance `Example` is not initialized correctly:
+
+```
+vtable for 'ExampleClass' @ 0x0 (subobject @ 0x20000004):
+[0]: 0x11e0006f
+[1]: 0x0 <InterruptVectorDefault()>
+```
+
+In this case, a call to a virtual method will result to an invalid call
+and the program won't work as expected.
+Here, the program will also print out `Begin example`, but does not print any values.
+It seems like the MCU resets here.
+
+In other environments like with the Arduino Core, the hard fault handler is called
+and the program gets into an infinite loop.
+
+With the macro `CPLUSPLUS`, an implemention auf `__libc_init_array` is called on startup.
+
+Then the virtual table is initialized correctly and new values are printed as expected:
+
+```
+vtable for 'ExampleClass' @ 0x212c (subobject @ 0x20000004):
+[0]: 0x1fb0 <ExampleClass::doNewLine()>
+[1]: 0x1fda <ExampleClass::printValue(int)>
+```

--- a/examples/cpp_virtual_methods/cpp_virtual_methods.cpp
+++ b/examples/cpp_virtual_methods/cpp_virtual_methods.cpp
@@ -1,0 +1,30 @@
+/*
+ * Example for using virtual methods in C++
+ * 05/21/2023 A. Mandera
+ */
+
+// Could be defined here, or in the processor defines.
+#define SYSTEM_CORE_CLOCK 48000000
+#define APB_CLOCK SYSTEM_CORE_CLOCK
+
+#include "ch32v003fun.h"
+#include "example.h"
+#include <stdio.h>
+
+int main() {
+    SystemInit48HSI();
+
+    // Setup UART @ 115200 baud
+    SetupUART(UART_BRR);
+    Delay_Ms(100);
+
+    printf("Begin example\n");
+
+    // Initialize variable in example class
+    Example.begin();
+
+    while (true) {
+        Example.doPrint(10);
+        Delay_Ms(1000);
+    }
+}

--- a/examples/cpp_virtual_methods/cpp_virtual_methods.cpp
+++ b/examples/cpp_virtual_methods/cpp_virtual_methods.cpp
@@ -12,19 +12,19 @@
 #include <stdio.h>
 
 int main() {
-    SystemInit48HSI();
+	SystemInit48HSI();
 
-    // Setup UART @ 115200 baud
-    SetupUART(UART_BRR);
-    Delay_Ms(100);
+	// Setup UART @ 115200 baud
+	SetupUART(UART_BRR);
+	Delay_Ms(100);
 
-    printf("Begin example\n");
+	printf("Begin example\n");
 
-    // Initialize variable in example class
-    Example.begin();
+	// Initialize variable in example class
+	Example.begin();
 
-    while (true) {
-        Example.doPrint(10);
-        Delay_Ms(1000);
-    }
+	while (true) {
+		Example.doPrint(10);
+		Delay_Ms(1000);
+	}
 }

--- a/examples/cpp_virtual_methods/example.cpp
+++ b/examples/cpp_virtual_methods/example.cpp
@@ -1,0 +1,30 @@
+/*
+ * Example for using virtual methods in C++
+ * 05/21/2023 A. Mandera
+ */
+
+#include "example.h"
+#include "stdio.h"
+
+ExampleClass Example;
+
+void Print::doPrint(int i) {
+    printValue(i);
+    doNewLine();
+}
+
+void ExampleClass::begin() {
+    this->_value = 1;
+}
+
+int ExampleClass::value() {
+    return this->_value++;
+}
+
+void ExampleClass::doNewLine() {
+    printf("\n");
+}
+
+void ExampleClass::printValue(int i) {
+    printf("Value: %d", this->value() + i);
+};

--- a/examples/cpp_virtual_methods/example.cpp
+++ b/examples/cpp_virtual_methods/example.cpp
@@ -9,22 +9,22 @@
 ExampleClass Example;
 
 void Print::doPrint(int i) {
-    printValue(i);
-    doNewLine();
+	printValue(i);
+	doNewLine();
 }
 
 void ExampleClass::begin() {
-    this->_value = 1;
+	this->_value = 1;
 }
 
 int ExampleClass::value() {
-    return this->_value++;
+	return this->_value++;
 }
 
 void ExampleClass::doNewLine() {
-    printf("\n");
+	printf("\n");
 }
 
 void ExampleClass::printValue(int i) {
-    printf("Value: %d", this->value() + i);
+	printf("Value: %d", this->value() + i);
 };

--- a/examples/cpp_virtual_methods/example.h
+++ b/examples/cpp_virtual_methods/example.h
@@ -7,19 +7,20 @@
 
 class Print {
 public:
-    void doPrint(int);
-    virtual void doNewLine(void) = 0;
-    virtual void printValue(int) = 0;
+	void doPrint(int);
+	virtual void doNewLine(void) = 0;
+	virtual void printValue(int) = 0;
 };
 
 class ExampleClass : public Print {
 public:
-    void begin();
-    int value();
-    void doNewLine(void) override;
-    void printValue(int) override;
+	void begin();
+	int value();
+	void doNewLine(void) override;
+	void printValue(int) override;
+
 private:
-    int _value;
+	int _value;
 };
 
 extern ExampleClass Example;

--- a/examples/cpp_virtual_methods/example.h
+++ b/examples/cpp_virtual_methods/example.h
@@ -1,0 +1,25 @@
+/*
+ * Example for using virtual methods in C++
+ * 05/21/2023 A. Mandera
+ */
+
+#pragma once
+
+class Print {
+public:
+    void doPrint(int);
+    virtual void doNewLine(void) = 0;
+    virtual void printValue(int) = 0;
+};
+
+class ExampleClass : public Print {
+public:
+    void begin();
+    int value();
+    void doNewLine(void) override;
+    void printValue(int) override;
+private:
+    int _value;
+};
+
+extern ExampleClass Example;


### PR DESCRIPTION
When using ch32v003fun with C++, there is an error when using virtual methods,
which is shown in the example program "cpp_virtual_methods" in the examples folder.

Without the usage of `__libc_init_array`, the virtual table of the class instance `Example` is not initialized correctly:

```
(gdb) info vtbl Example
vtable for 'ExampleClass' @ 0x0 (subobject @ 0x20000004):
[0]: 0x11e0006f
[1]: 0x0 <InterruptVectorDefault()>
```

In this case, a call to a virtual method will result to an invalid call and the program won't work as expected.

Here, the example program will only print out `Begin example`,
but does not print any values which are implemented in overridden virtual methods.
It seems like the MCU resets here.

In other environments like with my Arduino Core, the hard fault interrupt handler was called
and the program gets into an infinite loop.

With the added macro `CPLUSPLUS`, an implemention auf `__libc_init_array` is called in `handle_reset()`.

After that change, the virtual table is initialized correctly and new values are printed as expected:

```
(gdb) info vtbl Example
vtable for 'ExampleClass' @ 0x212c (subobject @ 0x20000004):
[0]: 0x1fb0 <ExampleClass::doNewLine()>
[1]: 0x1fda <ExampleClass::printValue(int)>
```

This also reflects the startup code for C++ inside the `OpenWCH/ch32v003` repository:
https://github.com/openwch/ch32v003/blob/main/C%2B%2B/Use%20MRS%20Create%20C%2B%2B%20project-example/CH32V003F4P6/Startup/startup_ch32v00x.S#L160

Another small change I did, was to add `TARGET_EXT` in `ch32v003fun.mk`, so my target file can be a C++ file and it is not limited to C.

The wrong behavior with vtables can be tested by removing the `CPLUSPLUS` macro in the example program's Makefile.
If another macro name other than `CPLUSPLUS` or even another solution is better in this case, then let me know :)

P.S.: I have tested my changes in my Arduino Core with my HardwareSerial implementation
and it seems to work fine there. So when this PR is merged, I can use upstream ch32v003fun as a submodule there. 👍