### PR TITLE
Add setjmp/longjmp support

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1321,6 +1321,18 @@ void handle_reset( void )
 
 #endif
 
+#if defined( __riscv_d )
+#define FLOAD( src, offset, dst ) \
+"	fld " #src ", " #offset "*8(" #dst ")\n"
+#define FSTORE( dst, offset, src ) \
+"	fsd " #dst ", " #offset "*8(" #src ")\n"
+#else
+#define FLOAD( src, offset, dst ) \
+"	flw " #src ", " #offset "*4(" #dst ")\n"
+#define FSTORE( dst, offset, src ) \
+"	fsw " #dst ", " #offset "*4(" #src ")\n"
+#endif
+
 __attribute__ ((naked)) int setjmp(jmp_buf env)
 {
 	asm volatile(
@@ -1331,7 +1343,7 @@ __attribute__ ((naked)) int setjmp(jmp_buf env)
 "	sw sp, 3*4(a0)\n"
 
     // RV32I only registers
-#if !defined( CH32V003 )
+#if !defined( __riscv_e )
 "	sw s2, 4*4(a0)\n"
 "	sw s3, 5*4(a0)\n"
 "	sw s4, 6*4(a0)\n"
@@ -1343,6 +1355,21 @@ __attribute__ ((naked)) int setjmp(jmp_buf env)
 "	sw s10, 12*4(a0)\n"
 "	sw s11, 13*4(a0)\n"
 #endif
+
+	// FPU registers
+#if defined( __riscv_f )
+	FSTORE(fs2, 14, a0)
+	FSTORE(fs3, 15, a0)
+	FSTORE(fs4, 16, a0)
+	FSTORE(fs5, 17, a0)
+	FSTORE(fs6, 18, a0)
+	FSTORE(fs7, 19, a0)
+	FSTORE(fs8, 20, a0)
+	FSTORE(fs9, 21, a0)
+	FSTORE(fs10, 22, a0)
+	FSTORE(fs11, 23, a0)
+#endif
+
 "	li a0, 0\n"
 "	ret\n"
 	);
@@ -1358,7 +1385,7 @@ __attribute__ ((naked)) void longjmp(jmp_buf env, int val)
 "	lw sp, 3*4(a0)\n"
 
     // RV32I only registers
-#if !defined( CH32V003 )
+#if !defined( __riscv_e )
 "	lw s2, 4*4(a0)\n"
 "	lw s3, 5*4(a0)\n"
 "	lw s4, 6*4(a0)\n"
@@ -1369,6 +1396,20 @@ __attribute__ ((naked)) void longjmp(jmp_buf env, int val)
 "	lw s9, 11*4(a0)\n"
 "	lw s10, 12*4(a0)\n"
 "	lw s11, 13*4(a0)\n"
+#endif
+
+	// FPU registers
+#if defined( __riscv_f )
+	FLOAD(fs2, 14, a0)
+	FLOAD(fs3, 15, a0)
+	FLOAD(fs4, 16, a0)
+	FLOAD(fs5, 17, a0)
+	FLOAD(fs6, 18, a0)
+	FLOAD(fs7, 19, a0)
+	FLOAD(fs8, 20, a0)
+	FLOAD(fs9, 21, a0)
+	FLOAD(fs10, 22, a0)
+	FLOAD(fs11, 23, a0)
 #endif
 
 "	seqz a0, a1\n" // a0 = (a1 == 0) ? 1 : 0

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1321,6 +1321,63 @@ void handle_reset( void )
 
 #endif
 
+int setjmp(jmp_buf env)
+{
+	asm volatile(
+	// Common registers
+"	sw ra, 0*4(a0)\n"
+"	sw s0, 1*4(a0)\n"
+"	sw s1, 2*4(a0)\n"
+"	sw sp, 3*4(a0)\n"
+
+    // RV32I only registers
+#if !defined( CH32V003 )
+"	sw s2, 4*4(a0)\n"
+"	sw s3, 5*4(a0)\n"
+"	sw s4, 6*4(a0)\n"
+"	sw s5, 7*4(a0)\n"
+"	sw s6, 8*4(a0)\n"
+"	sw s7, 9*4(a0)\n"
+"	sw s8, 10*4(a0)\n"
+"	sw s9, 11*4(a0)\n"
+"	sw s10, 12*4(a0)\n"
+"	sw s11, 13*4(a0)\n"
+#endif
+	);
+
+	return 0;
+}
+
+void longjmp(jmp_buf env, int val)
+{
+    asm volatile(
+    // Common registers
+"	lw ra, 0*4(a0)\n"
+"	lw s0, 1*4(a0)\n"
+"	lw s1, 2*4(a0)\n"
+"	lw sp, 3*4(a0)\n"
+
+    // RV32I only registers
+#if !defined( CH32V003 )
+"	lw s2, 4*4(a0)\n"
+"	lw s3, 5*4(a0)\n"
+"	lw s4, 6*4(a0)\n"
+"	lw s5, 7*4(a0)\n"
+"	lw s6, 8*4(a0)\n"
+"	lw s7, 9*4(a0)\n"
+"	lw s8, 10*4(a0)\n"
+"	lw s9, 11*4(a0)\n"
+"	lw s10, 12*4(a0)\n"
+"	lw s11, 13*4(a0)\n"
+#endif
+
+"	seqz a0, a1\n" // a0 = (a1 == 0) ? 1 : 0
+"	add a0, a0, a1\n"
+"	ret\n"
+	);
+	__builtin_unreachable(); // Disable warning about no return.
+}
+
 #if defined( FUNCONF_USE_UARTPRINTF ) && FUNCONF_USE_UARTPRINTF
 void SetupUART( int uartBRR )
 {

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1321,7 +1321,7 @@ void handle_reset( void )
 
 #endif
 
-int setjmp(jmp_buf env)
+__attribute__ ((naked)) int setjmp(jmp_buf env)
 {
 	asm volatile(
 	// Common registers
@@ -1343,12 +1343,12 @@ int setjmp(jmp_buf env)
 "	sw s10, 12*4(a0)\n"
 "	sw s11, 13*4(a0)\n"
 #endif
+"	li a0, 0\n"
+"	ret\n"
 	);
-
-	return 0;
 }
 
-void longjmp(jmp_buf env, int val)
+__attribute__ ((naked)) void longjmp(jmp_buf env, int val)
 {
     asm volatile(
     // Common registers

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -13794,7 +13794,29 @@ void SystemInit(void);
 // Put an output debug UART on Pin D5.
 // You can write to this with printf(...) or puts(...)
 
-#include <setjmp.h>
+#ifdef __riscv
+// _JBTYPE using long long to make sure the alignment is align to 8 byte,
+// otherwise in rv32imafd, store/restore FPR may mis-align.
+#define _JBTYPE long long
+#ifdef __riscv_e
+#define _JBLEN ((4*sizeof(long))/sizeof(long))
+#elif defined(__riscv_d)
+#define _JBLEN ((14*sizeof(long) + 12*sizeof(double))/sizeof(long))
+#elif defined(__riscv_f)
+#define _JBLEN ((14*sizeof(long) + 12*sizeof(float))/sizeof(long))
+#else
+#define _JBLEN ((14*sizeof(long))/sizeof(long))
+#endif
+#endif
+
+#ifdef _JBLEN
+#ifdef _JBTYPE
+typedef _JBTYPE jmp_buf[_JBLEN];
+#else
+typedef int jmp_buf[_JBLEN];
+#endif
+#endif
+
 int setjmp(jmp_buf env);
 void longjmp(jmp_buf env, int val);
 

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -13798,11 +13798,11 @@ void SystemInit(void);
 // _JBTYPE using long long to make sure the alignment is align to 8 byte,
 // otherwise in rv32imafd, store/restore FPR may mis-align.
 #define _JBTYPE long long
-#ifdef __riscv_e
+#if defined( __riscv_abi_rve )
 #define _JBLEN ((4*sizeof(long))/sizeof(long))
-#elif defined(__riscv_d)
+#elif defined( __riscv_float_abi_double )
 #define _JBLEN ((14*sizeof(long) + 12*sizeof(double))/sizeof(long))
-#elif defined(__riscv_f)
+#elif defined( __riscv_float_abi_single )
 #define _JBLEN ((14*sizeof(long) + 12*sizeof(float))/sizeof(long))
 #else
 #define _JBLEN ((14*sizeof(long))/sizeof(long))
@@ -13817,8 +13817,8 @@ typedef int jmp_buf[_JBLEN];
 #endif
 #endif
 
-int setjmp(jmp_buf env);
-void longjmp(jmp_buf env, int val);
+int setjmp( jmp_buf env );
+void longjmp( jmp_buf env, int val );
 
 void SetupUART( int uartBRR );
 

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -13523,6 +13523,32 @@ static inline uint32_t __get_SP(void)
 
 #endif
 
+#if defined(__riscv) || defined(__riscv__) || defined( CH32V003FUN_BASE )
+// _JBTYPE using long long to make sure the alignment is align to 8 byte,
+// otherwise in rv32imafd, store/restore FPR may mis-align.
+#define _JBTYPE long long
+#if defined( __riscv_abi_rve )
+#define _JBLEN ((4*sizeof(long))/sizeof(long))
+#elif defined( __riscv_float_abi_double )
+#define _JBLEN ((14*sizeof(long) + 12*sizeof(double))/sizeof(long))
+#elif defined( __riscv_float_abi_single )
+#define _JBLEN ((14*sizeof(long) + 12*sizeof(float))/sizeof(long))
+#else
+#define _JBLEN ((14*sizeof(long))/sizeof(long))
+#endif
+
+#ifdef _JBLEN
+#ifdef _JBTYPE
+typedef _JBTYPE jmp_buf[_JBLEN];
+#else
+typedef int jmp_buf[_JBLEN];
+#endif // _JBTYPE
+#endif // _JBLEN
+
+int setjmp( jmp_buf env );
+void longjmp( jmp_buf env, int val );
+#endif // defined(__riscv) || defined(__riscv__) || defined( CH32V003FUN_BASE )
+
 #ifdef __cplusplus
 }
 #endif
@@ -13793,32 +13819,6 @@ void SystemInit(void);
 #define UART_BRR (((FUNCONF_SYSTEM_CORE_CLOCK) + (UART_BAUD_RATE)/2) / (UART_BAUD_RATE))
 // Put an output debug UART on Pin D5.
 // You can write to this with printf(...) or puts(...)
-
-#ifdef __riscv
-// _JBTYPE using long long to make sure the alignment is align to 8 byte,
-// otherwise in rv32imafd, store/restore FPR may mis-align.
-#define _JBTYPE long long
-#if defined( __riscv_abi_rve )
-#define _JBLEN ((4*sizeof(long))/sizeof(long))
-#elif defined( __riscv_float_abi_double )
-#define _JBLEN ((14*sizeof(long) + 12*sizeof(double))/sizeof(long))
-#elif defined( __riscv_float_abi_single )
-#define _JBLEN ((14*sizeof(long) + 12*sizeof(float))/sizeof(long))
-#else
-#define _JBLEN ((14*sizeof(long))/sizeof(long))
-#endif
-#endif
-
-#ifdef _JBLEN
-#ifdef _JBTYPE
-typedef _JBTYPE jmp_buf[_JBLEN];
-#else
-typedef int jmp_buf[_JBLEN];
-#endif
-#endif
-
-int setjmp( jmp_buf env );
-void longjmp( jmp_buf env, int val );
 
 void SetupUART( int uartBRR );
 

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -13794,6 +13794,10 @@ void SystemInit(void);
 // Put an output debug UART on Pin D5.
 // You can write to this with printf(...) or puts(...)
 
+#include <setjmp.h>
+int setjmp(jmp_buf env);
+void longjmp(jmp_buf env, int val);
+
 void SetupUART( int uartBRR );
 
 void WaitForDebuggerToAttach();


### PR DESCRIPTION
`setjmp/longjmp` implementation for `rv32e` and `rv32ima`.
The standard `setjmp.h` that came with my toolchain defines `jmp_buf` with enough room for floating point registers as well. I did not add those registers because, as far as I can tell, support for floating point units is in the very early stages in the build tools.

I'm open to advice on how we could avoid including `setjmp.h` in `ch32v003fun.h`. That would allow us to define `jmp_buf` to not contain the space required for the floating point regs (saves 12*8 bytes of data).