### PR TITLE
Disable DEBUGPRINTF I/O when FUNCONF_USE_DEBUGPRINTF = 0

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1004,7 +1004,9 @@ void WaitForDebuggerToAttach()
 #endif
 
 #if (defined( FUNCONF_USE_DEBUGPRINTF ) && !FUNCONF_USE_DEBUGPRINTF) && \
-(defined( FUNCONF_USE_UARTPRINTF ) && !FUNCONF_USE_UARTPRINTF)
+((defined( FUNCONF_USE_UARTPRINTF ) && !FUNCONF_USE_UARTPRINTF) || \
+!defined( FUNCONF_USE_UARTPRINTF ))
+#warning( DEBUG Print Disabled)
 int _write(int fd, const char *buf, int size)
 {
 	return size;

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1003,7 +1003,8 @@ void WaitForDebuggerToAttach()
 
 #endif
 
-#if defined( FUNCONF_USE_DEBUGPRINTF ) && !FUNCONF_USE_DEBUGPRINTF
+#if (defined( FUNCONF_USE_DEBUGPRINTF ) && !FUNCONF_USE_DEBUGPRINTF) && \
+(defined( FUNCONF_USE_UARTPRINTF ) && !FUNCONF_USE_UARTPRINTF)
 int _write(int fd, const char *buf, int size)
 {
 	return size;

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1003,6 +1003,19 @@ void WaitForDebuggerToAttach()
 
 #endif
 
+#if defined( FUNCONF_USE_DEBUGPRINTF ) && !FUNCONF_USE_DEBUGPRINTF
+int _write(int fd, const char *buf, int size)
+{
+	return size;
+}
+
+// single to debug intf
+int putchar(int c)
+{
+	return 1;
+}
+#endif
+
 void DelaySysTick( uint32_t n )
 {
 	uint32_t targend = SysTick->CNT + n;


### PR DESCRIPTION
This patch will completely disable the SWDIO-based debug printf infrastructure when FUNCONF_USE_DEBUGPRINTF is set to zero. This allows printf() calls to be left in the project source without generating unwanted timeout delays when the debugger is not connected.