### PR TITLE
Fix support for Zephyr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+if(CONFIG_SOC_SERIES_CH32V00X)
+  zephyr_include_directories(
+    ch32v003fun
+  )
+endif()

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,3 @@
 name: hal_wch
 build:
-  cmake-ext: True
-  kconfig-ext: True
+  cmake: .


### PR DESCRIPTION
@fabiobaltieri - I need your help with this PR.

With the following file:

```yaml
$ cat zephyr/module.yml 
name: hal_wch
build:
  cmake-ext: True
  kconfig-ext: True
```

I am running into the following build problems:

```
$ west build -p always -b wch_ch32v003evt samples/basic/blinky
...
-- Found BOARD.dts: /home/user/zephyrproject/zephyr/boards/wch/ch32v003evt/wch_ch32v003evt.dts
-- Generated zephyr.dts: /home/user/zephyrproject/zephyr/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: /home/user/zephyrproject/zephyr/build/zephyr/include/generated/zephyr/devicetree_generated.h
-- Including generated dts.cmake file: /home/user/zephyrproject/zephyr/build/zephyr/dts.cmake
Parsing /home/user/zephyrproject/zephyr/Kconfig
/home/user/zephyrproject/zephyr/scripts/kconfig/kconfig.py: build/Kconfig/Kconfig.modules:134: Could not open '/home/user/zephyrproject/zephyr/' (in 'osource "$(ZEPHYR_HAL_WCH_KCONFIG)"') (EISDIR: Is a directory)
CMake Error at /home/user/zephyrproject/zephyr/cmake/modules/kconfig.cmake:389 (message):
  command failed with return code: 1
Call Stack (most recent call first):
  /home/user/zephyrproject/zephyr/cmake/modules/zephyr_default.cmake:132 (include)
  /home/user/zephyrproject/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
  /home/user/zephyrproject/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:92 (include_boilerplate)
  CMakeLists.txt:4 (find_package)


-- Configuring incomplete, errors occurred!
FATAL ERROR: command exited with status 1: /usr/bin/cmake -DWEST_PYTHON=/home/user/zephyrproject/.venv/bin/python3 -B/home/user/zephyrproject/zephyr/build -GNinja -DBOARD=wch_ch32v003evt -S/home/user/zephyrproject/zephyr/samples/basic/blinky
```

Now, with the following file:

```yaml
$ cat zephyr/module.yml 
name: hal_wch
build:
  cmake: .
```

and the new `CMakeLists.txt` file that this PR introduces, things are working much better!