### PR TITLE
Fix warning compiling in Windows

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -12,6 +12,7 @@
 #include "../ch32v003fun/ch32v003fun.h"
 
 #if defined(WINDOWS) || defined(WIN32) || defined(_WIN32)
+void Sleep(uint32_t dwMilliseconds);
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
I don't like warnings ;-)

```
$ make clean && make
rm -rf minichlink.exe
x86_64-w64-mingw32-gcc -o minichlink.exe minichlink.c pgm-wch-linke.c pgm-esp32s2-ch32xx.c nhc-link042.c minichgdb.c -L. -lpthread -lusb-1.0 -lsetupapi -lws2_32 -Os -s -Wall -D_WIN32_WINNT=0x0600
minichlink.c: In function 'DefaultUnbrick':
minichlink.c:1623:17: warning: implicit declaration of function 'Sleep'; did you mean '_sleep'? [-Wimplicit-function-declaration]
 1623 |                 Sleep(20);
      |                 ^~~~~
      |                 _sleep

mats@MATSENGSTRO019C MINGW64 ~/Downloads/ch32v003fun/minichlink (master)
```