### PR TITLE
Fix USB bootloader programmer

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -673,9 +673,10 @@ keep_going:
 					if ( offset == 0x1ffff000 ) MCF.HaltMode( dev, HALT_MODE_HALT_BUT_NO_RESET ); // do not reset if writing bootloader, even if it is considered flash memory
 					else MCF.HaltMode( dev, HALT_MODE_HALT_AND_RESET );
 				}
-
+				
 				if( MCF.WriteBinaryBlob )
 				{
+				        printf("Writing image\n");
 					if( MCF.WriteBinaryBlob( dev, offset, len, image ) )
 					{
 						fprintf( stderr, "Error: Fault writing image.\n" );
@@ -687,7 +688,7 @@ keep_going:
 					goto unimplemented;
 				}
 
-				printf( "Image written.\n" );
+				printf( "\nImage written.\n" );
 
 				free( image );
 				break;


### PR DESCRIPTION
``if( is_flash && memcmp( &eps->commandbuffer[60], blob, 1 ) ) goto verifyfail;`` I believe this should compare with respbuffer, otherwise it makes no sense.

``usleep(1000);`` before writing feature report so bootloader can process previous commands and minichlink doesn't throw error about retrying.

``if (eps->no_get_report) return r;`` so we don't wait to get feature report that will never come because bootloader finished working and usb connection throws ``ioctl (GFEATURE): No such device`` errors at us until timeout.