### PR TITLE
Remove redundant debug shell scripts

### DIFF
--- a/examples/i2c_oled/debug.sh
+++ b/examples/i2c_oled/debug.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# before running this you should start OOCD server
-#../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/openocd -f ../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/wch-riscv.cfg
- 
-../../../MRS_Toolchain_Linux_x64_V1.70/RISC-V\ Embedded\ GCC/bin/riscv-none-embed-gdb

--- a/examples/spi_dac/debug.sh
+++ b/examples/spi_dac/debug.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# before running this you should start OOCD server
-#../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/openocd -f ../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/wch-riscv.cfg
- 
-../../../MRS_Toolchain_Linux_x64_V1.70/RISC-V\ Embedded\ GCC/bin/riscv-none-embed-gdb

--- a/examples/spi_oled/debug.sh
+++ b/examples/spi_oled/debug.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# before running this you should start OOCD server
-#../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/openocd -f ../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/wch-riscv.cfg
- 
-../../../MRS_Toolchain_Linux_x64_V1.70/RISC-V\ Embedded\ GCC/bin/riscv-none-embed-gdb

--- a/examples/tim1_pwm/debug.sh
+++ b/examples/tim1_pwm/debug.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# before running this you should start OOCD server
-#../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/openocd -f ../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/wch-riscv.cfg
- 
-../../../MRS_Toolchain_Linux_x64_V1.70/RISC-V\ Embedded\ GCC/bin/riscv-none-embed-gdb

--- a/examples/tim2_pwm/debug.sh
+++ b/examples/tim2_pwm/debug.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# before running this you should start OOCD server
-#../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/openocd -f ../../../MRS_Toolchain_Linux_x64_V1.70/OpenOCD/bin/wch-riscv.cfg
- 
-../../../MRS_Toolchain_Linux_x64_V1.70/RISC-V\ Embedded\ GCC/bin/riscv-none-embed-gdb


### PR DESCRIPTION
This PR removes several shell scripts that were inadvertently left in with example code when it was originally checked in. These scripts referred to external resources that are unlikely to be present for most users and should not be generally distributed.