### PR TITLE
Fix typo preventing specpgm hint from being read on cmdline

### DIFF
--- a/minichlink/99-minichlink.rules
+++ b/minichlink/99-minichlink.rules
@@ -1,4 +1,6 @@
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8010", GROUP="plugdev", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="4004", GROUP="plugdev", MODE="0660"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="4004", GROUP="plugdev", MODE="0660"
-
+# rv003usb bootloader
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="b003", GROUP="plugdev", MODE="0660"
+#KERNEL=="hiddev*", SUBSYSTEM=="usbmisc", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="b003", GROUP="plugdev", MODE="0660"

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -649,6 +649,7 @@ help:
 	fprintf( stderr, " -t Disable 3.3V\n" );
 	fprintf( stderr, " -f Disable 5V\n" );
 	fprintf( stderr, " -c [serial port for Ardulink, try /dev/ttyACM0 or COM11 etc]\n" );
+	fprintf( stderr, " -C [Specified programmer, eg. b003boot, ardulink, esp32s2chfun]\n" );
 	fprintf( stderr, " -u Clear all code flash - by power off (also can unbrick)\n" );
 	fprintf( stderr, " -E Erase chip\n" );
 	fprintf( stderr, " -b Reboot out of Halt\n" );

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -649,7 +649,7 @@ help:
 	fprintf( stderr, " -t Disable 3.3V\n" );
 	fprintf( stderr, " -f Disable 5V\n" );
 	fprintf( stderr, " -c [serial port for Ardulink, try /dev/ttyACM0 or COM11 etc]\n" );
-	fprintf( stderr, " -C [Specified programmer, eg. b003boot, ardulink, esp32s2chfun]\n" );
+	fprintf( stderr, " -C [specified programmer, eg. b003boot, ardulink, esp32s2chfun]\n" );
 	fprintf( stderr, " -u Clear all code flash - by power off (also can unbrick)\n" );
 	fprintf( stderr, " -E Erase chip\n" );
 	fprintf( stderr, " -b Reboot out of Halt\n" );

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -114,7 +114,7 @@ int main( int argc, char ** argv )
 			if( i < argc )
 				hints.serial_port = argv[i];
 		}
-		else if( strncmp( v, "-c", 2 ) == 0 )
+		else if( strncmp( v, "-C", 2 ) == 0 )
 		{
 			i++;
 			if( i < argc )


### PR DESCRIPTION
This fixes a typo preventing programmers to be specified on the command line. It also adds a udev rule for the rv003usb bootloader.