### PR TITLE
Update wiring.c

### DIFF
--- a/examples/GPIO/wiring.c
+++ b/examples/GPIO/wiring.c
@@ -45,7 +45,7 @@ void pinMode(enum GPIOpins pin, enum GPIOpinMode mode) {
 	
 	if (pin <= pin_A2) {
 		GPIOx = GPIOA;
-		PinOffset *= pin;
+		PinOffset *= (pin + 1);
 	}
 	else if (pin <= pin_C7) {
 		GPIOx = GPIOC;
@@ -112,7 +112,7 @@ void digitalWrite(enum GPIOpins pin, uint8_t value) {
 	
 	if (pin <= pin_A2) {
 		GPIOx = GPIOA;
-		PinOffset = pin;
+		PinOffset = (pin + 1);
 	}
 	else if (pin <= pin_C7) {
 		GPIOx = GPIOC;
@@ -142,7 +142,7 @@ uint8_t digitalRead(uint8_t pin) {
 	
 	if (pin <= pin_A2) {
 		GPIOx = GPIOA;
-		PinOffset = pin;
+		PinOffset = (pin + 1);
 	}
 	else if (pin <= pin_C7) {
 		GPIOx = GPIOC;

--- a/examples/GPIO_analogRead/wiring.c
+++ b/examples/GPIO_analogRead/wiring.c
@@ -45,7 +45,7 @@ void pinMode(enum GPIOpins pin, enum GPIOpinMode mode) {
 	
 	if (pin <= pin_A2) {
 		GPIOx = GPIOA;
-		PinOffset *= pin;
+		PinOffset *= (pin + 1);
 	}
 	else if (pin <= pin_C7) {
 		GPIOx = GPIOC;
@@ -112,7 +112,7 @@ void digitalWrite(enum GPIOpins pin, uint8_t value) {
 	
 	if (pin <= pin_A2) {
 		GPIOx = GPIOA;
-		PinOffset = pin;
+		PinOffset = (pin + 1);
 	}
 	else if (pin <= pin_C7) {
 		GPIOx = GPIOC;
@@ -142,7 +142,7 @@ uint8_t digitalRead(uint8_t pin) {
 	
 	if (pin <= pin_A2) {
 		GPIOx = GPIOA;
-		PinOffset = pin;
+		PinOffset = (pin + 1);
 	}
 	else if (pin <= pin_C7) {
 		GPIOx = GPIOC;


### PR DESCRIPTION
fixed off-by-1 error addressing pins on port A: the enum starts with pin_A1 (i.e. 'pin_A1 = 0'), so, attempts to address this pin need to be incremented by 1.

Could also update the enum definition to include a pin_A0, but this pin doesn't actually exist on any current packages.