### PR TITLE
ch32v003fun.mk changes related to compiler prefix and newlib paths

### DIFF
--- a/ch32v003fun/ch32v003fun.mk
+++ b/ch32v003fun/ch32v003fun.mk
@@ -1,12 +1,24 @@
+# Default prefix for Windows
 ifeq ($(OS),Windows_NT)
     PREFIX?=riscv64-unknown-elf
+# Check if riscv64-linux-gnu-gcc exists
+else ifneq ($(shell which riscv64-linux-gnu-gcc),)
+    PREFIX?=riscv64-linux-gnu
+# Check if riscv64-unknown-elf-gcc exists
+else ifneq ($(shell which riscv64-unknown-elf-gcc),)
+    PREFIX?=riscv64-unknown-elf
+# Default prefix
 else
-    ifeq (, $(shell which riscv64-unknown-elf-gcc))
-        PREFIX?=riscv64-elf
-    else
-        PREFIX?=riscv64-unknown-elf
-    endif
+    PREFIX?=riscv64-elf
 endif
+
+# Fedora places newlib in a different location
+ifneq ($(wildcard /etc/fedora-release),)
+	NEWLIB?=/usr/arm-none-eabi/include
+else
+	NEWLIB?=/usr/include/newlib
+endif
+
 
 TARGET_MCU?=CH32V003
 TARGET_EXT?=c
@@ -129,7 +141,7 @@ endif
 
 CFLAGS+= \
 	$(CFLAGS_ARCH) -static-libgcc \
-	-I/usr/include/newlib \
+	-I$(NEWLIB) \
 	-I$(CH32V003FUN)/../extralibs \
 	-I$(CH32V003FUN) \
 	-nostdlib \

--- a/examples/cpp_virtual_methods/Makefile
+++ b/examples/cpp_virtual_methods/Makefile
@@ -15,7 +15,7 @@ CFLAGS:= \
 	-static-libgcc \
 	-march=rv32ec \
 	-mabi=ilp32e \
-	-I/usr/include/newlib \
+	-I$(NEWLIB) \
 	-I$(CH32V003FUN) \
 	-nostdlib \
 	-DCH32V003 \


### PR DESCRIPTION
This fixes compiler detection on Fedora 39 (gcc-riscv64-linux-gnu from the repo), which will no longer require compiling the entire gnu rv toolchain as described in the wiki. The repo provides `arm-none-eabi-newlib` for newlib, which places itself in a directory now properly checked by the makefile. **I have not tested this on a non-fedora system**