### PR TITLE
Switch to -Wl,--print-memory-usage from elf-size

### DIFF
--- a/ch32v003fun/ch32v003fun.mk
+++ b/ch32v003fun/ch32v003fun.mk
@@ -30,6 +30,7 @@ WRITE_SECTION?=flash
 SYSTEM_C?=$(CH32V003FUN)/ch32v003fun.c
 
 CFLAGS?=-g -Os -flto -ffunction-sections -fdata-sections -fmessage-length=0 -msmall-data-limit=8
+LDFLAGS+=-Wl,--print-memory-usage
 
 ifeq ($(TARGET_MCU),CH32V003)
 	CFLAGS_ARCH+=-march=rv32ec -mabi=ilp32e -DCH32V003=1
@@ -151,7 +152,6 @@ LDFLAGS+=-T $(LINKER_SCRIPT) -Wl,--gc-sections
 FILES_TO_COMPILE:=$(SYSTEM_C) $(TARGET).$(TARGET_EXT) $(ADDITIONAL_C_FILES) 
 
 $(TARGET).bin : $(TARGET).elf
-	$(PREFIX)-size $^
 	$(PREFIX)-objdump -S $^ > $(TARGET).lst
 	$(PREFIX)-objdump -t $^ > $(TARGET).map
 	$(PREFIX)-objcopy -O binary $< $(TARGET).bin


### PR DESCRIPTION
To compare:
Before:
```
riscv64-unknown-elf-size tim1_pwm.elf
   text       data        bss        dec        hex    filename
   8784          0        448       9232       2410    tim1_pwm.elf
```
After:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:        8784 B        16 KB     53.61%
             RAM:         448 B         2 KB     21.88%
```