### PR TITLE
Issue #212 fixes - examples fail to compile

### DIFF
--- a/examples/MCOtest/MCOtest.c
+++ b/examples/MCOtest/MCOtest.c
@@ -16,7 +16,11 @@ int main()
         // PC4 is T1CH4, 50MHz Output PP CNF = 10: Mux PP, MODE = 11: Out 50MHz
         GPIOC->CFGLR &= ~(GPIO_CFGLR_MODE4 | GPIO_CFGLR_CNF4);
         GPIOC->CFGLR |= GPIO_CFGLR_CNF4_1 | GPIO_CFGLR_MODE4_0 | GPIO_CFGLR_MODE4_1;
-
+		// turn the HSE on
+		RCC->CTLR |= RCC_HSE_ON;
+		// Wait till HSE is ready
+		while(!(RCC->CTLR & RCC_HSERDY));
+		
 	while(1)
 	{
 		switch(count)

--- a/examples/MCOtest/funconfig.h
+++ b/examples/MCOtest/funconfig.h
@@ -4,8 +4,8 @@
 #define FUNCONF_TINYVECTOR 1
 #define CH32V003           1
 
-#define FUNCONF_USE_HSE 1
+#define FUNCONF_USE_HSE 0
 #define FUNCONF_USE_HSI 1
 
-#endif
+#endif // _FUNCONFIG_H
 

--- a/extralibs/ch32v003_SPI.h
+++ b/extralibs/ch32v003_SPI.h
@@ -8,7 +8,9 @@
 #include<stdint.h>								//uintN_t support
 #include"../ch32v003fun/ch32v003fun.h"
 
-
+#ifndef APB_CLOCK
+	#define APB_CLOCK FUNCONF_SYSTEM_CORE_CLOCK
+#endif
 
 /*######## library usage and configuration
 


### PR DESCRIPTION
1. MCO example enabled both HSI and HSE, fixed by disabling HSE in funconf.h and enabling it in the example code.
2. SPI library still requires APB_CLOCK to be defined, which was removed in #208 