### PR TITLE
added support for clangd #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.map
 minichlink/minichlink
 minichlink/minichlink.so
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ This project can also be built, uploaded and debugged with VSCode and the Platfo
 
 See [here](https://github.com/Community-PIO-CH32V/platform-ch32v) for further details.
 
+## clangd
+
+If the C/C++ language server clangd is unable to find `ch32v003fun.h`, the example will have to be wiped `make clean` and built once with `bear -- make build`, which will generate a `compile_commands.json`, which clangd uses to find the include paths specified in the makefiles.  
+`make clangd` does this in one step.
+`build_all_clangd.sh` does in `build scripts` does this for all examples.
+
 ## Quick Reference
  * Needed for programming/debugging: `SWIO` is on `PD1`
  * Optional (not needed, can be configured as output if fuse set): `NRST` is on `PD7`

--- a/build_scripts/README.md
+++ b/build_scripts/README.md
@@ -1,0 +1,3 @@
+Scripts serve to build / clean all examples at once.  
+
+`build_all_clangd.sh` uses bear to additionally generate a `compile_commands.yaml` for each example so the C/C++ language server clangd can be aware of the paths in the makefiles.

--- a/build_scripts/build_all.cmd
+++ b/build_scripts/build_all.cmd
@@ -4,4 +4,8 @@ setlocal
 set TARGET=%1
 if [%1]==[] set TARGET=build
 
+cd ..\examples
+
 for /d %%i in (*) do make --directory=%%i %TARGET%
+
+cd ..\build_scripts

--- a/build_scripts/build_all.sh
+++ b/build_scripts/build_all.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "this will build all examples"
+sleep 2
+
+cd ../examples
+
+for dir in */; do
+	if [ -f "${dir}Makefile" ]; then
+		echo "running 'make build' in ${dir}"
+		(cd "${dir}" && make build)
+	else
+		echo "no Makefile in ${dir}"
+	fi
+done
+
+cd ../build_scripts

--- a/build_scripts/build_all_clangd.sh
+++ b/build_scripts/build_all_clangd.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "this will build all examples with 'bear' to generate 'compile_commands.json'"
+echo "'clangd' relies on these files to find the include paths"
+sleep 2
+
+cd ../examples
+
+if ! command -v bear --help &> /dev/null
+then
+	echo "'bear' could not be found"
+	echo "please install it from your package manager"
+	exit
+fi
+
+for dir in */; do
+	if [ -f "${dir}Makefile" ]; then
+		echo "running 'bear -- make' in ${dir}"
+		(cd "${dir}" && make clean && make clangd_clean && make clangd)
+	else
+		echo "no Makefile in ${dir}"
+	fi
+done
+
+cd ../build_scripts

--- a/build_scripts/clean_all.sh
+++ b/build_scripts/clean_all.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "this will clean all examples"
+sleep 2
+
+cd ../examples
+
+for dir in */; do
+	if [ -f "${dir}Makefile" ]; then
+		echo "running 'make clean' in ${dir}"
+		(cd "${dir}" && make clean)
+	else
+		echo "no Makefile in ${dir}"
+	fi
+done
+
+cd ../build_scripts

--- a/build_scripts/clean_all_clangd.sh
+++ b/build_scripts/clean_all_clangd.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "this will clean all examples and their 'compile_commands.json'"
+echo "'clangd' relies on these files to find the include paths"
+sleep 2
+
+cd ../examples
+
+for dir in */; do
+	if [ -f "${dir}Makefile" ]; then
+		echo "running 'make clean' and 'make clangd_clean' in ${dir}"
+		(cd "${dir}" && make clean && make clangd_clean)
+	else
+		echo "no Makefile in ${dir}"
+	fi
+done
+
+cd ../build_scripts

--- a/ch32v003fun/ch32v003fun.mk
+++ b/ch32v003fun/ch32v003fun.mk
@@ -46,6 +46,13 @@ monitor :
 gdbserver : 
 	-$(MINICHLINK)/minichlink -baG
 
+clangd :
+	make clean
+	bear -- make build
+
+clangd_clean :
+	rm -f compile_commands.json
+
 cv_flash : $(TARGET).bin
 	make -C $(MINICHLINK) all
 	$(MINICHLINK)/minichlink -w $< flash -b


### PR DESCRIPTION
I figured out compatibility with clangd, I've added instructions to the main README.

Also I found the useful build_all.cmd, which now has siblings for linux, one of which will generate all the necessary compile_commands.yaml files so any project can be opened.

Through gitignore, no compile_commands.yaml will be committed (except if you wish), they are generated fine locally.
Intentionally didn't add compile_commands.yaml to makefile clean as its use is during writing.

Blink.bin is a remnant, probably from before the .gitignore was used.

___
moved the build_scripts

___
this time with clangd in the makefile, like suggested

___

had an adventure with git restoring the blink.bin

in case anyone ever needs to perform similar surgery on a branch
```
travel back one commit, keeping file changes intact
do as often as needed
git reset --soft HEAD~

remove changed file from staging (pending for commit)
git reset -- <path>

restore file to state before current commit
git restore <path>

create new divergent head
git commit --amend -m "message"

push (unsafe (only ever do on own branch!!!!))
git push --force
```
always check with `git status` between each step!!!