### PR TITLE
fix compilation for arch linux

### DIFF
--- a/ch32v003fun/ch32v003fun.mk
+++ b/ch32v003fun/ch32v003fun.mk
@@ -1,5 +1,12 @@
-
-PREFIX?=riscv64-unknown-elf
+ifeq ($(OS),Windows_NT)
+    PREFIX?=riscv64-unknown-elf
+else
+    ifeq (, $(shell which riscv64-unknown-elf-gcc))
+        PREFIX?=riscv64-elf
+    else
+        PREFIX?=riscv64-unknown-elf
+    endif
+endif
 
 CH32V003FUN?=../../ch32v003fun
 MINICHLINK?=$(CH32V003FUN)/../minichlink


### PR DESCRIPTION
on arch linux, the risc compiler name is different. Add some logic to pick correct risc compiler on arch linux