### PR TITLE
Clean up #define situation for SYSTEM_CORE_CLOCK, APB_CLOCK, USE_HSI/HSE

### DIFF
--- a/attic/external_crystal_run_from_ram_turbo.c
+++ b/attic/external_crystal_run_from_ram_turbo.c
@@ -4,8 +4,6 @@
 #include "ch32v003fun.h"
 #include <stdio.h>
 
-#define APB_CLOCK SYSTEM_CORE_CLOCK
-
 uint32_t count;
 
 void RamFunction() __attribute__((naked));

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -34,6 +34,9 @@
 	#define FUNCONF_DEBUGPRINTF_TIMEOUT 160000
 #endif
 
+#if defined(FUNCONF_USE_HSI) && defined(FUNCONF_USE_HSE) && FUNCONF_USE_HSI && FUNCONF_USE_HSE
+       #error FUNCONF_USE_HSI and FUNCONF_USE_HSE cannot both be set
+#endif
 
 #if !defined( FUNCONF_USE_HSI ) && !defined( FUNCONF_USE_HSE )
 	#define FUNCONF_USE_HSI 1 // Default to use HSI

--- a/examples/MCOtest/MCOtest.c
+++ b/examples/MCOtest/MCOtest.c
@@ -1,6 +1,3 @@
-#define SYSTEM_CORE_CLOCK 48000000
-#define APB_CLOCK SYSTEM_CORE_CLOCK
-
 #include "ch32v003fun.h"
 #include <stdio.h>
 

--- a/examples/MCOtest/funconfig.h
+++ b/examples/MCOtest/funconfig.h
@@ -4,5 +4,8 @@
 #define FUNCONF_TINYVECTOR 1
 #define CH32V003           1
 
+#define FUNCONF_USE_HSE 1
+#define FUNCONF_USE_HSI 1
+
 #endif
 

--- a/examples/bootload/bootload.c
+++ b/examples/bootload/bootload.c
@@ -1,10 +1,5 @@
-// Could be defined here, or in the processor defines.
-#define SYSTEM_CORE_CLOCK 48000000
-
 #include "ch32v003fun.h"
 #include <stdio.h>
-
-#define APB_CLOCK SYSTEM_CORE_CLOCK
 
 uint32_t count;
 

--- a/examples/cpp_virtual_methods/cpp_virtual_methods.cpp
+++ b/examples/cpp_virtual_methods/cpp_virtual_methods.cpp
@@ -3,10 +3,6 @@
  * 05/21/2023 A. Mandera
  */
 
-// Could be defined here, or in the processor defines.
-#define SYSTEM_CORE_CLOCK 48000000
-#define APB_CLOCK SYSTEM_CORE_CLOCK
-
 #include "ch32v003fun.h"
 #include "example.h"
 #include <stdio.h>

--- a/examples/dma_gpio/dma_gpio.c
+++ b/examples/dma_gpio/dma_gpio.c
@@ -8,12 +8,9 @@
 // The interrupt fires once at the beginning and
 // once at the end.
 //
-#define SYSTEM_CORE_CLOCK 48000000
 
 #include "ch32v003fun.h"
 #include <stdio.h>
-
-#define APB_CLOCK SYSTEM_CORE_CLOCK
 
 volatile uint32_t count;
 

--- a/examples/self_modify_code/self_modify_code.c
+++ b/examples/self_modify_code/self_modify_code.c
@@ -1,7 +1,6 @@
 /* Small example showing how to use the SWIO programming pin to 
    do printf through the debug interface */
 
-#define SYSTEM_CORE_CLOCK 24000000
 #include "ch32v003fun.h"
 #include <stdio.h>
 

--- a/examples/spi_24L01_rx/nrf24l01_low_level.c
+++ b/examples/spi_24L01_rx/nrf24l01_low_level.c
@@ -1,5 +1,3 @@
-#define SYSTEM_CORE_CLOCK 48000000
-#define APB_CLOCK SYSTEM_CORE_CLOCK
 #include "ch32v003fun.h"
 
 

--- a/examples/spi_24L01_tx/nrf24l01_low_level.c
+++ b/examples/spi_24L01_tx/nrf24l01_low_level.c
@@ -1,5 +1,3 @@
-#define SYSTEM_CORE_CLOCK 48000000
-#define APB_CLOCK SYSTEM_CORE_CLOCK
 #include "ch32v003fun.h"
 
 

--- a/examples/standby_autowake/standby_autowake.c
+++ b/examples/standby_autowake/standby_autowake.c
@@ -1,11 +1,7 @@
 // based on https://paste.sr.ht/blob/b9b4fb45cbc70f2db7e31a77a6ef7dd2a7f220fb
-// Could be defined here, or in the processor defines.
-#define SYSTEM_CORE_CLOCK 48000000
 
 #include "ch32v003fun.h"
 #include <stdio.h>
-
-#define APB_CLOCK SYSTEM_CORE_CLOCK
 
 /* somehow this ISR won't get called??
 void AWU_IRQHandler( void ) __attribute__((interrupt));

--- a/examples/standby_btn/standby_btn.c
+++ b/examples/standby_btn/standby_btn.c
@@ -1,11 +1,7 @@
 // based on https://paste.sr.ht/blob/b9b4fb45cbc70f2db7e31a77a6ef7dd2a7f220fb
-// Could be defined here, or in the processor defines.
-#define SYSTEM_CORE_CLOCK 48000000
 
 #include "ch32v003fun.h"
 #include <stdio.h>
-
-#define APB_CLOCK SYSTEM_CORE_CLOCK
 
 void EXTI7_0_IRQHandler( void ) __attribute__((interrupt));
 void EXTI7_0_IRQHandler( void ) {

--- a/examples/ws2812bdemo/ws2812bdemo.c
+++ b/examples/ws2812bdemo/ws2812bdemo.c
@@ -1,7 +1,3 @@
-// Could be defined here, or in the processor defines.
-#define SYSTEM_CORE_CLOCK 48000000
-#define APB_CLOCK SYSTEM_CORE_CLOCK
-
 // NOTE: CONNECT WS2812's to PC6
 
 #include "ch32v003fun.h"

--- a/extralibs/ch32v003_GPIO_branchless.h
+++ b/extralibs/ch32v003_GPIO_branchless.h
@@ -290,14 +290,6 @@ static inline void GPIO_tim2_init();
 #define GPIO_timer_prescaler TIM_CKD_DIV2		// APB_CLOCK / 1024 / 2 = 23.4kHz
 #endif
 
-// maintenance define
-#if !defined(SYSTEM_CORE_CLOCK)
-#define SYSTEM_CORE_CLOCK 48000000
-#define APB_CLOCK SYSTEM_CORE_CLOCK
-#endif
-
-
-
 //######## define requirements / maintenance defines
 
 

--- a/extralibs/ch32v003_SPI.h
+++ b/extralibs/ch32v003_SPI.h
@@ -16,6 +16,11 @@ in the .c files that use this library, you'll need to #define some configuration
 
 SYSTEM_CORE_CLOCK and APB_CLOCK should be defined already as APB_CLOCK is used by this library
 
+
+#ifndef APB_CLOCK
+	#define APB_CLOCK FUNCONF_SYSTEM_CORE_CLOCK
+#endif
+
 to enable using the functions of this library:
 #define CH32V003_SPI_IMPLEMENTATION
 


### PR DESCRIPTION
Remove the HSI/HSE footgun (if someone sets both values the chip ends up in a weird state)
Remove old SYSTEM_CORE_CLOCK `#defines`
Remove superfluous uses of APB_CLOCK