### PR TITLE
Fix minichlink Windows build

### DIFF
--- a/.github/workflows/minichlink.yml
+++ b/.github/workflows/minichlink.yml
@@ -64,4 +64,6 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: minichlink (Windows)
-        path: minichlink/minichlink.exe
+        path: | 
+          minichlink/minichlink.exe
+          minichlink/libusb-1.0.dll

--- a/minichlink/Makefile
+++ b/minichlink/Makefile
@@ -9,7 +9,7 @@ C_S:=minichlink.c pgm-wch-linke.c pgm-esp32s2-ch32xx.c nhc-link042.c minichgdb.c
 
 ifeq ($(OS),Windows_NT)
 	LDFLAGS:=-L. -lpthread -lusb-1.0 -lsetupapi -lws2_32
-	CFLAGS:=-Os -s -Wall
+	CFLAGS:=-Os -s -Wall -D_WIN32_WINNT=0x0600
 	TOOLS:=minichlink.exe
 else
 	OS_NAME := $(shell uname -s | tr A-Z a-z)


### PR DESCRIPTION
An extremely peculiar thing.

When the CI ubuntu-latest runner installs the MinGW toolchain for Windows, it somehow ends up with a version that has a default Windows Target of `_WIN32_WINNT = _WIN32_WINNT_WS03` (0x0502), that's "Windows Server 2003", one minor version after XP.

This activates a piece of block in `microgdbstub.h` that checks of `POLLIN` was defined or not, and tries to define these missing values, e.g. `#define POLLIN 0x0001`. The `winsock2.h` header only exposes the these macros when `_WIN32_WINNT >= 0x0600 (0x600 = Windows Vista)`, which in the CI build is not the case. I think the microgdbstub.h tries to "polyfill" in the missing values to try and still make use of it in these old Windows versions.

However, these compiled values are then **wrong** for the Windows 10 version (or, everything starting at Vista) and so it does a `WSAPoll()` call with wrong POLLIN values etc, making the program dead.

This PR fixes that by **explicitly** defining our minimum targeted Windows version as "Windows Vista" (0x600) and above.

Note that this was not a problem when I built on my Ubuntu 22.10 machine with the same package installed. There, in `/usr/share/mingw-w64/include/_mingw.h` I have
```
#ifndef _WIN32_WINNT
#define _WIN32_WINNT 0xa00
#endif
```
as the targeted version (if not defined), which is "Windows 10". I still don't understand why the package downloaded in the CI is different.