### PR TITLE
Avoid bricking CH32V003J4M6 - For #219

### DIFF
--- a/examples/debugprintfdemo/debugprintfdemo.c
+++ b/examples/debugprintfdemo/debugprintfdemo.c
@@ -24,24 +24,20 @@ int main()
 	GPIOD->CFGLR &= ~(0xf<<(4*0));
 	GPIOD->CFGLR |= (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP)<<(4*0);
 
-	// GPIO D4 Push-Pull
-	GPIOD->CFGLR &= ~(0xf<<(4*4));
-	GPIOD->CFGLR |= (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP)<<(4*4);
-
 	// GPIO C0 Push-Pull
 	GPIOC->CFGLR &= ~(0xf<<(4*0));
 	GPIOC->CFGLR |= (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP)<<(4*0);
 
 	while(1)
 	{
-		GPIOD->BSHR = 1 | (1<<4);	 // Turn on GPIOs
+		GPIOD->BSHR = 1;	 // Turn on GPIOs
 		GPIOC->BSHR = 1;
 		printf( "+%lu\n", count++ );
 		Delay_Ms(100);
 		int i;
 		for( i = 0; i < 10000; i++ )
 			poll_input();
-		GPIOD->BSHR = (1<<16) | (1<<(16+4)); // Turn off GPIODs
+		GPIOD->BSHR = (1<<16); // Turn off GPIODs
 		GPIOC->BSHR = (1<<16);
 		printf( "-%lu[%c]\n", count++, last );
 		Delay_Ms(100);


### PR DESCRIPTION
Avoid bricking CH32V003J4M6 by not using `PD4` in the demo.