### PR TITLE
Remove plugdev warning on OSX

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -124,7 +124,7 @@ int main( int argc, char ** argv )
 		}
 	}
 
-#if !defined(WINDOWS) && !defined(WIN32) && !defined(_WIN32)
+#if !defined(WINDOWS) && !defined(WIN32) && !defined(_WIN32) && !defined(__APPLE__)
 	{
 		uid_t uid = getuid();
 		struct passwd* pw = getpwuid(uid);


### PR DESCRIPTION
On OSX, minichlink shows the warning 
> WARNING: You are not in the plugdev group, the canned udev rules will not work on your system

But udev does not exist on OSX, so this warning can be removed. I just extended the trick that makes it not appear on Windows either.