### PR TITLE
Fix detection of projects to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-dirs # Give it an id to handle to get step outputs in the outputs key above
-        run: echo "::set-output name=dir::$(find examples* -name Makefile -print0 |xargs -0 -n 1 dirname | jq -R -s -c 'split("\n")[:-1]')"
+        run: echo "::set-output name=dir::$(find examples* -maxdepth 2 -name Makefile -print0 |xargs -0 -n 1 dirname | jq -R -s -c 'split("\n")[:-1]')"
         # Define step output named dir base on ls command transformed to JSON thanks to jq
   # Build using native Makefile buildsystem
   makefile-build:


### PR DESCRIPTION
Drive by fix

Restricts search of folders with `Makefile` file in them to only 2 folders deep as seen from the root, so `examples/blink/Makefile` is fine but ont `examples/blink/nested_util/Makefile`