### PR TITLE
Declare strchr before use

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -365,6 +365,14 @@ static char *twoway_strstr(const unsigned char *h, const unsigned char *n)
 	}
 }
 
+WEAK char *strchr(const char *s, int c)
+{
+	c = (unsigned char)c;
+	if (!c) return (char *)s + strlen(s);
+	for (; *s && *(unsigned char *)s != c; s++);
+	return (char *)s;
+}
+
 WEAK char *strstr(const char *h, const char *n)
 {
 	/* Return immediately on empty needle */
@@ -381,14 +389,6 @@ WEAK char *strstr(const char *h, const char *n)
 	if (!n[4]) return fourbyte_strstr((void *)h, (void *)n);
 
 	return twoway_strstr((void *)h, (void *)n);
-}
-
-WEAK char *strchr(const char *s, int c)
-{
-	c = (unsigned char)c;
-	if (!c) return (char *)s + strlen(s);
-	for (; *s && *(unsigned char *)s != c; s++);
-	return (char *)s;
 }
 
 


### PR DESCRIPTION
Fixes warnings:
```c
../../ch32v003fun/ch32v003fun.c: In function 'strstr':
../../ch32v003fun/ch32v003fun.c:374:13: warning: implicit declaration of function 'strchr' [-Wimplicit-function-declaration]
  374 |         h = strchr(h, *n);
      |             ^~~~~~
../../ch32v003fun/ch32v003fun.c:90:1: note: include '<string.h>' or provide a declaration of 'strchr'
   89 | #include <ch32v003fun.h>
  +++ |+#include <string.h>
   90 | 
../../ch32v003fun/ch32v003fun.c:374:13: warning: incompatible implicit declaration of built-in function 'strchr' [-Wbuiltin-declaration-mismatch]
  374 |         h = strchr(h, *n);
      |             ^~~~~~
../../ch32v003fun/ch32v003fun.c:374:13: note: include '<string.h>' or provide a declaration of 'strchr'
```