### PR TITLE
Configurable flash / ram split with minichlink

### DIFF
--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -789,6 +789,19 @@ typedef struct
 	__IO uint32_t RES3;
 } ESG_TypeDef;
 
+typedef struct
+{
+    union
+    {   
+        __I uint32_t CHIPID;
+        struct 
+        {
+            __I uint16_t REVID;
+	        __I uint16_t DEVID;
+        };
+    };
+} INFO_TypeDef;
+
 #if defined(CH32V30x)
 /* FSMC Bank1 Registers */
 typedef struct
@@ -2483,7 +2496,7 @@ typedef struct
 
 #define OB_BASE                                 ((uint32_t)0x1FFFF800)    /* Flash Option Bytes base address */
 #define ESIG_BASE                               ((uint32_t)0x1FFFF7E0)
-#define CHIP_ID                                 *((uint32_t*)0x1FFFF704) // Mentioned in ch32v30x_dbgmcu.c, may not work on all processors.
+#define INFO_BASE                               ((uint32_t)0x1FFFF704)
 
 #if defined(CH32V003) || defined(CH32V10x)
 #define EXTEN_BASE                              ((uint32_t)0x40023800)
@@ -2771,6 +2784,8 @@ typedef struct
 #endif // defined(CH32V20x) || defined(CH32V30x)
 #define OB                                      ((OB_TypeDef *)OB_BASE)
 #define ESIG                                    ((ESG_TypeDef *)ESIG_BASE)
+// Mentioned in ch32v30x_dbgmcu.c, may not work on all processors.
+#define INFO                                    ((INFO_TypeDef *)INFO_BASE) 
 #define EXTEN                                   ((EXTEN_TypeDef *)EXTEN_BASE)
 #define EXTEND                                  ((EXTEND_TypeDef *)EXTEN_BASE)  // Alias to EXTEN
 

--- a/examples_v30x/check_memory_split/Makefile
+++ b/examples_v30x/check_memory_split/Makefile
@@ -1,0 +1,12 @@
+all : flash
+
+TARGET:=check_memory_split
+TARGET_MCU:=CH32V307
+TARGET_MCU_PACKAGE:=CH32V307VCT6
+TARGET_MCU_MEMORY_SPLIT:=3
+
+include ../../ch32v003fun/ch32v003fun.mk
+
+flash : cv_flash
+clean : cv_clean
+

--- a/examples_v30x/check_memory_split/check_memory_split.c
+++ b/examples_v30x/check_memory_split/check_memory_split.c
@@ -1,0 +1,59 @@
+// Example testing memory option bytes on ch32v307
+/* 
+   WARNING Portions of this code are under the following copyright.
+*/
+/********************************** (C) COPYRIGHT  *******************************
+ * File Name          : ch32v00x_flash.c
+ * Author             : WCH
+ * Version            : V1.0.0
+ * Date               : 2022/08/08
+ * Description        : This file provides all the FLASH firmware functions.
+ *********************************************************************************
+ * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+ * Attention: This software (modified or not) and binary are used for 
+ * microcontroller manufactured by Nanjing Qinheng Microelectronics.
+ *******************************************************************************/
+
+#include "ch32v003fun.h"
+#include <stdio.h>
+
+uint32_t count;
+
+#ifdef TARGET_MCU_MEMORY_SPLIT
+#define BUILD_MEMORY_SPLIT TARGET_MCU_MEMORY_SPLIT
+#else
+#define BUILD_MEMORY_SPLIT -1
+#endif
+
+int main()
+{
+	SystemInit();
+
+	Delay_Ms( 100 );
+
+	printf("Chip ID: %08x\n", INFO->CHIPID );
+	printf("Device ID: %04x\n", INFO->DEVID );
+	printf("Revision ID: %04x\n", INFO->REVID );
+
+	printf("Option bytes in flash are: %04x\n", OB->USER );
+
+	printf("Current RAM split %d\n", (uint8_t)((FLASH->OBR >> 8) & 0x3));
+	printf("Flash RAM split %d\n", (uint8_t)((OB->USER >> 6) & 0x3));
+	printf("Build RAM split %d\n", BUILD_MEMORY_SPLIT);
+
+	// Now check the RAM capacity by sweeping a read and write back operation
+	// in 4k steps until we trigger a fault
+	printf("Testing RAM capacity:\n");
+
+	// volatile to prevent the no-op from being optimized out
+	volatile uint8_t *poke_addr = (void *) SRAM_BASE;
+
+	for (int i = 0; i <= 32; i++) {
+		uint32_t offset = 0x1000 * i;
+		printf("%3dk test: Poking SRAM+0x%05lx... ", i, offset);
+		poke_addr[offset] = poke_addr[offset];
+		printf("success!\n");
+	}
+
+	while(1);
+}

--- a/examples_v30x/check_memory_split/funconfig.h
+++ b/examples_v30x/check_memory_split/funconfig.h
@@ -1,0 +1,6 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+
+#endif
+

--- a/extralibs/ch32v307gigabit.h
+++ b/extralibs/ch32v307gigabit.h
@@ -422,7 +422,7 @@ void ETH_IRQHandler( void )
 		    if (int_sta & ETH_DMA_IT_RBU)
 		    {
 		        ETH->DMASR = ETH_DMA_IT_RBU;
-		        if((INFO->CHIP_ID & 0xf0) == 0x10)
+		        if((INFO->CHIPID & 0xf0) == 0x10)
 		        {
 		            ((ETH_DMADESCTypeDef *)(((ETH_DMADESCTypeDef *)(ETH->DMACHRDR))->Buffer2NextDescAddr))->Status = ETH_DMARxDesc_OWN;
 		            ETH->DMARPDR = 0;

--- a/extralibs/ch32v307gigabit.h
+++ b/extralibs/ch32v307gigabit.h
@@ -422,7 +422,7 @@ void ETH_IRQHandler( void )
 		    if (int_sta & ETH_DMA_IT_RBU)
 		    {
 		        ETH->DMASR = ETH_DMA_IT_RBU;
-		        if((CHIP_ID & 0xf0) == 0x10)
+		        if((INFO->CHIP_ID & 0xf0) == 0x10)
 		        {
 		            ((ETH_DMADESCTypeDef *)(((ETH_DMADESCTypeDef *)(ETH->DMACHRDR))->Buffer2NextDescAddr))->Status = ETH_DMARxDesc_OWN;
 		            ETH->DMARPDR = 0;

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -304,6 +304,44 @@ keep_going:
 				else
 					goto unimplemented;
 				break;
+			case 'S':  //Erase whole chip.
+			{	
+				if( !MCF.SetSplit )
+					goto unimplemented;
+				enum RAMSplit split = FLASH_DEFAULT;
+
+				iarg+=2;
+				if( iarg >= argc )
+				{
+					fprintf( stderr, "FLASH/RAM split requires two values: flash size and RAM size (in kb)\n" );
+					goto unimplemented;
+				}
+
+				uint32_t flash_size = SimpleReadNumberInt( argv[iarg-1], 0);
+				uint32_t sram_size = SimpleReadNumberInt( argv[iarg], 0 );
+				
+				if (flash_size == 192 && sram_size == 128) {
+					split = FLASH_192_RAM_128;
+				} else if (flash_size == 224 && sram_size == 96) {
+					split = FLASH_224_RAM_96;
+				} else if (flash_size == 256 && sram_size == 64) {
+					split = FLASH_256_RAM_64;
+				} else if (flash_size == 288 && sram_size == 32) {
+					split = FLASH_288_RAM_32;
+				}else if (flash_size == 128 && sram_size == 64) {
+					split = FLASH_128_RAM_64;
+				} else if (flash_size == 144 && sram_size == 48) {
+					split = FLASH_144_RAM_48;
+				} else if (flash_size == 160 && sram_size == 32) {
+					split = FLASH_160_RAM_32;
+				} else {
+					fprintf( stderr, "Unknown split: %dk FLASH / %dk RAM\n", flash_size, sram_size );
+					goto unimplemented;
+				}
+
+				MCF.SetSplit(dev, split);
+				break;
+			}
 			case 'G':
 			case 'T':
 			{
@@ -692,6 +730,7 @@ help:
 	fprintf( stderr, " -G Terminal + GDB (must be last arg)\n" );
 	fprintf( stderr, " -P Enable Read Protection\n" );
 	fprintf( stderr, " -p Disable Read Protection\n" );
+	fprintf( stderr, " -S set FLASH/SRAM split [FLASH kbytes] [SRAM kbytes]\n" );
 	fprintf( stderr, " -w [binary image to write] [address, decimal or 0x, try0x08000000]\n" );
 	fprintf( stderr, " -r [output binary image] [memory address, decimal or 0x, try 0x08000000] [size, decimal or 0x, try 16384]\n" );
 	fprintf( stderr, "   Note: for memory addresses, you can use 'flash' 'launcher' 'bootloader' 'option' 'ram' and say \"ram+0x10\" for instance\n" );

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -1605,6 +1605,198 @@ flashoperr:
 	return -93;
 }
 
+static int DefaultSetSplit(void * dev, enum RAMSplit split) {
+
+	uint8_t split_code = 0;
+	uint16_t option_bytes = 0;
+	uint32_t flash_ctlr = 0;
+	struct InternalState * iss = (struct InternalState*)(((struct ProgrammerStructBase*)dev)->internal);
+
+
+	// If the progammer already read the chip_id, use it
+	// Otherwise read it off the chip
+	uint32_t chip_id = iss->target_chip_id;
+	if (!chip_id) {
+		if( MCF.ReadWord( dev, (intptr_t)&INFO->CHIPID, &chip_id ) ) goto flashoperr;
+	}
+
+	uint32_t chip = chip_id & 0xFFFFFF0F;
+
+	/* List of ChipIDs
+	* Values taken from: ch32v307/EVT/EXAM/SRC/Peripheral/src/ch32v30x_dbgmcu.c:108
+	* CH32V303CBT6: 0x303305x4
+	* CH32V303RBT6: 0x303205x4
+	* CH32V303RCT6: 0x303105x4
+	* CH32V303VCT6: 0x303005x4
+	* CH32V305FBP6: 0x305205x8
+	* CH32V305RBT6: 0x305005x8
+	* CH32V305GBU6: 0x305B05x8
+	* CH32V307WCU6: 0x307305x8
+	* CH32V307FBP6: 0x307205x8
+	* CH32V307RCT6: 0x307105x8
+	* CH32V307VCT6: 0x307005x8
+	* CH32V317VCT6: 0x3170B5X8
+	* CH32V317WCU6: 0x3173B5X8
+	* CH32V317TCU6: 0x3175B5X8
+	*/
+
+	switch (split)
+	{
+		case FLASH_192_RAM_128:
+			if (chip == 0x30700508 
+			 || chip == 0x30710508 
+			 || chip == 0x30730508
+			 || chip == 0x30300504
+			 || chip == 0x30310504
+			 || chip == 0x30720508
+			 || chip == 0x30740508) {
+				split_code = 0;
+			} else {
+				fprintf( stderr, "Error, 192k/128k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+		
+		case FLASH_224_RAM_96:
+			if (chip == 0x30700508 
+			 || chip == 0x30710508 
+			 || chip == 0x30730508
+			 || chip == 0x30300504
+			 || chip == 0x30310504
+			 || chip == 0x30720508
+			 || chip == 0x30740508) {
+				split_code = 1;
+			} else {
+				fprintf( stderr, "Error, 224k/96k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+		
+		case FLASH_256_RAM_64:
+			if (chip == 0x30700508 
+			 || chip == 0x30710508 
+			 || chip == 0x30730508
+			 || chip == 0x30300504
+			 || chip == 0x30310504) {
+				split_code = 2;
+			} else {
+				fprintf( stderr, "Error, 256k/64k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		case FLASH_288_RAM_32:
+			if (chip == 0x30700508 
+			 || chip == 0x30710508 
+			 || chip == 0x30730508
+			 || chip == 0x30300504
+			 || chip == 0x30310504) {
+				split_code = 3;
+			} else {
+				fprintf( stderr, "Error, 288k/32k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		case FLASH_128_RAM_64:
+			if (chip == 0x2034050c
+			 || chip == 0x2080050c
+			 || chip == 0x2081050c
+			 || chip == 0x2082050c
+			 || chip == 0x2083050c) {
+				split_code = 0;
+			} else {
+				fprintf( stderr, "Error, 128k/64k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		case FLASH_144_RAM_48:
+			if (chip == 0x2034050c
+			 || chip == 0x2080050c
+			 || chip == 0x2081050c
+			 || chip == 0x2082050c
+			 || chip == 0x2083050c) {
+				split_code = 1;
+			} else {
+				fprintf( stderr, "Error, 144k/48k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		case FLASH_160_RAM_32:
+			if (chip == 0x2034050c
+			 || chip == 0x2080050c
+			 || chip == 0x2081050c
+			 || chip == 0x2082050c
+			 || chip == 0x2083050c) {
+				split_code = 2;
+			} else {
+				fprintf( stderr, "Error, 160k/32k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		default:
+			fprintf( stderr, "Error: chip 0x%08x does not support a configurable RAM split\n", chip);
+			return -110;
+			
+	}
+
+	if( !MCF.WriteHalfWord || !MCF.ReadHalfWord)
+	{
+		fprintf( stderr, "Error: for setting ram split option bytes, half-word read and write is required\n" );
+		return -5;
+	}
+
+	if( MCF.ReadHalfWord( dev, (intptr_t)&OB->USER, &option_bytes ) ) goto flashoperr;
+	printf("initial option_bytes = %04x\n", option_bytes);
+
+
+	// Option byte b is stored as 16 bits (~b << 8)|b
+	// Mask off upper copy and clear split bits
+	option_bytes &= 0x003F;
+	// Set split code at [7:6]
+	option_bytes |= split_code << 6;
+	// Add inverted copy back as high byte
+	option_bytes |= (~option_bytes) << 8;
+
+	InternalUnlockFlash(dev, iss);
+
+	if( MCF.ReadWord( dev, (intptr_t)&FLASH->CTLR, &flash_ctlr ) ) goto flashoperr;
+	flash_ctlr |= CR_OPTER_Set;
+	if( MCF.WriteWord( dev, (intptr_t)&FLASH->CTLR, flash_ctlr ) ) goto flashoperr;
+	flash_ctlr |= CR_STRT_Set;
+	if( MCF.WriteWord( dev, (intptr_t)&FLASH->CTLR, flash_ctlr ) ) goto flashoperr;
+	if( MCF.WaitForFlash(dev) ) goto flashoperr;
+
+	if( MCF.ReadWord( dev, (intptr_t)&FLASH->CTLR, &flash_ctlr ) ) goto flashoperr;
+	flash_ctlr &= CR_OPTER_Reset;
+	flash_ctlr |= CR_OPTPG_Set;
+	if( MCF.WriteWord( dev, (intptr_t)&FLASH->CTLR, flash_ctlr ) ) goto flashoperr;
+	if( MCF.WriteWord( dev, (intptr_t)&OB->RDPR, RDP_Key ) ) goto flashoperr;
+	if( MCF.WaitForFlash(dev) ) goto flashoperr;
+
+	if( MCF.WriteWord( dev, (intptr_t)&FLASH->OBKEYR, FLASH_KEY1 ) ) goto flashoperr;
+	if( MCF.WriteWord( dev, (intptr_t)&FLASH->OBKEYR, FLASH_KEY2 ) ) goto flashoperr;
+	if( MCF.WaitForFlash(dev) ) goto flashoperr;
+
+	if( MCF.ReadWord( dev, (intptr_t)&FLASH->CTLR, &flash_ctlr ) ) goto flashoperr;
+	flash_ctlr |= CR_OPTPG_Set;
+	if( MCF.WriteWord( dev, (intptr_t)&FLASH->CTLR, flash_ctlr ) ) goto flashoperr;
+	if( MCF.WriteHalfWord( dev, (intptr_t)&OB->USER, option_bytes ) ) goto flashoperr;
+	if( MCF.WaitForFlash(dev) ) goto flashoperr;
+
+	flash_ctlr &= CR_OPTPG_Reset;
+	if( MCF.WriteWord( dev, (intptr_t)&FLASH->CTLR, flash_ctlr ) ) goto flashoperr;
+	if( MCF.WaitForFlash(dev) ) goto flashoperr;
+
+	return 0;
+flashoperr:
+	fprintf( stderr, "Error: Flash operation error\n" );
+	return -93;
+}
+
 void PostSetupConfigureInterface( void * dev )
 {
 	struct InternalState * iss = (struct InternalState*)(((struct ProgrammerStructBase*)dev)->internal);
@@ -2062,6 +2254,8 @@ int SetupAutomaticHighLevelFunctions( void * dev )
 		MCF.Erase = DefaultErase;
 	if( !MCF.HaltMode )
 		MCF.HaltMode = DefaultHaltMode;
+	if( !MCF.SetSplit )
+		MCF.SetSplit = DefaultSetSplit;
 	if( !MCF.PollTerminal )
 		MCF.PollTerminal = DefaultPollTerminal;
 	if( !MCF.WaitForFlash )

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -304,7 +304,7 @@ keep_going:
 				else
 					goto unimplemented;
 				break;
-			case 'S':  //Erase whole chip.
+			case 'S':  // Set FLASH/RAM split in option bytes
 			{	
 				if( !MCF.SetSplit )
 					goto unimplemented;

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -147,7 +147,6 @@ struct InternalState
 	int flash_size;
 	enum RiscVChip target_chip_type;
 	uint32_t target_chip_id;
-	enum RAMSplit split;
 	uint8_t flash_sector_status[MAX_FLASH_SECTORS];  // 0 means unerased/unknown. 1 means erased.
 	int nr_registers_for_debug; // Updated by PostSetupConfigureInterface
 };

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+enum RAMSplit;
+
 struct MiniChlinkFunctions
 {
 	// All functions return 0 if OK, negative number if fault, positive number as status code.
@@ -24,6 +26,7 @@ struct MiniChlinkFunctions
 	int (*HaltMode)( void * dev, int mode ); //0 for halt, 1 for reset, 2 for resume
 	int (*ConfigureNRSTAsGPIO)( void * dev, int one_if_yes_gpio );
 	int (*ConfigureReadProtection)( void * dev, int one_if_yes_protect );
+	int (*SetSplit)( void * dev, enum RAMSplit split );
 
 	// No boundary or limit rules.  Must support any combination of alignment and size.
 	int (*WriteBinaryBlob)( void * dev, uint32_t address_to_write, uint32_t blob_size, uint8_t * blob );
@@ -115,6 +118,21 @@ enum RiscVChip {
 	CHIP_CH32X03x = 0x0d,
 };
 
+enum RAMSplit {
+	// For supported V30x and some V20x devices
+	FLASH_192_RAM_128 = 0x00,
+	FLASH_224_RAM_96  = 0x01,
+	FLASH_256_RAM_64  = 0x02,
+	FLASH_288_RAM_32  = 0x03,
+
+	// For some V20x devices
+	FLASH_128_RAM_64  = 0x10,
+	FLASH_144_RAM_48  = 0x11,
+	FLASH_160_RAM_32  = 0x12,
+
+	FLASH_DEFAULT = 0xFF,
+};
+
 struct InternalState
 {
 	uint32_t statetag;
@@ -128,6 +146,8 @@ struct InternalState
 	int sector_size;
 	int flash_size;
 	enum RiscVChip target_chip_type;
+	uint32_t target_chip_id;
+	enum RAMSplit split;
 	uint8_t flash_sector_status[MAX_FLASH_SECTORS];  // 0 means unerased/unknown. 1 means erased.
 	int nr_registers_for_debug; // Updated by PostSetupConfigureInterface
 };

--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -394,6 +394,7 @@ static int LESetupInterface( void * d )
 	printChipInfo(chip);
 
 	iss->target_chip_type = chip;
+	iss->target_chip_id = (rbuff[4] << 24) | (rbuff[5] << 16) | (rbuff[6] << 8) | rbuff[7];
 
 	// For some reason, if we don't do this sometimes the programmer starts in a hosey mode.
 	MCF.WriteReg32( d, DMCONTROL, 0x80000001 ); // Make the debug module work properly.
@@ -562,6 +563,12 @@ int LEExit( void * d )
 	return 0;
 }
 
+int LESetSplit(void * d, enum RAMSplit split) {
+	struct InternalState * iss = (struct InternalState*)(((struct ProgrammerStructBase*)d)->internal);
+	iss->split = split;
+	return 0;
+}
+
 void * TryInit_WCHLinkE()
 {
 	libusb_device_handle * wch_linke_devh;
@@ -583,6 +590,7 @@ void * TryInit_WCHLinkE()
 	MCF.Unbrick = LEUnbrick;
 	MCF.ConfigureNRSTAsGPIO = LEConfigureNRSTAsGPIO;
 	MCF.ConfigureReadProtection = LEConfigureReadProtection;
+	MCF.SetSplit = LESetSplit;
 
 	MCF.Exit = LEExit;
 	return ret;
@@ -761,6 +769,143 @@ static int LEReadBinaryBlob( void * d, uint32_t offset, uint32_t amount, uint8_t
 }
 #endif
 
+static void SetFlashRamSplit(libusb_device_handle * dev, enum RAMSplit split, uint32_t chip_id) {
+	uint8_t split_cmd[] = {0x81, 0x06, 0x08, 0x02, 0x3f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}; 
+
+
+	/* List of ChipIDs List
+	* Taken from: ch32v307/EVT/EXAM/SRC/Peripheral/src/ch32v30x_dbgmcu.c:108
+	* CH32V303CBT6: 0x303305x4
+	* CH32V303RBT6: 0x303205x4
+	* CH32V303RCT6: 0x303105x4
+	* CH32V303VCT6: 0x303005x4
+	* CH32V305FBP6: 0x305205x8
+	* CH32V305RBT6: 0x305005x8
+	* CH32V305GBU6: 0x305B05x8
+	* CH32V307WCU6: 0x307305x8
+	* CH32V307FBP6: 0x307205x8
+	* CH32V307RCT6: 0x307105x8
+	* CH32V307VCT6: 0x307005x8
+	* CH32V317VCT6: 0x3170B5X8
+	* CH32V317WCU6: 0x3173B5X8
+	* CH32V317TCU6: 0x3175B5X8
+	*/
+
+	uint32_t chip = chip_id & 0xFFFFFF0F;
+
+	switch (split)
+	{
+		case FLASH_192_RAM_128:
+			if (chip == 0x30700508 
+			 || chip == 0x30710508 
+			 || chip == 0x30730508
+			 || chip == 0x30300504
+			 || chip == 0x30310504
+			 || chip == 0x30720508
+			 || chip == 0x30740508) {
+				split_cmd[4] |= (0) << 6;
+				wch_link_command( (libusb_device_handle *)dev, split_cmd, 11, 0, 0, 0 );
+			} else {
+				fprintf( stderr, "Error, 192k/128k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+		
+		case FLASH_224_RAM_96:
+			if (chip == 0x30700508 
+			 || chip == 0x30710508 
+			 || chip == 0x30730508
+			 || chip == 0x30300504
+			 || chip == 0x30310504
+			 || chip == 0x30720508
+			 || chip == 0x30740508) {
+				split_cmd[4] |= (1) << 6;
+				wch_link_command( (libusb_device_handle *)dev, split_cmd, 11, 0, 0, 0 );
+			} else {
+				fprintf( stderr, "Error, 224k/96k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+		
+		case FLASH_256_RAM_64:
+			if (chip == 0x30700508 
+			 || chip == 0x30710508 
+			 || chip == 0x30730508
+			 || chip == 0x30300504
+			 || chip == 0x30310504) {
+				split_cmd[4] |= (2) << 6;
+				wch_link_command( (libusb_device_handle *)dev, split_cmd, 11, 0, 0, 0 );
+			} else {
+				fprintf( stderr, "Error, 256k/64k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		case FLASH_288_RAM_32:
+			if (chip == 0x30700508 
+			 || chip == 0x30710508 
+			 || chip == 0x30730508
+			 || chip == 0x30300504
+			 || chip == 0x30310504) {
+				split_cmd[4] |= (3) << 6;
+				wch_link_command( (libusb_device_handle *)dev, split_cmd, 11, 0, 0, 0 );
+			} else {
+				fprintf( stderr, "Error, 288k/32k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		case FLASH_128_RAM_64:
+			if (chip == 0x2034050c
+			 || chip == 0x2080050c
+			 || chip == 0x2081050c
+			 || chip == 0x2082050c
+			 || chip == 0x2083050c) {
+				split_cmd[4] |= (0) << 6;
+				wch_link_command( (libusb_device_handle *)dev, split_cmd, 11, 0, 0, 0 );
+			} else {
+				fprintf( stderr, "Error, 128k/64k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		case FLASH_144_RAM_48:
+			if (chip == 0x2034050c
+			 || chip == 0x2080050c
+			 || chip == 0x2081050c
+			 || chip == 0x2082050c
+			 || chip == 0x2083050c) {
+				split_cmd[4] |= (1) << 6;
+				wch_link_command( (libusb_device_handle *)dev, split_cmd, 11, 0, 0, 0 );
+			} else {
+				fprintf( stderr, "Error, 144k/48k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		case FLASH_160_RAM_32:
+			if (chip == 0x2034050c
+			 || chip == 0x2080050c
+			 || chip == 0x2081050c
+			 || chip == 0x2082050c
+			 || chip == 0x2083050c) {
+				split_cmd[4] |= (1) << 6;
+				wch_link_command( (libusb_device_handle *)dev, split_cmd, 11, 0, 0, 0 );
+			} else {
+				fprintf( stderr, "Error, 160k/32k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		default:
+			// Leave the Flash / SRAM split alone
+			(void) dev;
+			(void) split;
+			(void) chip;
+			(void) split_cmd;
+	}
+}
+
 static int LEWriteBinaryBlob( void * d, uint32_t address_to_write, uint32_t len, uint8_t * blob )
 {
 	libusb_device_handle * dev = ((struct LinkEProgrammerStruct*)d)->devh;
@@ -776,6 +921,10 @@ static int LEWriteBinaryBlob( void * d, uint32_t address_to_write, uint32_t len,
 	int padlen = ((len-1) & (~(iss->sector_size-1))) + iss->sector_size;
 
 	wch_link_command( (libusb_device_handle *)dev, "\x81\x06\x01\x01", 4, 0, 0, 0 );
+
+	// Set FLASH/SRAM split for supported V20x and V30x devices
+	SetFlashRamSplit(dev, iss->split, iss->target_chip_id);
+	
 	wch_link_command( (libusb_device_handle *)dev, "\x81\x06\x01\x01", 4, 0, 0, 0 ); // Not sure why but it seems to work better when we request twice.
 
 	// This contains the write data quantity, in bytes.  (The last 2 octets)


### PR DESCRIPTION
This adds support for changing the amount of SRAM available in parts where the flash / SRAM split is configurable. Right now, this only works for the wch-linke adapter. The split is given as a command line flag and applied during the bulk memory write. Without this, the CH32V307 is limited to 32k of SRAM of a possible 128k. Adding this setting addresses issues #232, #280, and (in part) #303.

As referenced in issues #232, #280, and #303, some of the CH32V20x and  CH32V30x parts have a user configurable option trading flash size for user RAM size. As described by the CH32V307 datasheet (pg 4):
> The products with 256K FLASH+64K SRAM support user select word to be configured as one of several
combinations of (192K FLASH+128K SRAM), (224K FLASH+96K SRAM), (256K FLASH+64K SRAM),
(288K FLASH+32K SRAM).

Speculation is that the chips cannot execute from flash and instead copy the entire contents of the firmware image to hidden internal SRAM. This flag would then be configuring the amount of that internal RAM used for code storage vs user RAM.

This information is stored in the user option section of flash. According to #232, the official programmer sets this via a special command, the same one used to set readout protection. This patch uses the command described there, however does sanity checks based on chip id and applies the setting only if appropriate for the target.

I suspect there is a more general solution to be had here. The flag can be set by firmware running on the chip. Updates require unlocking the flash, making the write, and then become active after a reset. One generic possibility would be to upload a code stub that sets the flag. Another would be to use the read word and write word functionality to set it.

Another drawback to this patch is the setting is only applied during the bulk memory write. This is fine for the common case of uploading code. One weirdness is that the new `-S [FLASH kB] [RAM kB]` flag needs to appear before the `-w` flag. Note that the current erase and program workflow clears this flag to the default (32k SRAM for the '307). I'm open to suggestions on how to improve that aspect.

I've tested this patch with my WCH [CH32V307V-EVT](https://www.lcsc.com/product-detail/Development-Boards-Kits_WCH-Jiangsu-Qin-Heng-CH32V307V-EVT-R1_C2943980.html) dev board and its integrated WCH programmer. My testing has been somewhat limited, but an application that allocates a 48k SRAM buffer and uses it seems to be working as expected. I don't currently have other hardware to test on.