### PR TITLE
Remove CFLAGS switch for STDOUT_UART

### DIFF
--- a/examples/uartdemo/Makefile
+++ b/examples/uartdemo/Makefile
@@ -2,8 +2,6 @@ all : flash
 
 TARGET:=uartdemo
 
-CFLAGS+=-DSTDOUT_UART
-
 include ../../ch32v003fun/ch32v003fun.mk
 
 flash : cv_flash


### PR DESCRIPTION
```We don't do it that way anymore.  Check FUNCONF_USE_UARTPRINTF in your funconfig.h```
