### PR TITLE
Break out random number generation to separate header

### DIFF
--- a/examples/spi_oled/rand.h
+++ b/examples/spi_oled/rand.h
@@ -1,0 +1,51 @@
+/*
+ * rand.h - LFSR-based random number generation
+ * Released to Public Domain 08-05-2024 E. Brombaugh
+ */
+ 
+/*
+ * Common function
+ * seed = 0 - advances LFSR state and returns result
+ * seed = anything else - set seed to that value
+ * bit = 1-32 - number of bits to generate
+ */
+uint32_t rnd_fun(uint32_t seed, uint8_t bits)
+{
+	static uint32_t rnd_state = 1;
+	uint32_t lsb;
+	
+	if(seed)
+	{
+		rnd_state = seed;
+		return 0;
+	}
+	
+	while(bits--)
+	{
+		lsb = rnd_state & 1;
+		rnd_state >>= 1;
+		if(lsb)
+			rnd_state ^= 0x80200003;
+	}
+	
+	return rnd_state;
+}
+
+/*
+ * stdlib random emulation
+ */
+
+#define RAND_MAX 0x7FFFFFFF
+
+/* generates 31 bits PRN */
+int rand(void)
+{
+	return rnd_fun(0,31)&RAND_MAX;
+}
+
+/* set seed */
+void srand(unsigned int seed)
+{
+	rnd_fun(seed,0);
+}
+

--- a/examples/spi_oled/spi_oled.c
+++ b/examples/spi_oled/spi_oled.c
@@ -12,35 +12,7 @@
 #include <stdio.h>
 #include "ssd1306_spi.h"
 #include "ssd1306.h"
-
-/* White Noise Generator State */
-#define NOISE_BITS 8
-#define NOISE_MASK ((1<<NOISE_BITS)-1)
-#define NOISE_POLY_TAP0 31
-#define NOISE_POLY_TAP1 21
-#define NOISE_POLY_TAP2 1
-#define NOISE_POLY_TAP3 0
-uint32_t lfsr = 1;
-
-/*
- * random byte generator
- */
-uint8_t rand8(void)
-{
-	uint8_t bit;
-	uint32_t new_data;
-	
-	for(bit=0;bit<NOISE_BITS;bit++)
-	{
-		new_data = ((lfsr>>NOISE_POLY_TAP0) ^
-					(lfsr>>NOISE_POLY_TAP1) ^
-					(lfsr>>NOISE_POLY_TAP2) ^
-					(lfsr>>NOISE_POLY_TAP3));
-		lfsr = (lfsr<<1) | (new_data&1);
-	}
-	
-	return lfsr&NOISE_MASK;
-}
+#include "rand.h"
 
 /*
  * return pixel value in buffer
@@ -240,7 +212,7 @@ int main()
 			/* fill with random */
 			for(i=0;i<sizeof(ssd1306_buffer);i++)
 			{
-				ssd1306_buffer[i] = rand8();
+				ssd1306_buffer[i] = rand();
 			}
 			ssd1306_refresh();
 


### PR DESCRIPTION
This change replaces the original LFSR code with a somewhat more efficient approach and pulls the function out into a separate header file that could be more easily used by others. It also adds two wrapper functions that emulate the behavior of the rand() and srand() functions from <stdlib.h>.
