### PR TITLE
Fix for UART fractional BRR caclulation

### DIFF
--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -5109,10 +5109,10 @@ void SystemInit(void);
 #else
 	#define UART_BAUD_RATE 115200
 #endif
-#define OVER8DIV 4
-#define INTEGER_DIVIDER (((25 * (FUNCONF_SYSTEM_CORE_CLOCK)) / ((OVER8DIV) * (UART_BAUD_RATE))))
+#define OVER4DIV 4
+#define INTEGER_DIVIDER (((25 * (FUNCONF_SYSTEM_CORE_CLOCK)) / ((OVER4DIV) * (UART_BAUD_RATE))))
 #define FRACTIONAL_DIVIDER ((INTEGER_DIVIDER)%100)
-#define UART_BRR ((((INTEGER_DIVIDER) / 100) << 4) | (((((FRACTIONAL_DIVIDER) * ((OVER8DIV)*2)) + 50)/100)&7))
+#define UART_BRR ((((INTEGER_DIVIDER) / 100) << 4) | (((((FRACTIONAL_DIVIDER) * ((OVER4DIV)*4)) + 50)/100)&15))
 // Put an output debug UART on Pin D5.
 // You can write to this with printf(...) or puts(...)
 


### PR DESCRIPTION
I couldn't get the UART to work above 230400baud, always resulted in garbage. 
Looks like the fractional part was calculated as 3bit value, while it is a 4 bit value. 
With the fixes the ch32v003 sports 2Mbaud without hassle, even on HSI and factory calibration.