### PR TITLE
Add Enable/Disable Read Protection. Also rename Info -p to -i

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -191,6 +191,20 @@ keep_going:
 				else
 					goto unimplemented;
 				break;
+			case 'p': 
+				if( MCF.HaltMode ) MCF.HaltMode( dev, 0 );
+				if( MCF.ConfigureReadProtection )
+					MCF.ConfigureReadProtection( dev, 0 );
+				else
+					goto unimplemented;
+				break;
+			case 'P':
+				if( MCF.HaltMode ) MCF.HaltMode( dev, 0 );
+				if( MCF.ConfigureReadProtection )
+					MCF.ConfigureReadProtection( dev, 1 );
+				else
+					goto unimplemented;
+				break;
 			case 'G':
 			case 'T':
 			{
@@ -305,7 +319,7 @@ keep_going:
 					goto unimplemented;
 				break;
 			}
-			case 'p':
+			case 'i':
 			{
 				if( MCF.PrintChipInfo )
 					MCF.PrintChipInfo( dev ); 
@@ -547,8 +561,8 @@ help:
 	fprintf( stderr, " -m [debug register]\n" );
 	fprintf( stderr, " -T Terminal Only\n" );
 	fprintf( stderr, " -G Terminal + GDB\n" );
-//	fprintf( stderr, " -P Enable Read Protection (UNTESTED)\n" );
-//	fprintf( stderr, " -p Disable Read Protection (UNTESTED)\n" );
+	fprintf( stderr, " -P Enable Read Protection\n" );
+	fprintf( stderr, " -p Disable Read Protection\n" );
 	fprintf( stderr, " -w [binary image to write] [address, decimal or 0x, try0x08000000]\n" );
 	fprintf( stderr, " -r [output binary image] [memory address, decimal or 0x, try 0x08000000] [size, decimal or 0x, try 16384]\n" );
 	fprintf( stderr, "   Note: for memory addresses, you can use 'flash' 'launcher' 'bootloader' 'option' 'ram' and say \"ram+0x10\" for instance\n" );
@@ -1772,6 +1786,12 @@ int DefaultConfigureNRSTAsGPIO( void * dev, int one_if_yes_gpio  )
 	printf( "RET: %d\n", ret );
 	return 0;
 #endif
+}
+
+int DefaultConfigureReadProtection( void * dev, int one_if_yes_protect  )
+{
+	fprintf( stderr, "Error: DefaultConfigureReadProtection does not work via the programmer here.  Please see the demo \"optionbytes\"\n" );
+	return -5;
 }
 
 int DefaultPrintChipInfo( void * dev )

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -23,6 +23,7 @@ struct MiniChlinkFunctions
 
 	int (*HaltMode)( void * dev, int mode ); //0 for halt, 1 for reset, 2 for resume
 	int (*ConfigureNRSTAsGPIO)( void * dev, int one_if_yes_gpio );
+	int (*ConfigureReadProtection)( void * dev, int one_if_yes_protect );
 
 	// No boundary or limit rules.  Must support any combination of alignment and size.
 	int (*WriteBinaryBlob)( void * dev, uint32_t address_to_write, uint32_t blob_size, uint8_t * blob );

--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -309,6 +309,21 @@ static int LEConfigureNRSTAsGPIO( void * d, int one_if_yes_gpio )
 	return 0;
 }
 
+static int LEConfigureReadProtection( void * d, int one_if_yes_protect )
+{
+	libusb_device_handle * dev = ((struct LinkEProgrammerStruct*)d)->devh;
+
+	if( one_if_yes_protect )
+	{
+		wch_link_multicommands( (libusb_device_handle *)dev, 2, 11, "\x81\x06\x08\x03\xf7\xff\xff\xff\xff\xff\xff", 4, "\x81\x0b\x01\x01" );
+	}
+	else
+	{
+		wch_link_multicommands( (libusb_device_handle *)dev, 2, 11, "\x81\x06\x08\x02\xf7\xff\xff\xff\xff\xff\xff", 4, "\x81\x0b\x01\x01" );
+	}
+	return 0;
+}
+
 int LEExit( void * d )
 {
 	libusb_device_handle * dev = ((struct LinkEProgrammerStruct*)d)->devh;
@@ -337,6 +352,7 @@ void * TryInit_WCHLinkE()
 	MCF.Control5v = LEControl5v;
 	MCF.Unbrick = LEUnbrick;
 	MCF.ConfigureNRSTAsGPIO = LEConfigureNRSTAsGPIO;
+	MCF.ConfigureReadProtection = LEConfigureReadProtection;
 
 	MCF.Exit = LEExit;
 	return ret;


### PR DESCRIPTION
I was playing around with writing to the Data0/1 fields in the Option Bytes and got myself into a situation where the chip was bricked - at least from a minichlink point of view.

When trying to flash I got this message that couldn't be fixed by a simple -u Unbrick.
```
Interface Setup
Fault writing memory (DMABSTRACTS = 08000302) (Execption executing Abstract Command) DMSTATUS: 004c0382
Fault on DefaultWriteWord Part 1
Fault writing memory (DMABSTRACTS = 08000302) (Execption executing Abstract Command) DMSTATUS: 004c0382
Fault on DefaultWriteWord Part 2
```

I could fix it with the WCH-LinkUtility and it turned out that I had enabled the Read Protection in my code.

The `usage()` function in minichlink had two commented-out lines for Read Protection, but no actual implementation so I added code for it.  I also had to rename the hidden `Info` command which was using the -p flag to use a more appropriate -i.
