### PR TITLE
Add missing register config for HSE w/ PLL and set correct sysclk

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1018,13 +1018,16 @@ void SystemInit()
 
 #if defined(FUNCONF_USE_HSE) && FUNCONF_USE_HSE
 
+	RCC->CFGR0 |= (uint32_t)(RCC_PLLSRC_HSE_Mul2);
 	RCC->CTLR  = RCC_HSION | RCC_HSEON | RCC_PLLON | HSEBYP;       // Keep HSI and PLL on just in case, while turning on HSE
 
 	// Values lifted from the EVT.  There is little to no documentation on what this does.
 	while(!(RCC->CTLR&RCC_HSERDY));
 
+	while(!(RCC->CTLR&RCC_PLLRDY));
+
 	#if defined(FUNCONF_USE_PLL) && FUNCONF_USE_PLL
-		RCC->CFGR0 = BASE_CFGR0 | RCC_SW_HSE;
+		RCC->CFGR0 = BASE_CFGR0 | RCC_SW_PLL;
 		RCC->CTLR  = RCC_HSEON | RCC_PLLON | HSEBYP;                    // Turn off HSI.
 	#else
 		RCC->CFGR0 = BASE_CFGR0 | RCC_SW_HSE;


### PR DESCRIPTION
The HSE with PLL didn't initialize properly because of three reasons:
- The PLLSRC register wasn't written, so the source was still HSI
- There was no wait for the RCC_PLLRDY flag (PLL is responsive but in theory it might still be out-of-sync)
- The sysclk-source was implemented as HSE w/o PLL, no matter what FUNCONF_USE_PLL said
- 
I implemented the three changes and now HSE+PLL works fine :)

I also recommend removing the HSI shutdown because the debug core seems to depend on it. Shutting it down seems to prevent users from flashing new code. But I'll leave that open for discussion, because the HSI consumes 120(min)/180(typ)/270(max) uA which might be a problem for some applications.