### PR TITLE
Add example for using SPI TX with DMA on the CH32V003

### DIFF
--- a/examples/dma_spi/Makefile
+++ b/examples/dma_spi/Makefile
@@ -1,0 +1,11 @@
+all : flash
+
+TARGET:=dma_spi
+TARGET_MCU:=CH32V003
+
+include ../../ch32v003fun/ch32v003fun.mk
+
+flash : cv_flash
+clean : cv_clean
+
+

--- a/examples/dma_spi/README.md
+++ b/examples/dma_spi/README.md
@@ -6,6 +6,8 @@ when the transfer is complete. Due to the DMA flagging Transfer Complete
 before the SPI has clocked out the last byte, I have implemented some code to check
 for the BSY (busy) flag before clearing the CS line.
 
+![Screenshot_20240718_232950](https://github.com/user-attachments/assets/67d0bbe0-f40c-4aeb-bf76-60632292363a)
+
 ## License
 MIT License
 

--- a/examples/dma_spi/README.md
+++ b/examples/dma_spi/README.md
@@ -40,6 +40,7 @@ or logic analyzer to PC5 (SCK), PC6 (MOSI) and PC0 (CS). You should then see a
 continuous bursts of the sequence {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
 being transmitted over the SPI bus.
 
-To initiate a transfer the user must set the CS line low, set spi_state to TRANSMITTING,
+To initiate a transfer manually the user must set the CS line low, set spi_state to TRANSMITTING,
 disable the DMA for register access, load the data length into the DMA transfer counter and
-then re-enable the DMA. The DMA will then take care of the rest.
+then re-enable the DMA. The DMA will then take care of the rest. All of this is done in the
+initiate_transfer() function.

--- a/examples/dma_spi/README.md
+++ b/examples/dma_spi/README.md
@@ -1,10 +1,10 @@
 # DMA SPI TX example
 This example can be used as a baseline for implementing SPI using DMA.
 It uses a basic finite state machine to control the CS line, where it is
-set by the user before initiating a transfer and then cleared by the DMA ISR
-when the transfer is complete. Due to the DMA flagging Transfer Complete
-before the SPI has clocked out the last byte, I have implemented some code to check
-for the BSY (busy) flag before clearing the CS line.
+set by the user before initiating a transfer and then cleared by the DMA ISR. 
+Due to the DMA flagging Transfer Complete before the SPI has clocked out the 
+last byte, I have implemented some code to check for the BSY (busy) flag on SPI
+to clear before subsequently clearing the CS line.
 
 ![Screenshot_20240718_232950](https://github.com/user-attachments/assets/67d0bbe0-f40c-4aeb-bf76-60632292363a)
 

--- a/examples/dma_spi/README.md
+++ b/examples/dma_spi/README.md
@@ -1,0 +1,43 @@
+# DMA SPI TX example
+This example can be used as a baseline for implementing SPI using DMA.
+It uses a basic finite state machine to control the CS line, where it is
+set by the user before initiating a transfer and then cleared by the DMA ISR
+when the transfer is complete. Due to the DMA flagging Transfer Complete
+before the SPI has clocked out the last byte, I have implemented some code to check
+for the BSY (busy) flag before clearing the CS line.
+
+## License
+MIT License
+
+Copyright (c) 2024 Fredrik Saevland
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Building
+**make** - build the project
+
+## Use
+Flash the binary to the CH32V003 board of your choice and connect an oscilloscope
+or logic analyzer to PC5 (SCK), PC6 (MOSI) and PC0 (CS). You should then see a
+continuous bursts of the sequence {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+being transmitted over the SPI bus.
+
+To initiate a transfer the user must set the CS line low, set spi_state to TRANSMITTING,
+disable the DMA for register access, load the data length into the DMA transfer counter and
+then re-enable the DMA. The DMA will then take care of the rest.

--- a/examples/dma_spi/dma_spi.c
+++ b/examples/dma_spi/dma_spi.c
@@ -1,0 +1,140 @@
+/* 
+SPI DMA example with software NSS
+Based on cnlohr's example for the CH32V203
+Author: Fredrik Saevland (fsaev)
+		https://github.com/fsaev
+
+MIT License
+
+Copyright (c) 2024 Fredrik Saevland
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "ch32v003fun.h"
+#include <stdio.h>
+#include <string.h>
+
+
+#define SENDBUFF_BYTES 8
+uint8_t sendbuff[] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+enum TransferState {
+	IDLE,
+	TRANSMITTING,
+	DMA_DONE
+};
+
+volatile enum TransferState spi_state = IDLE;
+
+void DMA1_Channel3_IRQHandler( void ) __attribute__((interrupt));
+
+void DMA1_Channel3_IRQHandler( void ) 
+{
+
+	// Backup flags.
+	volatile int intfr = DMA1->INTFR;
+	do
+	{
+		// Clear all possible flags.
+		DMA1->INTFCR = 0xFFFFFFFF;
+
+		if(intfr & DMA1_IT_TC3) { // Transmission complete
+			if(spi_state == TRANSMITTING) {
+				spi_state = DMA_DONE;
+			}
+		}
+
+		intfr = DMA1->INTFR;
+	} while( intfr );
+}
+
+int main()
+{
+	SystemInit();
+
+	funGpioInitAll();
+
+	/* Set up pins for Alternate Function*/
+	// PC5 is SCK, 50MHz Output, alt func, p-p
+	funPinMode( PC5, GPIO_CFGLR_OUT_50Mhz_AF_PP );
+	
+	// PC6 is MOSI, 50MHz Output, alt func, p-p
+	funPinMode( PC6, GPIO_CFGLR_OUT_50Mhz_AF_PP );
+
+	// PC0 is Software NSS, 50MHz Output, GPIO, p-p
+	funPinMode( PC0, GPIO_CFGLR_OUT_50Mhz_PP );
+	funPinMode( PC1, GPIO_CFGLR_OUT_50Mhz_PP );
+	funDigitalWrite(PC0, FUN_HIGH);
+
+	RCC->APB2PRSTR = RCC_SPI1RST;
+	RCC->APB2PRSTR = 0;
+	RCC->APB2PCENR |= RCC_APB2Periph_SPI1;
+	RCC->AHBPCENR |= RCC_AHBPeriph_DMA1;
+
+	// Configure SPI
+	SPI1->CTLR1 = 
+		SPI_NSS_Soft | SPI_CPHA_1Edge | SPI_CPOL_Low | SPI_DataSize_8b |
+		SPI_Mode_Master | SPI_Direction_1Line_Tx | SPI_BaudRatePrescaler_16;
+
+	// Enable TX DMA
+	SPI1->CTLR2 = SPI_CTLR2_TXDMAEN;
+
+	//SPI1->HSCR = 1; // High-speed enable.
+	SPI1->CTLR1 |= CTLR1_SPE_Set;
+
+	//DMA1_Channel3 is for SPI1TX
+	DMA1_Channel3->PADDR = (uint32_t)&SPI1->DATAR;
+	DMA1_Channel3->MADDR = (uint32_t)sendbuff;
+	DMA1_Channel3->CFGR  =
+		DMA_M2M_Disable |
+		DMA_Priority_VeryHigh |
+		DMA_MemoryDataSize_Byte | // 8-bit mode
+		DMA_PeripheralDataSize_Byte |
+		DMA_MemoryInc_Enable |
+		DMA_Mode_Normal | // DMA_Mode_Normal
+		DMA_DIR_PeripheralDST |
+		DMA_IT_TC; // Transmission Complete
+
+	NVIC_EnableIRQ( DMA1_Channel3_IRQn );
+
+	uint32_t timestamp = 0;
+
+	while(1)
+	{
+		if(SysTick->CNT - timestamp > 10000)
+		{
+			timestamp = SysTick->CNT;
+
+			// Send repeatedly
+			funDigitalWrite(PC0, FUN_LOW); // Set CS low
+			spi_state = TRANSMITTING;
+			DMA1_Channel3->CFGR &= ~DMA_CFGR1_EN; // Disable DMA in order to write to CNTR
+			DMA1_Channel3->CNTR  = SENDBUFF_BYTES; // Reload size of buffer
+			DMA1_Channel3->CFGR |= DMA_CFGR1_EN; // Initate DMA transfer
+		}
+
+		// When DMA is done and last byte is clocked out, set CS high
+		if(spi_state == DMA_DONE && !(SPI1->STATR & SPI_I2S_FLAG_BSY)){
+			funDigitalWrite(PC0, FUN_HIGH); // Set CS high
+			spi_state = IDLE;
+		}
+	}
+}
+

--- a/examples/dma_spi/dma_spi.c
+++ b/examples/dma_spi/dma_spi.c
@@ -80,7 +80,6 @@ int main()
 
 	// PC0 is Software NSS, 50MHz Output, GPIO, p-p
 	funPinMode( PC0, GPIO_CFGLR_OUT_50Mhz_PP );
-	funPinMode( PC1, GPIO_CFGLR_OUT_50Mhz_PP );
 	funDigitalWrite(PC0, FUN_HIGH);
 
 	RCC->APB2PRSTR = RCC_SPI1RST;

--- a/examples/dma_spi/dma_spi.c
+++ b/examples/dma_spi/dma_spi.c
@@ -28,9 +28,6 @@ SOFTWARE.
 */
 
 #include "ch32v003fun.h"
-#include <stdio.h>
-#include <string.h>
-
 
 #define SENDBUFF_BYTES 8
 uint8_t sendbuff[] = {0, 1, 2, 3, 4, 5, 6, 7};

--- a/examples/dma_spi/dma_spi.c
+++ b/examples/dma_spi/dma_spi.c
@@ -65,6 +65,16 @@ void DMA1_Channel3_IRQHandler( void )
 	} while( intfr );
 }
 
+/* Starts a single transmission of sendbuff */
+void initiate_transfer()
+{
+	funDigitalWrite(PC0, FUN_LOW); // Set CS low
+	spi_state = TRANSMITTING;
+	DMA1_Channel3->CFGR &= ~DMA_CFGR1_EN; // Disable DMA in order to write to CNTR
+	DMA1_Channel3->CNTR  = SENDBUFF_BYTES; // Reload size of buffer
+	DMA1_Channel3->CFGR |= DMA_CFGR1_EN; // Initate DMA transfer
+}
+
 int main()
 {
 	SystemInit();
@@ -122,11 +132,7 @@ int main()
 			timestamp = SysTick->CNT;
 
 			// Send repeatedly
-			funDigitalWrite(PC0, FUN_LOW); // Set CS low
-			spi_state = TRANSMITTING;
-			DMA1_Channel3->CFGR &= ~DMA_CFGR1_EN; // Disable DMA in order to write to CNTR
-			DMA1_Channel3->CNTR  = SENDBUFF_BYTES; // Reload size of buffer
-			DMA1_Channel3->CFGR |= DMA_CFGR1_EN; // Initate DMA transfer
+			initiate_transfer();
 		}
 
 		// When DMA is done and last byte is clocked out, set CS high

--- a/examples/dma_spi/funconfig.h
+++ b/examples/dma_spi/funconfig.h
@@ -1,0 +1,11 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+#define CH32V003           1
+
+#define FUNCONF_USE_DEBUGPRINTF 1
+#define FUNCONF_USE_UARTPRINTF  0
+
+
+#endif
+


### PR DESCRIPTION
Implement SPI TX  using DMA, with 8-bit mode and soft NSS using a small state machine. This example prints the sequence of 0 .. 7 repeatedly.