### PR TITLE
Add minichlink unbrick to makefile

### DIFF
--- a/ch32v003fun/ch32v003fun.mk
+++ b/ch32v003fun/ch32v003fun.mk
@@ -158,6 +158,9 @@ terminal : monitor
 monitor :
 	$(MINICHLINK)/minichlink -T
 
+unbrick :
+	$(MINICHLINK)/minichlink -u
+
 gdbserver : 
 	-$(MINICHLINK)/minichlink -baG
 


### PR DESCRIPTION
Add the minichlink unbrick command to the makefile, such that the chip can be unbricked using 'make unbrick'.