### PR TITLE
cleanup and simplify AH fix for ch32v307 read memory

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -367,8 +367,6 @@ keep_going:
 					return -9;
 				}
 
-				// Round up amount.
-				amount = ( amount + 3 ) & 0xfffffffc;
 				FILE * f = 0;
 				int hex = 0;
 				if( strcmp( fname, "-" ) == 0 )
@@ -654,67 +652,6 @@ static int DefaultWaitForDoneOp( void * dev, int ignore )
 {
 	int r;
 	uint32_t rrv;
-	uint32_t temp;
-
-	//Debug regdump pre-command
-	#if 0
-	MCF.ReadReg32(dev, DMDATA0, &temp);
-	fprintf(stderr, "Pr-DMDATA0: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMDATA1, &temp);
-	fprintf(stderr, "Pr-DMDATA1: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMCONTROL, &temp);
-	fprintf(stderr, "Pr-DMCONTROL: %08x\n", temp);
-	
-	MCF.ReadReg32(dev, DMSTATUS, &temp);
-	fprintf(stderr, "Pr-DMSTATUS: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMHARTINFO, &temp);
-	fprintf(stderr, "Pr-DMHARTINFO: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMABSTRACTCS, &temp);
-	fprintf(stderr, "Pr-DMABSTRACTCS: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMCOMMAND, &temp);
-	fprintf(stderr, "Pr-DMCOMMAND: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMABSTRACTAUTO, &temp);
-	fprintf(stderr, "Pr-DMABSTRACTAUTO: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF0, &temp);
-	fprintf(stderr, "Pr-DMPROGBUF0: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF1, &temp);
-	fprintf(stderr, "Pr-DMPROGBUF1: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF2, &temp);
-	fprintf(stderr, "Pr-DMPROGBUF2: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF3, &temp);
-	fprintf(stderr, "Pr-DMPROGBUF3: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF4, &temp);
-	fprintf(stderr, "Pr-DMPROGBUF4: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF5, &temp);
-	fprintf(stderr, "Pr-DMPROGBUF5: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF6, &temp);
-	fprintf(stderr, "Pr-DMPROGBUF6: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF7, &temp);
-	fprintf(stderr, "Pr-DMPROGBUF7: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMCPBR, &temp);
-	fprintf(stderr, "Pr-DMCPBR: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMCFGR, &temp);
-	fprintf(stderr, "Pr-DMCFGR: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMSHDWCFGR, &temp);
-	fprintf(stderr, "Pr-DMSHDWCFGR: %08x\n", temp);
-	#endif
 
 	do
 	{
@@ -722,66 +659,6 @@ static int DefaultWaitForDoneOp( void * dev, int ignore )
 		if( r ) return r;
 	}
 	while( rrv & (1<<12) );
-
-	//Debug regdump post-command
-	#if 0
-	MCF.ReadReg32(dev, DMDATA0, &temp);
-	fprintf(stderr, "Po-DMDATA0: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMDATA1, &temp);
-	fprintf(stderr, "Po-DMDATA1: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMCONTROL, &temp);
-	fprintf(stderr, "Po-DMCONTROL: %08x\n", temp);
-	
-	MCF.ReadReg32(dev, DMSTATUS, &temp);
-	fprintf(stderr, "Po-DMSTATUS: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMHARTINFO, &temp);
-	fprintf(stderr, "Po-DMHARTINFO: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMABSTRACTCS, &temp);
-	fprintf(stderr, "Po-DMABSTRACTCS: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMCOMMAND, &temp);
-	fprintf(stderr, "Po-DMCOMMAND: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMABSTRACTAUTO, &temp);
-	fprintf(stderr, "Po-DMABSTRACTAUTO: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF0, &temp);
-	fprintf(stderr, "Po-DMPROGBUF0: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF1, &temp);
-	fprintf(stderr, "Po-DMPROGBUF1: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF2, &temp);
-	fprintf(stderr, "Po-DMPROGBUF2: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF3, &temp);
-	fprintf(stderr, "Po-DMPROGBUF3: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF4, &temp);
-	fprintf(stderr, "Po-DMPROGBUF4: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF5, &temp);
-	fprintf(stderr, "Po-DMPROGBUF5: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF6, &temp);
-	fprintf(stderr, "Po-DMPROGBUF6: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMPROGBUF7, &temp);
-	fprintf(stderr, "Po-DMPROGBUF7: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMCPBR, &temp);
-	fprintf(stderr, "Po-MCPBR: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMCFGR, &temp);
-	fprintf(stderr, "Po-DMCFGR: %08x\n", temp);
-
-	MCF.ReadReg32(dev, DMSHDWCFGR, &temp);
-	fprintf(stderr, "Po-DMSHDWCFGR: %08x\n", temp);
-	#endif
 
 	if( (rrv >> 8 ) & 7 )
 	{
@@ -799,6 +676,7 @@ static int DefaultWaitForDoneOp( void * dev, int ignore )
 			default: errortext = "Other Error"; break;
 			}
 
+			uint32_t temp;
 			MCF.ReadReg32( dev, DMSTATUS, &temp );
 			fprintf( stderr, "Fault writing memory (DMABSTRACTS = %08x) (%s) DMSTATUS: %08x\n", rrv, errortext, temp );
 		}
@@ -1337,8 +1215,7 @@ static int DefaultReadWord( void * dev, uint32_t address_to_read, uint32_t * dat
 		}
 
 		MCF.WriteReg32( dev, DMDATA1, address_to_read );
-		//MCF.WriteReg32( dev, DMCOMMAND, 0x00241000 ); // Only execute. //AH removed as part of CH32V307 discussion
-		MCF.WriteReg32( dev, DMCOMMAND, 0x00261000 ); //AH replacement based on that discussion
+		MCF.WriteReg32( dev, DMCOMMAND, 0x00241000 ); 
 
 		iss->statetag = STTAG( "RDSQ" );
 		iss->currentstateval = address_to_read;

--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -17,8 +17,8 @@ struct LinkEProgrammerStruct
 };
 
 // For non-ch32v003 chips.
-static int LEReadBinaryBlob( void * d, uint32_t offset, uint32_t amount, uint8_t * readbuff );
-static int InternalLinkEHaltMode( void * d, int mode );
+//static int LEReadBinaryBlob( void * d, uint32_t offset, uint32_t amount, uint8_t * readbuff );
+//static int InternalLinkEHaltMode( void * d, int mode );
 //static int LEWriteBinaryBlob( void * d, uint32_t address_to_write, uint32_t len, uint8_t * blob );
 
 #define WCHTIMEOUT 5000
@@ -232,12 +232,6 @@ static int LESetupInterface( void * d )
 	}
         uint32_t target_chip_type = ( rbuff[4] << 4) + (rbuff[5] >> 4);
         fprintf(stderr, "Chip Type: %03x\n", target_chip_type);
-        if( target_chip_type == 0x307 )
-        {
-                fprintf( stderr, "CH32V307 Detected.  Allowing old-flash-mode for operation.\n" );
-                //MCF.WriteBinaryBlob = LEWriteBinaryBlob;
-                MCF.ReadBinaryBlob = LEReadBinaryBlob;
-        }
 
 	// For some reason, if we don't do this sometimes the programmer starts in a hosey mode.
 	MCF.WriteReg32( d, DMCONTROL, 0x80000001 ); // Make the debug module work properly.
@@ -245,8 +239,7 @@ static int LESetupInterface( void * d )
 	MCF.WriteReg32( d, DMCONTROL, 0x80000001 ); // No, really make sure.
 	MCF.WriteReg32( d, DMABSTRACTCS, 0x00000700 ); // Ignore any pending errors.
 	MCF.WriteReg32( d, DMABSTRACTAUTO, 0 );
-	//MCF.WriteReg32( d, DMCOMMAND, 0x00261000 ); // Read x0 (Null command) //AH changed as part of CH32V307 discussion
-	MCF.WriteReg32( d, DMCOMMAND, 0x00221000 ); // Read x0 (Null command) //AH replacement based on that discussion
+	MCF.WriteReg32( d, DMCOMMAND, 0x00221000 ); // Read x0 (Null command) with nopostexec (to fix v307 read issues)
 
 	int r = 0;
 
@@ -414,6 +407,7 @@ const uint8_t * bootloader = (const uint8_t*)
 int bootloader_len = 512;
 #endif
 
+#if 0
 static int InternalLinkEHaltMode( void * d, int mode )
 {
 	libusb_device_handle * dev = ((struct LinkEProgrammerStruct*)d)->devh;
@@ -438,7 +432,9 @@ static int InternalLinkEHaltMode( void * d, int mode )
 	}
 	return 0;
 }
+#endif
 
+#if 0
 static int LEReadBinaryBlob( void * d, uint32_t offset, uint32_t amount, uint8_t * readbuff )
 {
 	libusb_device_handle * dev = ((struct LinkEProgrammerStruct*)d)->devh;
@@ -496,6 +492,7 @@ static int LEReadBinaryBlob( void * d, uint32_t offset, uint32_t amount, uint8_t
 
 	return 0;
 }
+#endif
 
 #if 0
 static int LEWriteBinaryBlob( void * d, uint32_t address_to_write, uint32_t len, uint8_t * blob )


### PR DESCRIPTION
+ remove round up in -r mode to read the requested amount of bytes
+ remove the 0x307 check and stash the old ReadBinaryBlob method