### PR TITLE
Update minichlink to not reset when writing bootloader.

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -600,8 +600,14 @@ keep_going:
 					exit( -9 );
 				}
 
+
 				int is_flash = IsAddressFlash( offset );
-				if( MCF.HaltMode ) MCF.HaltMode( dev, is_flash ? HALT_MODE_HALT_AND_RESET : HALT_MODE_HALT_BUT_NO_RESET );
+				//if( MCF.HaltMode ) MCF.HaltMode( dev, is_flash ? HALT_MODE_HALT_AND_RESET : HALT_MODE_HALT_BUT_NO_RESET );
+				if( MCF.HaltMode && is_flash )
+				{
+					if ( offset == 0x1ffff000 ) MCF.HaltMode( dev, HALT_MODE_HALT_BUT_NO_RESET ); // do not reset if writing bootloader, even if it is considered flash memory
+					else MCF.HaltMode( dev, HALT_MODE_HALT_AND_RESET );
+				}
 
 				if( MCF.WriteBinaryBlob )
 				{


### PR DESCRIPTION
fixes:
```
cd examples/bootload
make

which errors out with:
../../minichlink/minichlink -a -U -w bootload.bin bootloader -B                                                                     
Found WCH Link                                                                                                                      
WCH Programmer is LinkE version 2.9                                                                                                 
Chip Type: 003                                                                                                                      
Setup success                                                                                                                       
Flash Storage: 16 kB                                                                                                                
Part UUID    : f4-d6-ab-cd-5c-f5-bc-52                                                                                              
PFlags       : ff-ff-ff-ff                                                                                                          
Part Type (B): 00-00-06-ec                                                                                                          
Read protection: disabled                                                                                                           
Interface Setup                                                                                                                     
FLASH_OBTKEYR = 00000000 (0)                                                                                                        
Fault writing memory (DMABSTRACTS = 08000302) (Execption executing Abstract Command) DMSTATUS: 004c0382                             
Fault on DefaultReadWord Part 1
```