### PR TITLE
Revert "Fix SPI Direction"

### DIFF
--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -3875,7 +3875,7 @@ typedef struct
 
 /* SPI_data_direction */
 #define SPI_Direction_2Lines_FullDuplex    ((uint16_t)0x0000)
-#define SPI_Direction_2Lines_RxOnly        ((uint16_t)0x4000)
+#define SPI_Direction_2Lines_RxOnly        ((uint16_t)0x0400)
 #define SPI_Direction_1Line_Rx             ((uint16_t)0x8000)
 #define SPI_Direction_1Line_Tx             ((uint16_t)0xC000)
 


### PR DESCRIPTION
Reverts cnlohr/ch32v003fun#163

Damn, I should've looked into the RM further, I thought the only two bits important here were the BIDIOE and the BIDIMODE turns out the RXONLY is the relevant bit here I guess (as it says in the name duh), so I was wrong, sorry 