### PR TITLE
time macros 3

### DIFF
--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -4958,9 +4958,17 @@ static inline uint32_t __get_SP(void)
 extern "C" {
 #endif
 
-// You can use SYSTICK_USE_HCLK, if you do, you will have a high-resolution
-// however it will limit your max delay to 44 seconds before it will wrap
-// around.  You must also call SETUP_SYSTICK_HCLK.
+/* SYSTICK info
+ * time on the ch32v003 is kept by the SysTick counter (32bt)
+ * by default, it will operate at (SYSTEM_CORE_CLOCK / 8) = 6MHz
+ * to unlock 48MHz:
+ * 	#define SYSTICK_USE_HCLK
+ * 	call the SETUP_SYSTICK_HCLK macro once
+ *
+ * 				formula			6MHz		48MHz
+ * rollover			((2^32)-1)/f		89.5s		715s
+ * time resolution		1/f			167ns		20ns
+*/
 
 #ifdef SYSTICK_USE_HCLK
 #define DELAY_US_TIME ((SYSTEM_CORE_CLOCK)/1000000)
@@ -4971,6 +4979,17 @@ extern "C" {
 #define DELAY_MS_TIME ((SYSTEM_CORE_CLOCK)/8000)
 #define SETUP_SYSTICK_HCLK SysTick->CTLR = 1;
 #endif
+
+#define Delay_Us(n) DelaySysTick( (n) * DELAY_US_TIME )
+#define Delay_Ms(n) DelaySysTick( (n) * DELAY_MS_TIME )
+
+#define Time_RAW	(Systick->CNT)
+#define Time_Us		((Systick->CNT) / DELAY_US_TIME)
+#define Time_Ms		((Systick->CNT) / DELAY_MS_TIME)
+
+
+
+#ifndef __ASSEMBLER__
 
 #if defined(__riscv) || defined(__riscv__) || defined( CH32V003FUN_BASE )
 
@@ -4987,10 +5006,7 @@ void DefaultIRQHandler( void ) __attribute__((section(".text.vector_handler"))) 
 
 #endif
 
-#define Delay_Us(n) DelaySysTick( (n) * DELAY_US_TIME )
-#define Delay_Ms(n) DelaySysTick( (n) * DELAY_MS_TIME )
 
-#ifndef __ASSEMBLER__
 
 void DelaySysTick( uint32_t n );
 

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -4984,8 +4984,8 @@ extern "C" {
 #define Delay_Us(n) DelaySysTick( (n) * DELAY_US_TIME )
 #define Delay_Ms(n) DelaySysTick( (n) * DELAY_MS_TIME )
 
-#define Tick_from_Us(n)	(n * DELAY_US_TIME)
-#define Tick_from_Ms(n)	(n * DELAY_MS_TIME)
+#define Ticks_from_Us(n)	(n * DELAY_US_TIME)
+#define Ticks_from_Ms(n)	(n * DELAY_MS_TIME)
 
 
 

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -4959,14 +4959,14 @@ extern "C" {
 #endif
 
 /* SYSTICK info
- * time on the ch32v003 is kept by the SysTick counter (32bt)
+ * time on the ch32v003 is kept by the SysTick counter (32bit)
  * by default, it will operate at (SYSTEM_CORE_CLOCK / 8) = 6MHz
  * to unlock 48MHz:
  * 	#define SYSTICK_USE_HCLK
  * 	call the SETUP_SYSTICK_HCLK macro once
  *
  * 				formula			6MHz		48MHz
- * rollover			((2^32)-1)/f		89.5s		715s
+ * rollover			((2^32)-1)/f		715s		89.5s
  * time resolution		1/f			167ns		20ns
 */
 
@@ -4983,9 +4983,9 @@ extern "C" {
 #define Delay_Us(n) DelaySysTick( (n) * DELAY_US_TIME )
 #define Delay_Ms(n) DelaySysTick( (n) * DELAY_MS_TIME )
 
-#define Time_RAW	(Systick->CNT)
-#define Time_Us		((Systick->CNT) / DELAY_US_TIME)
-#define Time_Ms		((Systick->CNT) / DELAY_MS_TIME)
+#define Time_RAW	(SysTick->CNT)
+#define Time_Us		((SysTick->CNT) / DELAY_US_TIME)
+#define Time_Ms		((SysTick->CNT) / DELAY_MS_TIME)
 
 
 

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -4989,8 +4989,6 @@ extern "C" {
 
 
 
-#ifndef __ASSEMBLER__
-
 #if defined(__riscv) || defined(__riscv__) || defined( CH32V003FUN_BASE )
 
 // Stuff that can only be compiled on device (not for the programmer, or other host programs)
@@ -5007,6 +5005,8 @@ void DefaultIRQHandler( void ) __attribute__((section(".text.vector_handler"))) 
 #endif
 
 
+
+#ifndef __ASSEMBLER__
 
 void DelaySysTick( uint32_t n );
 

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -4961,6 +4961,7 @@ extern "C" {
 /* SYSTICK info
  * time on the ch32v003 is kept by the SysTick counter (32bit)
  * by default, it will operate at (SYSTEM_CORE_CLOCK / 8) = 6MHz
+ * you may want to keep all your time values in ticks
  * to unlock 48MHz:
  * 	#define SYSTICK_USE_HCLK
  * 	call the SETUP_SYSTICK_HCLK macro once
@@ -4983,9 +4984,8 @@ extern "C" {
 #define Delay_Us(n) DelaySysTick( (n) * DELAY_US_TIME )
 #define Delay_Ms(n) DelaySysTick( (n) * DELAY_MS_TIME )
 
-#define Time_RAW	(SysTick->CNT)
-#define Time_Us		((SysTick->CNT) / DELAY_US_TIME)
-#define Time_Ms		((SysTick->CNT) / DELAY_MS_TIME)
+#define Tick_from_Us(n)	(n * DELAY_US_TIME)
+#define Tick_from_Ms(n)	(n * DELAY_MS_TIME)
 
 
 


### PR DESCRIPTION
 * added macros to get current time according to systick
 * clarified SysTick mode description
 * moved all the sections to do with time together so they're in one spot
 * fixed typos
 * moved #ifndef __ASSEMBLER__ back where it was (moved by misstake)