### PR TITLE
Update CI actions, build minichlink for MacOs ARM64 too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       dir: ${{ steps.set-dirs.outputs.dir }} # generate output name dir by using inner step output
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: set-dirs # Give it an id to handle to get step outputs in the outputs key above
         run: echo "::set-output name=dir::$(find examples* -name Makefile -print0 |xargs -0 -n 1 dirname | jq -R -s -c 'split("\n")[:-1]')"
         # Define step output named dir base on ls command transformed to JSON thanks to jq
@@ -21,7 +21,7 @@ jobs:
       matrix:
         example: ${{fromJson(needs.find-examples.outputs.dir)}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get install -y build-essential make libnewlib-dev gcc-riscv64-unknown-elf libusb-1.0-0-dev libudev-dev
     - name: Build ${{ matrix.example }}
@@ -34,14 +34,14 @@ jobs:
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cache/pip
           ~/.platformio/.cache
         key: ${{ runner.os }}-pio
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Install PlatformIO Core

--- a/.github/workflows/minichlink.yml
+++ b/.github/workflows/minichlink.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: [ubuntu-latest, macos-12]
+            os: [ubuntu-latest, macos-12, macos-14]
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Dependencies (Linux)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: sudo apt-get update && sudo apt-get install -y build-essential make libusb-1.0-0-dev libudev-dev mingw-w64-x86-64-dev gcc-mingw-w64-x86-64
@@ -37,25 +37,31 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: tar czf minichlink.tar.gz -C minichlink minichlink minichlink.so 99-minichlink.rules
     - name: "Pack (Mac)"
-      if: ${{ matrix.os == 'macos-12' }}
+      if: ${{ matrix.os == 'macos-12' || matrix.os == 'macos-14' }}
       run: tar czf minichlink.tar.gz -C minichlink minichlink
     # no packing needed for Windows as it's .exe only
 
     - name: "Upload minichlink (Linux)"
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: minichlink (Linux)
         path: minichlink.tar.gz
     - name: "Upload minichlink (MacOs 12)"
       if: ${{ matrix.os == 'macos-12' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: minichlink (MacOS 12)
         path: minichlink.tar.gz  
+    - name: "Upload minichlink (MacOs 14)"
+      if: ${{ matrix.os == 'macos-14' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: minichlink (MacOS 14 ARM64)
+        path: minichlink.tar.gz    
     - name: "Upload minichlink (Windows)"
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: minichlink (Windows)
         path: | 


### PR DESCRIPTION
Gets rid of all the warnings seen in e.g. https://github.com/cnlohr/ch32v003fun/actions/runs/10867336760 and adds a build for MacOs ARM64 too!