### PR TITLE
Exti defs

### DIFF
--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -5259,6 +5259,39 @@ typedef struct
 #define AFIO_PCFR1_SWJ_CFG_JTAGDISABLE          ((uint32_t)0x02000000) /* JTAG-DP Disabled and SW-DP Enabled */
 #define AFIO_PCFR1_SWJ_CFG_DISABLE              ((uint32_t)0x04000000) /* JTAG-DP Disabled and SW-DP Disabled */
 
+
+#if defined(CH32V003)
+/*****************  Bit definition for AFIO_EXTICR register  *****************/
+#define AFIO_EXTICR_EXTI0                       ((uint16_t)0x0003) /* EXTI 0 configuration */
+#define AFIO_EXTICR_EXTI1                       ((uint16_t)0x000C) /* EXTI 1 configuration */
+#define AFIO_EXTICR_EXTI2                       ((uint16_t)0x0030) /* EXTI 2 configuration */
+#define AFIO_EXTICR_EXTI3                       ((uint16_t)0x00C0) /* EXTI 3 configuration */
+#define AFIO_EXTICR_EXTI4                       ((uint16_t)0x0300) /* EXTI 4 configuration */
+#define AFIO_EXTICR_EXTI5                       ((uint16_t)0x0C00) /* EXTI 5 configuration */
+#define AFIO_EXTICR_EXTI6                       ((uint16_t)0x3000) /* EXTI 6 configuration */
+#define AFIO_EXTICR_EXTI7                       ((uint16_t)0xC000) /* EXTI 7 configuration */
+
+#define AFIO_EXTICR_EXTI0_PC                    ((uint16_t)0x0002) /* PC[0] pin */
+#define AFIO_EXTICR_EXTI0_PD                    ((uint16_t)0x0003) /* PD[0] pin */
+#define AFIO_EXTICR_EXTI1_PA                    ((uint16_t)0x0000) /* PA[1] pin */
+#define AFIO_EXTICR_EXTI1_PC                    ((uint16_t)0x0008) /* PC[1] pin */
+#define AFIO_EXTICR_EXTI1_PD                    ((uint16_t)0x000C) /* PD[1] pin */
+#define AFIO_EXTICR_EXTI2_PA                    ((uint16_t)0x0000) /* PA[2] pin */
+#define AFIO_EXTICR_EXTI2_PC                    ((uint16_t)0x0020) /* PC[2] pin */
+#define AFIO_EXTICR_EXTI2_PD                    ((uint16_t)0x0030) /* PD[2] pin */
+#define AFIO_EXTICR_EXTI3_PC                    ((uint16_t)0x0080) /* PC[3] pin */
+#define AFIO_EXTICR_EXTI3_PD                    ((uint16_t)0x00C0) /* PD[3] pin */
+#define AFIO_EXTICR_EXTI4_PC                    ((uint16_t)0x0200) /* PC[4] pin */
+#define AFIO_EXTICR_EXTI4_PD                    ((uint16_t)0x0300) /* PD[4] pin */
+#define AFIO_EXTICR_EXTI5_PC                    ((uint16_t)0x0800) /* PC[5] pin */
+#define AFIO_EXTICR_EXTI5_PD                    ((uint16_t)0x0C00) /* PD[5] pin */
+#define AFIO_EXTICR_EXTI6_PC                    ((uint16_t)0x2000) /* PC[6] pin */
+#define AFIO_EXTICR_EXTI6_PD                    ((uint16_t)0x3000) /* PD[6] pin */
+#define AFIO_EXTICR_EXTI7_PC                    ((uint16_t)0x8000) /* PC[7] pin */
+#define AFIO_EXTICR_EXTI7_PD                    ((uint16_t)0xC000) /* PD[7] pin */
+#endif
+
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 /*****************  Bit definition for AFIO_EXTICR1 register  *****************/
 #define AFIO_EXTICR1_EXTI0                      ((uint16_t)0x000F) /* EXTI 0 configuration */
 #define AFIO_EXTICR1_EXTI1                      ((uint16_t)0x00F0) /* EXTI 1 configuration */
@@ -5297,7 +5330,6 @@ typedef struct
 #define AFIO_EXTICR1_EXTI3_PF                   ((uint16_t)0x5000) /* PF[3] pin */
 #define AFIO_EXTICR1_EXTI3_PG                   ((uint16_t)0x6000) /* PG[3] pin */
 
-#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 /*****************  Bit definition for AFIO_EXTICR2 register  *****************/
 #define AFIO_EXTICR2_EXTI4                      ((uint16_t)0x000F) /* EXTI 4 configuration */
 #define AFIO_EXTICR2_EXTI5                      ((uint16_t)0x00F0) /* EXTI 5 configuration */

--- a/examples/exti_pin_change_isr/exti_pin_change_isr.c
+++ b/examples/exti_pin_change_isr/exti_pin_change_isr.c
@@ -35,11 +35,11 @@ void EXTI7_0_IRQHandler( void ) __attribute__((interrupt));
 void EXTI7_0_IRQHandler( void ) 
 {
 	// Flash just a little blip.
-	GPIOC->BSHR = 2;
-	GPIOC->BSHR = (2<<16);
+	funDigitalWrite( PC1, FUN_HIGH );
+	funDigitalWrite( PC1, FUN_LOW );
 
 	// Acknowledge the interrupt
-	EXTI->INTFR = 1<<3;
+	EXTI->INTFR = EXTI_Line3;
 }
 
 int main()
@@ -50,14 +50,12 @@ int main()
 	RCC->APB2PCENR = RCC_APB2Periph_GPIOD | RCC_APB2Periph_GPIOC | RCC_APB2Periph_AFIO;
 
 	// GPIO D3 for input pin change.
-	GPIOD->CFGLR =
-		(GPIO_CNF_IN_PUPD)<<(4*1) |  // Keep SWIO enabled.
-		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*3);  //PD4 = GPIOD IN
+	funPinMode( PD3, GPIO_CFGLR_IN_FLOAT );
+	// funPinMode( PD4, GPIO_CFGLR_IN_PUPD ); // Keep SWIO enabled / seems to be unnecessary
 
-	// GPIO C0 Push-Pull (our output) 
-	GPIOC->CFGLR =
-		(GPIO_Speed_10MHz | GPIO_CNF_OUT_PP)<<(4*0) |
-		(GPIO_Speed_10MHz | GPIO_CNF_OUT_PP)<<(4*1);
+	// GPIO C0 Push-Pull (our output)
+	funPinMode( PC0,  GPIO_CFGLR_OUT_10Mhz_PP );
+	funPinMode( PC1,  GPIO_CFGLR_OUT_10Mhz_PP );
 
 	// Ugh this is tricky.
 	// This is how we set (INTSYSCR) to enable hardware interrupt nesting
@@ -84,9 +82,9 @@ int main()
 		 : : :  "t1" );
 
 	// Configure the IO as an interrupt.
-	AFIO->EXTICR = 3<<(3*2); //PORTD.3 (3 out front says PORTD, 3 in back says 3)
-	EXTI->INTENR = 1<<3; // Enable EXT3
-	EXTI->RTENR = 1<<3;  // Rising edge trigger
+	AFIO->EXTICR = AFIO_EXTICR_EXTI3_PD;
+	EXTI->INTENR = EXTI_INTENR_MR3; // Enable EXT3
+	EXTI->RTENR = EXTI_RTENR_TR3;  // Rising edge trigger
 
 	// enable interrupt
 	NVIC_EnableIRQ( EXTI7_0_IRQn );


### PR DESCRIPTION
Fixes for the defines of the EXTICR register of the ch32v003 device, and update the exti example to use the corrected definitions