### PR TITLE
fix uart printf baud

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1049,7 +1049,7 @@ void SystemInit()
 #endif
 
 #if defined( FUNCONF_USE_UARTPRINTF ) && FUNCONF_USE_UARTPRINTF
-	SetupUART( FUNCONF_UARTPRINTF_BAUD );
+	SetupUART( UART_BRR );
 #endif
 #if defined( FUNCONF_USE_DEBUGPRINTF ) && FUNCONF_USE_DEBUGPRINTF
 	SetupDebugPrintf();

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -5092,9 +5092,13 @@ void DelaySysTick( uint32_t n );
 int main() __attribute__((used));
 void SystemInit(void);
 
-#define UART_BAUD_RATE 115200
+#ifdef FUNCONF_UART_PRINTF_BAUD
+	#define UART_BAUD_RATE FUNCONF_UART_PRINTF_BAUD
+#else
+	#define UART_BAUD_RATE 115200
+#endif
 #define OVER8DIV 4
-#define INTEGER_DIVIDER (((25 * (APB_CLOCK)) / ((OVER8DIV) * (UART_BAUD_RATE))))
+#define INTEGER_DIVIDER (((25 * (FUNCONF_SYSTEM_CORE_CLOCK)) / ((OVER8DIV) * (UART_BAUD_RATE))))
 #define FRACTIONAL_DIVIDER ((INTEGER_DIVIDER)%100)
 #define UART_BRR ((((INTEGER_DIVIDER) / 100) << 4) | (((((FRACTIONAL_DIVIDER) * ((OVER8DIV)*2)) + 50)/100)&7))
 // Put an output debug UART on Pin D5.


### PR DESCRIPTION
I tried running uartdemo, but it did not work because the baud rate was set directly on the BRR.
Since the CH32V003 has only one UART, I use the UART macro that was already there.