### PR TITLE
Declare the _write() function as "weak" to allow redefinition.

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1387,7 +1387,8 @@ void poll_input()
 //   b7 = is a "printf" waiting?
 //   b0..b3 = # of bytes in printf (+4).  (5 or higher indicates a print of some kind)
 //     note: if b7 is 0 in reply, but b0..b3 have >=4 then we received data from host.
-
+// declare as weak to allow overriding.
+int _write(int fd, const char *buf, int size) __attribute__((weak));
 int _write(int fd, const char *buf, int size)
 {
 	char buffer[4] = { 0 };


### PR DESCRIPTION
Declare the _write() function as "weak" to allow overriding for printf compatibility with external UART libraries (which support async R/W with DMA buffers and IRQ). See https://github.com/hexeguitar/ch32v003fun_libs/pull/3