### PR TITLE
PlatformIO clarifications and Intellisense fix

### DIFF
--- a/.github/add_include.py
+++ b/.github/add_include.py
@@ -18,3 +18,4 @@ for filter in src_filters:
 # propagate to all construction environments
 for e in env, projenv, DefaultEnvironment():
    e.Append(CCFLAGS=[("-I", example_folder)])
+   e.Append(CPPPATH=[example_folder])

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,14 @@ include_dir = .
 [env]
 platform = https://github.com/Community-PIO-CH32V/platform-ch32v.git
 monitor_speed = 115200
+; default upload and debug protocol is "wch-link", using OpenOCD and
+; expecting a WCH-LinkE programming adapter.
+; To use minichlink, uncomment this
+;upload_protocol = minichlink
+; additionally uncomment this to use ardulink on a specific COM port
+;upload_flags =
+;  -c
+;  COM3
 
 ; for examples that use ch32v003fun as their base
 [fun_base]


### PR DESCRIPTION
Teeny tiny fix and extra comments. 

To make intellisense find the right include folder for `funconfig.h` not only during CI compilation, I also add the right path in `CPPPATH`, not as raw `CCFLAGS`.

Clarification for people wanting to upload via minichlink instead of OpenOCD were also made. With that, we get back the nice Intellisense in PlatformIO.

![grafik](https://github.com/cnlohr/ch32v003fun/assets/26485477/7e320b7f-6c78-40c2-8041-106803c64d4f)
