### PR TITLE
Fix InterruptVectorDefault() for CH32V10x, CH32V20x and CH32V30x

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -843,6 +843,8 @@ void TIM2_IRQHandler( void )             __attribute__((section(".text.vector_ha
 #if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 void TIM3_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM4_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFSWakeUp_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 #endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 void I2C1_EV_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void I2C1_ER_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1132,54 +1132,54 @@ void InterruptVectorDefault()
 
 #if defined(CH32V10x)
 "	.word   SysTick_Handler            /* SysTick Handler */ \n \
-    	.word   0 \n \
-        .word   SW_Handler                 /* SW Handler */ \n \
-    	.word   0 \n \
-    	/* External Interrupts */ \n \
-        .word   WWDG_IRQHandler            /* Window Watchdog */ \n \
-        .word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
-        .word   TAMPER_IRQHandler          /* TAMPER */ \n \
-        .word   RTC_IRQHandler             /* RTC */ \n \
-        .word   FLASH_IRQHandler           /* Flash */ \n \
-        .word   RCC_IRQHandler             /* RCC */ \n \
-        .word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
-        .word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
-        .word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
-        .word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
-        .word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
-        .word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
-        .word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
-        .word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
-        .word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
-        .word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
-        .word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
-        .word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
-        .word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
-        .word   0 \n \
-        .word   0 \n \
-        .word   0 \n \
-        .word   0 \n \
-        .word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
-        .word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
-        .word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
-        .word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
-        .word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
-        .word   TIM2_IRQHandler            /* TIM2 */ \n \
-        .word   TIM3_IRQHandler            /* TIM3 */ \n \
-        .word   TIM4_IRQHandler            /* TIM4 */ \n \
-        .word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
-        .word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
-        .word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
-        .word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
-        .word   SPI1_IRQHandler            /* SPI1 */ \n \
-        .word   SPI2_IRQHandler            /* SPI2 */ \n \
-        .word   USART1_IRQHandler          /* USART1 */ \n \
-        .word   USART2_IRQHandler          /* USART2 */ \n \
-        .word   USART3_IRQHandler          /* USART3 */ \n \
-        .word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
-        .word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
-        .word   USBFSWakeup_IRQHandler     /* USB Wakeup from suspend */ \n \
-        .word   USBFS_IRQHandler           /* USBFS */ \n "
+	.word   0 \n \
+	.word   SW_Handler                 /* SW Handler */ \n \
+	.word   0 \n \
+	/* External Interrupts */ \n \
+	.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
+	.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
+	.word   TAMPER_IRQHandler          /* TAMPER */ \n \
+	.word   RTC_IRQHandler             /* RTC */ \n \
+	.word   FLASH_IRQHandler           /* Flash */ \n \
+	.word   RCC_IRQHandler             /* RCC */ \n \
+	.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
+	.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
+	.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
+	.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
+	.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
+	.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
+	.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
+	.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
+	.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
+	.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
+	.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
+	.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
+	.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
+	.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
+	.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
+	.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
+	.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
+	.word   TIM2_IRQHandler            /* TIM2 */ \n \
+	.word   TIM3_IRQHandler            /* TIM3 */ \n \
+	.word   TIM4_IRQHandler            /* TIM4 */ \n \
+	.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
+	.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
+	.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
+	.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
+	.word   SPI1_IRQHandler            /* SPI1 */ \n \
+	.word   SPI2_IRQHandler            /* SPI2 */ \n \
+	.word   USART1_IRQHandler          /* USART1 */ \n \
+	.word   USART2_IRQHandler          /* USART2 */ \n \
+	.word   USART3_IRQHandler          /* USART3 */ \n \
+	.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
+	.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
+	.word   USBFSWakeup_IRQHandler     /* USB Wakeup from suspend */ \n \
+	.word   USBFS_IRQHandler           /* USBFS */ \n "
 	//defined(CH32V10x)
 #elif defined(CH32V20x)
 "	.word   SysTick_Handler            /* SysTick */ \n \

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -826,6 +826,9 @@ void ADC1_IRQHandler( void )             __attribute__((section(".text.vector_ha
 #elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 void ADC1_2_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 #endif
+#if defined(CH32V10x)
+void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+#endif
 #if defined(CH32V20x) || defined(CH32V30x)
 void USB_HP_CAN1_TX_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USB_LP_CAN1_RX0_IRQHandler( void )  __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -843,8 +846,6 @@ void TIM2_IRQHandler( void )             __attribute__((section(".text.vector_ha
 #if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 void TIM3_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM4_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBFSWakeUp_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 #endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 void I2C1_EV_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void I2C1_ER_IRQHandler( void )          __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -895,7 +896,7 @@ void DMA2_Channel3_IRQHandler( void ) 	__attribute__((section(".text.vector_hand
 void DMA2_Channel4_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA2_Channel5_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void OTG_FS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBFSWakeUp_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DVP_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART6_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -1229,7 +1230,7 @@ void InterruptVectorDefault()
 		.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
 		.word   USBWakeUp_IRQHandler       /* USB Wake up from suspend */ \n \
 		.word   USBFS_IRQHandler           /* USBFS Break */ \n \
-		.word   USBFSWakeUp_IRQHandler     /* USBFS Wake up from suspend */ \n "
+		.word   USBFSWakeup_IRQHandler     /* USBFS Wake up from suspend */ \n "
 	#if defined(CH32V20x_D6) //CH32V20x variants
 	"	.word   UART4_IRQHandler           /* UART4 */ \n \
     	.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */ \n"

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -865,9 +865,6 @@ void EXTI15_10_IRQHandler( void ) 		 __attribute__((section(".text.vector_handle
 void RTCAlarm_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USBWakeUp_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 #endif
-#if defined(CH32V10x) || defined(CH32V20x)
-void USBFS_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-#endif // defined(CH32V10x) || defined(CH32V20x)
 #if defined(CH32V20x) || defined(CH32V30x)
 void USBFSWakeUp_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void ETH_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -899,7 +896,6 @@ void DMA2_Channel5_IRQHandler( void ) 	__attribute__((section(".text.vector_hand
 void OTG_FS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USBHSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USBHS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DVP_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART6_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART7_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -866,10 +866,10 @@ void RTCAlarm_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler
 void USBWakeUp_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 #endif
 #if defined(CH32V10x) || defined(CH32V20x)
-void USBHD_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFS_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 #endif // defined(CH32V10x) || defined(CH32V20x)
 #if defined(CH32V20x) || defined(CH32V30x)
-void USBHDWakeUp_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFSWakeUp_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void ETH_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void ETHWakeUp_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void OSC32KCal_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -899,6 +899,7 @@ void DMA2_Channel5_IRQHandler( void ) 	__attribute__((section(".text.vector_hand
 void OTG_FS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USBHSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USBHS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DVP_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART6_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART7_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -828,7 +828,7 @@ void ADC1_2_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"
 #endif
 #if defined(CH32V10x)
 void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBFSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFSWakeUp_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 #endif
 #if defined(CH32V20x) || defined(CH32V30x)
 void USB_HP_CAN1_TX_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -894,8 +894,9 @@ void DMA2_Channel3_IRQHandler( void ) 	__attribute__((section(".text.vector_hand
 void DMA2_Channel4_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA2_Channel5_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void OTG_FS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBHSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBHSWakeUp_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USBHS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DVP_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART6_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART7_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -1175,7 +1176,7 @@ void InterruptVectorDefault()
 	.word   USART3_IRQHandler          /* USART3 */ \n \
 	.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
 	.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
-	.word   USBFSWakeup_IRQHandler     /* USB Wakeup from suspend */ \n \
+	.word   USBFSWakeUp_IRQHandler     /* USB Wakeup from suspend */ \n \
 	.word   USBFS_IRQHandler           /* USBFS */ \n "
 	//defined(CH32V10x)
 #elif defined(CH32V20x)
@@ -1228,7 +1229,7 @@ void InterruptVectorDefault()
 	.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
 	.word   USBWakeUp_IRQHandler       /* USB Wake up from suspend */ \n \
 	.word   USBFS_IRQHandler           /* USBFS Break */ \n \
-	.word   USBFSWakeup_IRQHandler     /* USBFS Wake up from suspend */ \n "
+	.word   USBFSWakeUp_IRQHandler     /* USBFS Wake up from suspend */ \n "
 #if defined(CH32V20x_D6) //CH32V20x variants
 "	.word   UART4_IRQHandler           /* UART4 */ \n \
 	.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */ \n"
@@ -1424,7 +1425,7 @@ void InterruptVectorDefault()
 	.word   CAN2_RX1_IRQHandler        /* CAN2 RX1 */ \n \
 	.word   CAN2_SCE_IRQHandler        /* CAN2 SCE */ \n \
 	.word   USBFS_IRQHandler           /* USBFS */ \n \
-	.word   USBHSWakeup_IRQHandler     /* USBHS Wakeup */ \n \
+	.word   USBHSWakeUp_IRQHandler     /* USBHS Wakeup */ \n \
 	.word   USBHS_IRQHandler           /* USBHS */ \n \
 	.word   DVP_IRQHandler             /* DVP */ \n \
 	.word   UART6_IRQHandler           /* UART6 */ \n \

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -828,6 +828,7 @@ void ADC1_2_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"
 #endif
 #if defined(CH32V10x)
 void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 #endif
 #if defined(CH32V20x) || defined(CH32V30x)
 void USB_HP_CAN1_TX_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -897,8 +897,8 @@ void DMA2_Channel3_IRQHandler( void ) 	__attribute__((section(".text.vector_hand
 void DMA2_Channel4_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA2_Channel5_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void OTG_FS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBFSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBHSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBHS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DVP_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART6_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART7_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -1234,7 +1234,7 @@ void InterruptVectorDefault()
 	.word   USBFSWakeup_IRQHandler     /* USBFS Wake up from suspend */ \n "
 #if defined(CH32V20x_D6) //CH32V20x variants
 "	.word   UART4_IRQHandler           /* UART4 */ \n \
-    	.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */ \n"
+	.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */ \n"
 #elif defined(CH32V20x_D8)
 "	.word   ETH_IRQHandler             /* ETH global */  \n\
 	.word   ETHWakeUp_IRQHandler       /* ETH Wake up */  \n\
@@ -1427,8 +1427,8 @@ void InterruptVectorDefault()
 	.word   CAN2_RX1_IRQHandler        /* CAN2 RX1 */ \n \
 	.word   CAN2_SCE_IRQHandler        /* CAN2 SCE */ \n \
 	.word   USBFS_IRQHandler           /* USBFS */ \n \
-	.word   USBFSWakeup_IRQHandler     /* USBHS Wakeup */ \n \
-	.word   USBFS_IRQHandler           /* USBHS */ \n \
+	.word   USBHSWakeup_IRQHandler     /* USBHS Wakeup */ \n \
+	.word   USBHS_IRQHandler           /* USBHS */ \n \
 	.word   DVP_IRQHandler             /* DVP */ \n \
 	.word   UART6_IRQHandler           /* UART6 */ \n \
 	.word   UART7_IRQHandler           /* UART7 */ \n \

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -871,6 +871,8 @@ void ETHWakeUp_IRQHandler( void ) 		 __attribute__((section(".text.vector_handle
 void OSC32KCal_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void OSCWakeUp_IRQHandler( void ) 		 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA1_Channel8_IRQHandler( void ) 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void BB_IRQHandler( void ) 			 	 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void LLE_IRQHandler( void ) 			 __attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 // This appears to be masked to USBHD
 void TIM8_BRK_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM8_UP_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -891,8 +893,8 @@ void DMA2_Channel3_IRQHandler( void ) 	__attribute__((section(".text.vector_hand
 void DMA2_Channel4_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA2_Channel5_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void OTG_FS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBHSWakeup_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
-void USBHS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFSWakeUp_IRQHandler( void )		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBFS_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DVP_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART6_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void UART7_IRQHandler( void ) 			__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -911,6 +913,10 @@ void DMA2_Channel8_IRQHandler( void ) 	__attribute__((section(".text.vector_hand
 void DMA2_Channel9_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA2_Channel10_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void DMA2_Channel11_IRQHandler( void ) 	__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void CAN2_TX_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void CAN2_RX0_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void CAN2_RX1_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void CAN2_SCE_IRQHandler( void ) 		__attribute__((section(".text.vector_handler"))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 #endif
 
 #if defined( CH32X03x)
@@ -1119,121 +1125,329 @@ void InterruptVectorDefault()
 	.word   0 \n\
 	.word   0 \n"
 #endif
-"	.word   SysTick_Handler            /* SysTick = 12 */ \n\
-	.word   0 \n\
-	.word   SW_Handler                 /* SW = 14 */ \n\
-	.word   0 \n\
-	/* External Interrupts */ \n\
-	.word   WWDG_IRQHandler            /* 16: Window Watchdog */ \n\
-	.word   PVD_IRQHandler             /* 17: PVD through EXTI Line detect */ \n\
-	.word   TAMPER_IRQHandler          /* 18: TAMPER */ \n\
-	.word   RTC_IRQHandler             /* 19: RTC */ \n\
-	.word   FLASH_IRQHandler           /* 20: Flash */ \n\
-	.word   RCC_IRQHandler             /* 21: RCC */ \n\
-	.word   EXTI0_IRQHandler           /* 22: EXTI Line 0 */ \n\
-	.word   EXTI1_IRQHandler           /* 23: EXTI Line 1 */ \n\
-	.word   EXTI2_IRQHandler           /* 24: EXTI Line 2 */ \n\
-	.word   EXTI3_IRQHandler           /* 25: EXTI Line 3 */ \n\
-	.word   EXTI4_IRQHandler           /* 26: EXTI Line 4 */ \n\
-	.word   DMA1_Channel1_IRQHandler   /* 27: DMA1 Channel 1 */ \n\
-	.word   DMA1_Channel2_IRQHandler   /* 28: DMA1 Channel 2 */ \n\
-	.word   DMA1_Channel3_IRQHandler   /* 29: DMA1 Channel 3 */ \n\
-	.word   DMA1_Channel4_IRQHandler   /* 30: DMA1 Channel 4 */ \n\
-	.word   DMA1_Channel5_IRQHandler   /* 31: DMA1 Channel 5 */ \n\
-	.word   DMA1_Channel6_IRQHandler   /* 32: DMA1 Channel 6 */ \n\
-	.word   DMA1_Channel7_IRQHandler   /* 33: DMA1 Channel 7 */ \n\
-	.word   ADC1_2_IRQHandler          /* 34: ADC1_2 */ \n"
-#if defined(CH32V20x) || defined(CH32V30x)
-"	.word   USB_HP_CAN1_TX_IRQHandler  /* 35: USB HP and CAN1 TX */ \n\
-	.word   USB_LP_CAN1_RX0_IRQHandler /* 36: USB LP and CAN1RX0 */ \n\
-	.word   CAN1_RX1_IRQHandler        /* 37: CAN1 RX1 */ \n\
-	.word   CAN1_SCE_IRQHandler        /* 38: CAN1 SCE */ \n"
-#else
-"	.word   0 \n\
-	.word   0 \n\
-	.word   0 \n\
-	.word   0 \n"
-#endif
-"	.word   EXTI9_5_IRQHandler         /* 39: EXTI Line 9..5 */ \n\
-	.word   TIM1_BRK_IRQHandler        /* 40: TIM1 Break */ \n\
-	.word   TIM1_UP_IRQHandler         /* 41: TIM1 Update */ \n\
-	.word   TIM1_TRG_COM_IRQHandler    /* 42: TIM1 Trigger and Commutation */ \n\
-	.word   TIM1_CC_IRQHandler         /* 43: TIM1 Capture Compare */ \n\
-	.word   TIM2_IRQHandler            /* 44: TIM2 */ \n\
-	.word   TIM3_IRQHandler            /* 45: TIM3 */ \n\
-	.word   TIM4_IRQHandler            /* 46: TIM4 */ \n\
-	.word   I2C1_EV_IRQHandler         /* 47: I2C1 Event */ \n\
-	.word   I2C1_ER_IRQHandler         /* 48: I2C1 Error */ \n\
-	.word   I2C2_EV_IRQHandler         /* 49: I2C2 Event */ \n\
-	.word   I2C2_ER_IRQHandler         /* 50: I2C2 Error */ \n\
-	.word   SPI1_IRQHandler            /* 51: SPI1 */ \n\
-	.word   SPI2_IRQHandler            /* 52: SPI2 */ \n\
-	.word   USART1_IRQHandler          /* 53: USART1 */ \n\
-	.word   USART2_IRQHandler          /* 54: USART2 */ \n\
-	.word   USART3_IRQHandler          /* 55: USART3 */ \n\
-	.word   EXTI15_10_IRQHandler       /* 56: EXTI Line 15..10 */ \n\
-	.word   RTCAlarm_IRQHandler        /* 57: RTC Alarm through EXTI Line */ \n"
-#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
-"	.word   USBWakeUp_IRQHandler       /* 58: USB Wake up from suspend */ \n"
-#if defined(CH32V20x) || defined(CH32V30x)
 
-#if defined(CH32V30x)
-"   .word   TIM8_BRK_IRQHandler        /* 59: TIM8 Break == masked to USBHD? */ \n"
+#if defined(CH32V10x)
+"		.word   SysTick_Handler            /* SysTick Handler */ \n \
+    	.word   0 \n \
+        .word   SW_Handler                 /* SW Handler */ \n \
+    	.word   0 \n \
+    			/* External Interrupts */ \n \
+        .word   WWDG_IRQHandler            /* Window Watchdog */ \n \
+        .word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
+        .word   TAMPER_IRQHandler          /* TAMPER */ \n \
+        .word   RTC_IRQHandler             /* RTC */ \n \
+        .word   FLASH_IRQHandler           /* Flash */ \n \
+        .word   RCC_IRQHandler             /* RCC */ \n \
+        .word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
+        .word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
+        .word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
+        .word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
+        .word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
+        .word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
+        .word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
+        .word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
+        .word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
+        .word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
+        .word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
+        .word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
+        .word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
+        .word   0 \n \
+        .word   0 \n \
+        .word   0 \n \
+        .word   0 \n \
+        .word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
+        .word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
+        .word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
+        .word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
+        .word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
+        .word   TIM2_IRQHandler            /* TIM2 */ \n \
+        .word   TIM3_IRQHandler            /* TIM3 */ \n \
+        .word   TIM4_IRQHandler            /* TIM4 */ \n \
+        .word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
+        .word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
+        .word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
+        .word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
+        .word   SPI1_IRQHandler            /* SPI1 */ \n \
+        .word   SPI2_IRQHandler            /* SPI2 */ \n \
+        .word   USART1_IRQHandler          /* USART1 */ \n \
+        .word   USART2_IRQHandler          /* USART2 */ \n \
+        .word   USART3_IRQHandler          /* USART3 */ \n \
+        .word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
+        .word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
+        .word   USBFSWakeup_IRQHandler     /* USB Wakeup from suspend */ \n \
+        .word   USBFS_IRQHandler           /* USBFS */ \n "
+		//defined(CH32V10x)
+#elif defined(CH32V20x)
+"		.word   SysTick_Handler            /* SysTick */ \n \
+		.word   0 \n \
+		.word   SW_Handler                 /* SW */ \n \
+		.word   0 \n \
+		/* External Interrupts */ \n \
+		.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
+		.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
+		.word   TAMPER_IRQHandler          /* TAMPER */ \n \
+		.word   RTC_IRQHandler             /* RTC */ \n \
+		.word   FLASH_IRQHandler           /* Flash */ \n \
+		.word   RCC_IRQHandler             /* RCC */ \n \
+		.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
+		.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
+		.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
+		.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
+		.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
+		.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
+		.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
+		.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
+		.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
+		.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
+		.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
+		.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
+		.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
+		.word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */ \n \
+		.word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */ \n \
+		.word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */ \n \
+		.word   CAN1_SCE_IRQHandler        /* CAN1 SCE */ \n \
+		.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
+		.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
+		.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
+		.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
+		.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
+		.word   TIM2_IRQHandler            /* TIM2 */ \n \
+		.word   TIM3_IRQHandler            /* TIM3 */ \n \
+		.word   TIM4_IRQHandler            /* TIM4 */ \n \
+		.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
+		.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
+		.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
+		.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
+		.word   SPI1_IRQHandler            /* SPI1 */ \n \
+		.word   SPI2_IRQHandler            /* SPI2 */ \n \
+		.word   USART1_IRQHandler          /* USART1 */ \n \
+		.word   USART2_IRQHandler          /* USART2 */ \n \
+		.word   USART3_IRQHandler          /* USART3 */ \n \
+		.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
+		.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
+		.word   USBWakeUp_IRQHandler       /* USB Wake up from suspend */ \n \
+		.word   USBFS_IRQHandler           /* USBFS Break */ \n \
+		.word   USBFSWakeUp_IRQHandler     /* USBFS Wake up from suspend */ \n "
+	#if defined(CH32V20x_D6) //CH32V20x variants
+	"	.word   UART4_IRQHandler           /* UART4 */ \n \
+    	.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */ \n"
+	#elif defined(CH32V20x_D8)
+	"	.word   ETH_IRQHandler             /* ETH global */  \n\
+		.word   ETHWakeUp_IRQHandler       /* ETH Wake up */  \n\
+		.word	0 \n\
+		.word	0 \n\
+		.word   TIM5_IRQHandler            /* TIM5 */  \n\
+		.word   UART4_IRQHandler           /* UART4 */  \n\
+		.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */  \n\
+		.word   OSC32KCal_IRQHandler       /* OSC32KCal */  \n\
+		.word   OSCWakeUp_IRQHandler       /* OSC Wake Up */ \n"
+	#elif defined(CH32V20x_D8W)
+	"	.word   ETH_IRQHandler             /* ETH global */  \n\
+		.word   ETHWakeUp_IRQHandler       /* ETH Wake up */  \n\
+		.word   BB_IRQHandler              /* BLE BB */  \n\
+		.word   LLE_IRQHandler             /* BLE LLE */  \n\
+		.word   TIM5_IRQHandler            /* TIM5 */  \n\
+		.word   UART4_IRQHandler           /* UART4 */  \n\
+		.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */  \n\
+		.word   OSC32KCal_IRQHandler       /* OSC32KCal */  \n\
+		.word   OSCWakeUp_IRQHandler       /* OSC Wake Up */ \n "
+	#endif //CH32V20x variants
+//defined(CH32V20x)
+#elif defined(CH32V30x)
+	#if defined(CH32V30x_D8)
+	"	.word   SysTick_Handler            /* SysTick */ \n \
+		.word   0 \n \
+		.word   SW_Handler                 /* SW */ \n \
+		.word   0 \n \
+		/* External Interrupts */ \n \
+		.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
+		.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
+		.word   TAMPER_IRQHandler          /* TAMPER */ \n \
+		.word   RTC_IRQHandler             /* RTC */ \n \
+		.word   FLASH_IRQHandler           /* Flash */ \n \
+		.word   RCC_IRQHandler             /* RCC */ \n \
+		.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
+		.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
+		.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
+		.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
+		.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
+		.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
+		.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
+		.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
+		.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
+		.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
+		.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
+		.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
+		.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
+		.word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */ \n \
+		.word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */ \n \
+		.word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */ \n \
+		.word   CAN1_SCE_IRQHandler        /* CAN1 SCE */ \n \
+		.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
+		.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
+		.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
+		.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
+		.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
+		.word   TIM2_IRQHandler            /* TIM2 */ \n \
+		.word   TIM3_IRQHandler            /* TIM3 */ \n \
+		.word   TIM4_IRQHandler            /* TIM4 */ \n \
+		.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
+		.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
+		.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
+		.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
+		.word   SPI1_IRQHandler            /* SPI1 */ \n \
+		.word   SPI2_IRQHandler            /* SPI2 */ \n \
+		.word   USART1_IRQHandler          /* USART1 */ \n \
+		.word   USART2_IRQHandler          /* USART2 */ \n \
+		.word   USART3_IRQHandler          /* USART3 */ \n \
+		.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
+		.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
+		.word   0 \n \
+		.word   TIM8_BRK_IRQHandler        /* TIM8 Break */ \n \
+		.word   TIM8_UP_IRQHandler         /* TIM8 Update */ \n \
+		.word   TIM8_TRG_COM_IRQHandler    /* TIM8 Trigger and Commutation */ \n \
+		.word   TIM8_CC_IRQHandler         /* TIM8 Capture Compare */ \n \
+		.word   RNG_IRQHandler             /* RNG */ \n \
+		.word   0 \n \
+		.word   SDIO_IRQHandler            /* SDIO */ \n \
+		.word   TIM5_IRQHandler            /* TIM5 */ \n \
+		.word   SPI3_IRQHandler            /* SPI3 */ \n \
+		.word   UART4_IRQHandler           /* UART4 */ \n \
+		.word   UART5_IRQHandler           /* UART5 */ \n \
+		.word   TIM6_IRQHandler            /* TIM6 */ \n \
+		.word   TIM7_IRQHandler            /* TIM7 */ \n \
+		.word   DMA2_Channel1_IRQHandler   /* DMA2 Channel 1 */ \n \
+		.word   DMA2_Channel2_IRQHandler   /* DMA2 Channel 2 */ \n \
+		.word   DMA2_Channel3_IRQHandler   /* DMA2 Channel 3 */ \n \
+		.word   DMA2_Channel4_IRQHandler   /* DMA2 Channel 4 */ \n \
+		.word   DMA2_Channel5_IRQHandler   /* DMA2 Channel 5 */ \n \
+		.word   0 \n \
+		.word   0 \n \
+		.word   0 \n \
+		.word   0 \n \
+		.word   0 \n \
+		.word   0 \n \
+		.word   USBFS_IRQHandler          /* USBFS */ \n \
+		.word   0 \n \
+		.word   0 \n \
+		.word   0 \n \
+		.word   UART6_IRQHandler           /* UART6 */ \n \
+		.word   UART7_IRQHandler           /* UART7 */ \n \
+		.word   UART8_IRQHandler           /* UART8 */ \n \
+		.word   TIM9_BRK_IRQHandler        /* TIM9 Break */ \n \
+		.word   TIM9_UP_IRQHandler         /* TIM9 Update */ \n \
+		.word   TIM9_TRG_COM_IRQHandler    /* TIM9 Trigger and Commutation */ \n \
+		.word   TIM9_CC_IRQHandler         /* TIM9 Capture Compare */ \n \
+		.word   TIM10_BRK_IRQHandler       /* TIM10 Break */ \n \
+		.word   TIM10_UP_IRQHandler        /* TIM10 Update */ \n \
+		.word   TIM10_TRG_COM_IRQHandler   /* TIM10 Trigger and Commutation */ \n \
+		.word   TIM10_CC_IRQHandler        /* TIM10 Capture Compare */ \n \
+		.word   DMA2_Channel6_IRQHandler   /* DMA2 Channel 6 */ \n \
+		.word   DMA2_Channel7_IRQHandler   /* DMA2 Channel 7 */ \n \
+		.word   DMA2_Channel8_IRQHandler   /* DMA2 Channel 8 */ \n \
+		.word   DMA2_Channel9_IRQHandler   /* DMA2 Channel 9 */ \n \
+		.word   DMA2_Channel10_IRQHandler  /* DMA2 Channel 10 */ \n \
+		.word   DMA2_Channel11_IRQHandler  /* DMA2 Channel 11 */ \n "
+		//defined(CH32V30x_D8)
+	#elif defined(CH32V30x_D8C)
+	"	.word   SysTick_Handler            /* SysTick */ \n \
+		.word   0 \n \
+		.word   SW_Handler                 /* SW */ \n \
+		.word   0 \n \
+		/* External Interrupts */ \n \
+		.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
+		.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
+		.word   TAMPER_IRQHandler          /* TAMPER */ \n \
+		.word   RTC_IRQHandler             /* RTC */ \n \
+		.word   FLASH_IRQHandler           /* Flash */ \n \
+		.word   RCC_IRQHandler             /* RCC */ \n \
+		.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
+		.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
+		.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
+		.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
+		.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
+		.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
+		.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
+		.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
+		.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
+		.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
+		.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
+		.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
+		.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
+		.word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */ \n \
+		.word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */ \n \
+		.word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */ \n \
+		.word   CAN1_SCE_IRQHandler        /* CAN1 SCE */ \n \
+		.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
+		.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
+		.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
+		.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
+		.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
+		.word   TIM2_IRQHandler            /* TIM2 */ \n \
+		.word   TIM3_IRQHandler            /* TIM3 */ \n \
+		.word   TIM4_IRQHandler            /* TIM4 */ \n \
+		.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
+		.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
+		.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
+		.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
+		.word   SPI1_IRQHandler            /* SPI1 */ \n \
+		.word   SPI2_IRQHandler            /* SPI2 */ \n \
+		.word   USART1_IRQHandler          /* USART1 */ \n \
+		.word   USART2_IRQHandler          /* USART2 */ \n \
+		.word   USART3_IRQHandler          /* USART3 */ \n \
+		.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
+		.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
+		.word   USBWakeUp_IRQHandler       /* USB Wakeup from suspend */ \n \
+		.word   TIM8_BRK_IRQHandler        /* TIM8 Break */ \n \
+		.word   TIM8_UP_IRQHandler         /* TIM8 Update */ \n \
+		.word   TIM8_TRG_COM_IRQHandler    /* TIM8 Trigger and Commutation */ \n \
+		.word   TIM8_CC_IRQHandler         /* TIM8 Capture Compare */ \n \
+		.word   RNG_IRQHandler             /* RNG */ \n \
+		.word   0 \n \
+		.word   SDIO_IRQHandler            /* SDIO */ \n \
+		.word   TIM5_IRQHandler            /* TIM5 */ \n \
+		.word   SPI3_IRQHandler            /* SPI3 */ \n \
+		.word   UART4_IRQHandler           /* UART4 */ \n \
+		.word   UART5_IRQHandler           /* UART5 */ \n \
+		.word   TIM6_IRQHandler            /* TIM6 */ \n \
+		.word   TIM7_IRQHandler            /* TIM7 */ \n \
+		.word   DMA2_Channel1_IRQHandler   /* DMA2 Channel 1 */ \n \
+		.word   DMA2_Channel2_IRQHandler   /* DMA2 Channel 2 */ \n \
+		.word   DMA2_Channel3_IRQHandler   /* DMA2 Channel 3 */ \n \
+		.word   DMA2_Channel4_IRQHandler   /* DMA2 Channel 4 */ \n \
+		.word   DMA2_Channel5_IRQHandler   /* DMA2 Channel 5 */ \n \
+		.word   ETH_IRQHandler             /* ETH */ \n \
+		.word   ETHWakeUp_IRQHandler       /* ETH WakeUp */ \n \
+		.word   CAN2_TX_IRQHandler         /* CAN2 TX */ \n \
+		.word   CAN2_RX0_IRQHandler        /* CAN2 RX0 */ \n \
+		.word   CAN2_RX1_IRQHandler        /* CAN2 RX1 */ \n \
+		.word   CAN2_SCE_IRQHandler        /* CAN2 SCE */ \n \
+		.word   USBFS_IRQHandler           /* USBFS */ \n \
+		.word   USBFSWakeup_IRQHandler     /* USBHS Wakeup */ \n \
+		.word   USBFS_IRQHandler           /* USBHS */ \n \
+		.word   DVP_IRQHandler             /* DVP */ \n \
+		.word   UART6_IRQHandler           /* UART6 */ \n \
+		.word   UART7_IRQHandler           /* UART7 */ \n \
+		.word   UART8_IRQHandler           /* UART8 */ \n \
+		.word   TIM9_BRK_IRQHandler        /* TIM9 Break */ \n \
+		.word   TIM9_UP_IRQHandler         /* TIM9 Update */ \n \
+		.word   TIM9_TRG_COM_IRQHandler    /* TIM9 Trigger and Commutation */ \n \
+		.word   TIM9_CC_IRQHandler         /* TIM9 Capture Compare */ \n \
+		.word   TIM10_BRK_IRQHandler       /* TIM10 Break */ \n \
+		.word   TIM10_UP_IRQHandler        /* TIM10 Update */ \n \
+		.word   TIM10_TRG_COM_IRQHandler   /* TIM10 Trigger and Commutation */ \n \
+		.word   TIM10_CC_IRQHandler        /* TIM10 Capture Compare */ \n \
+		.word   DMA2_Channel6_IRQHandler   /* DMA2 Channel 6 */ \n \
+		.word   DMA2_Channel7_IRQHandler   /* DMA2 Channel 7 */ \n \
+		.word   DMA2_Channel8_IRQHandler   /* DMA2 Channel 8 */ \n \
+		.word   DMA2_Channel9_IRQHandler   /* DMA2 Channel 9 */ \n \
+		.word   DMA2_Channel10_IRQHandler  /* DMA2 Channel 10 */ \n \
+		.word   DMA2_Channel11_IRQHandler  /* DMA2 Channel 11 */ \n "
+	//defined(CH32V30x_D8C)
+	#endif
 #else
-"	.word   USBHD_IRQHandler           /* 59: USBHD Break */ \n"
-#endif
-"   .word   TIM8_UP_IRQHandler         /* 60: TIM8 Update */ \n\
-    .word   TIM8_TRG_COM_IRQHandler    /* 61: TIM8 Trigger and Commutation */ \n\
-    .word   TIM8_CC_IRQHandler         /* 62: TIM8 Capture Compare */ \n\
-    .word   RNG_IRQHandler             /* 63: RNG */ \n\
-    .word   FSMC_IRQHandler            /* 64: FSMC */ \n\
-    .word   SDIO_IRQHandler            /* 65: SDIO */ \n\
-    .word   TIM5_IRQHandler            /* 66: TIM5 */ \n\
-    .word   SPI3_IRQHandler            /* 67: SPI3 */ \n\
-    .word   UART4_IRQHandler           /* 68: UART4 */ \n\
-    .word   UART5_IRQHandler           /* 59: UART5 */ \n\
-    .word   TIM6_IRQHandler            /* 70: TIM6 */ \n\
-    .word   TIM7_IRQHandler            /* 71: TIM7 */ \n\
-    .word   DMA2_Channel1_IRQHandler   /* 72: DMA2 Channel 1 */ \n\
-    .word   DMA2_Channel2_IRQHandler   /* 73: DMA2 Channel 2 */ \n\
-    .word   DMA2_Channel3_IRQHandler   /* 74: DMA2 Channel 3 */ \n\
-    .word   DMA2_Channel4_IRQHandler   /* 75: DMA2 Channel 4 */ \n\
-    .word   DMA2_Channel5_IRQHandler   /* 76: DMA2 Channel 5 */ \n\
-	.word   ETH_IRQHandler             /* 77: ETH global */ \n\
-	.word   ETHWakeUp_IRQHandler       /* 78: ETH Wake up */ \n\
-    .word   0                          /* 79: CAN2_TX */ \n\
-    .word   0                          /* 80: CAN2_RX0 */ \n\
-    .word   0                          /* 81: CAN2_RX1 */ \n\
-    .word   0                          /* 82: CAN2_SCE */ \n\
-    .word   OTG_FS_IRQHandler          /* 83: OTGFS */ \n"
-#if defined(CH32V30x)
-"   .word   USBHSWakeup_IRQHandler     /* 84: USBHsWakeUp */ \n\
-    .word   USBHS_IRQHandler           /* 85: USBHS */ \n\
-    .word   DVP_IRQHandler             /* 86: DVP */ \n"
-#else
-"   .word   0                          /* 84: USBHsWakeUp */ \n\
-    .word   0                          /* 85: USBHS */ \n\
-    .word   0                          /* 86: DVP */ \n"
-#endif
-"   .word   UART6_IRQHandler           /* 87: UART6 */ \n\
-    .word   UART7_IRQHandler           /* 88: UART7 */ \n\
-    .word   UART8_IRQHandler           /* 89: UART8 */ \n\
-    .word   TIM9_BRK_IRQHandler        /* 90: TIM9 Break */ \n\
-    .word   TIM9_UP_IRQHandler         /* 91: TIM9 Update */ \n\
-    .word   TIM9_TRG_COM_IRQHandler    /* 92: TIM9 Trigger and Commutation */ \n\
-    .word   TIM9_CC_IRQHandler         /* 93: TIM9 Capture Compare */ \n\
-    .word   TIM10_BRK_IRQHandler       /* 94: TIM10 Break */ \n\
-    .word   TIM10_UP_IRQHandler        /* 95: TIM10 Update */ \n\
-    .word   TIM10_TRG_COM_IRQHandler   /* 96: TIM10 Trigger and Commutation */ \n\
-    .word   TIM10_CC_IRQHandler        /* 97: TIM10 Capture Compare */ \n\
-    .word   DMA2_Channel6_IRQHandler   /* 98: DMA2 Channel 6 */ \n\
-    .word   DMA2_Channel7_IRQHandler   /* 99: DMA2 Channel 7 */ \n\
-    .word   DMA2_Channel8_IRQHandler   /* 100: DMA2 Channel 8 */ \n\
-    .word   DMA2_Channel9_IRQHandler   /* 101: DMA2 Channel 9 */ \n\
-    .word   DMA2_Channel10_IRQHandler  /* 102: DMA2 Channel 10 */ \n\
-    .word   DMA2_Channel11_IRQHandler  /* 103: DMA2 Channel 11 */ \n"
-#endif
-#endif
+#error Unknown MCU family!
+#endif 
 
 #endif // !defined(FUNCONF_TINYVECTOR) || !FUNCONF_TINYVECTOR
 "	.option rvc; \n");

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1131,11 +1131,11 @@ void InterruptVectorDefault()
 #endif
 
 #if defined(CH32V10x)
-"		.word   SysTick_Handler            /* SysTick Handler */ \n \
+"	.word   SysTick_Handler            /* SysTick Handler */ \n \
     	.word   0 \n \
         .word   SW_Handler                 /* SW Handler */ \n \
     	.word   0 \n \
-    			/* External Interrupts */ \n \
+    	/* External Interrupts */ \n \
         .word   WWDG_IRQHandler            /* Window Watchdog */ \n \
         .word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
         .word   TAMPER_IRQHandler          /* TAMPER */ \n \
@@ -1180,275 +1180,275 @@ void InterruptVectorDefault()
         .word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
         .word   USBFSWakeup_IRQHandler     /* USB Wakeup from suspend */ \n \
         .word   USBFS_IRQHandler           /* USBFS */ \n "
-		//defined(CH32V10x)
+	//defined(CH32V10x)
 #elif defined(CH32V20x)
-"		.word   SysTick_Handler            /* SysTick */ \n \
-		.word   0 \n \
-		.word   SW_Handler                 /* SW */ \n \
-		.word   0 \n \
-		/* External Interrupts */ \n \
-		.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
-		.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
-		.word   TAMPER_IRQHandler          /* TAMPER */ \n \
-		.word   RTC_IRQHandler             /* RTC */ \n \
-		.word   FLASH_IRQHandler           /* Flash */ \n \
-		.word   RCC_IRQHandler             /* RCC */ \n \
-		.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
-		.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
-		.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
-		.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
-		.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
-		.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
-		.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
-		.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
-		.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
-		.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
-		.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
-		.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
-		.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
-		.word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */ \n \
-		.word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */ \n \
-		.word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */ \n \
-		.word   CAN1_SCE_IRQHandler        /* CAN1 SCE */ \n \
-		.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
-		.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
-		.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
-		.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
-		.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
-		.word   TIM2_IRQHandler            /* TIM2 */ \n \
-		.word   TIM3_IRQHandler            /* TIM3 */ \n \
-		.word   TIM4_IRQHandler            /* TIM4 */ \n \
-		.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
-		.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
-		.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
-		.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
-		.word   SPI1_IRQHandler            /* SPI1 */ \n \
-		.word   SPI2_IRQHandler            /* SPI2 */ \n \
-		.word   USART1_IRQHandler          /* USART1 */ \n \
-		.word   USART2_IRQHandler          /* USART2 */ \n \
-		.word   USART3_IRQHandler          /* USART3 */ \n \
-		.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
-		.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
-		.word   USBWakeUp_IRQHandler       /* USB Wake up from suspend */ \n \
-		.word   USBFS_IRQHandler           /* USBFS Break */ \n \
-		.word   USBFSWakeup_IRQHandler     /* USBFS Wake up from suspend */ \n "
-	#if defined(CH32V20x_D6) //CH32V20x variants
-	"	.word   UART4_IRQHandler           /* UART4 */ \n \
+"	.word   SysTick_Handler            /* SysTick */ \n \
+	.word   0 \n \
+	.word   SW_Handler                 /* SW */ \n \
+	.word   0 \n \
+	/* External Interrupts */ \n \
+	.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
+	.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
+	.word   TAMPER_IRQHandler          /* TAMPER */ \n \
+	.word   RTC_IRQHandler             /* RTC */ \n \
+	.word   FLASH_IRQHandler           /* Flash */ \n \
+	.word   RCC_IRQHandler             /* RCC */ \n \
+	.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
+	.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
+	.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
+	.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
+	.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
+	.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
+	.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
+	.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
+	.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
+	.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
+	.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
+	.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
+	.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
+	.word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */ \n \
+	.word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */ \n \
+	.word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */ \n \
+	.word   CAN1_SCE_IRQHandler        /* CAN1 SCE */ \n \
+	.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
+	.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
+	.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
+	.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
+	.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
+	.word   TIM2_IRQHandler            /* TIM2 */ \n \
+	.word   TIM3_IRQHandler            /* TIM3 */ \n \
+	.word   TIM4_IRQHandler            /* TIM4 */ \n \
+	.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
+	.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
+	.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
+	.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
+	.word   SPI1_IRQHandler            /* SPI1 */ \n \
+	.word   SPI2_IRQHandler            /* SPI2 */ \n \
+	.word   USART1_IRQHandler          /* USART1 */ \n \
+	.word   USART2_IRQHandler          /* USART2 */ \n \
+	.word   USART3_IRQHandler          /* USART3 */ \n \
+	.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
+	.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
+	.word   USBWakeUp_IRQHandler       /* USB Wake up from suspend */ \n \
+	.word   USBFS_IRQHandler           /* USBFS Break */ \n \
+	.word   USBFSWakeup_IRQHandler     /* USBFS Wake up from suspend */ \n "
+#if defined(CH32V20x_D6) //CH32V20x variants
+"	.word   UART4_IRQHandler           /* UART4 */ \n \
     	.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */ \n"
-	#elif defined(CH32V20x_D8)
-	"	.word   ETH_IRQHandler             /* ETH global */  \n\
-		.word   ETHWakeUp_IRQHandler       /* ETH Wake up */  \n\
-		.word	0 \n\
-		.word	0 \n\
-		.word   TIM5_IRQHandler            /* TIM5 */  \n\
-		.word   UART4_IRQHandler           /* UART4 */  \n\
-		.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */  \n\
-		.word   OSC32KCal_IRQHandler       /* OSC32KCal */  \n\
-		.word   OSCWakeUp_IRQHandler       /* OSC Wake Up */ \n"
-	#elif defined(CH32V20x_D8W)
-	"	.word   ETH_IRQHandler             /* ETH global */  \n\
-		.word   ETHWakeUp_IRQHandler       /* ETH Wake up */  \n\
-		.word   BB_IRQHandler              /* BLE BB */  \n\
-		.word   LLE_IRQHandler             /* BLE LLE */  \n\
-		.word   TIM5_IRQHandler            /* TIM5 */  \n\
-		.word   UART4_IRQHandler           /* UART4 */  \n\
-		.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */  \n\
-		.word   OSC32KCal_IRQHandler       /* OSC32KCal */  \n\
-		.word   OSCWakeUp_IRQHandler       /* OSC Wake Up */ \n "
-	#endif //CH32V20x variants
+#elif defined(CH32V20x_D8)
+"	.word   ETH_IRQHandler             /* ETH global */  \n\
+	.word   ETHWakeUp_IRQHandler       /* ETH Wake up */  \n\
+	.word	0 \n\
+	.word	0 \n\
+	.word   TIM5_IRQHandler            /* TIM5 */  \n\
+	.word   UART4_IRQHandler           /* UART4 */  \n\
+	.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */  \n\
+	.word   OSC32KCal_IRQHandler       /* OSC32KCal */  \n\
+	.word   OSCWakeUp_IRQHandler       /* OSC Wake Up */ \n"
+#elif defined(CH32V20x_D8W)
+"	.word   ETH_IRQHandler             /* ETH global */  \n\
+	.word   ETHWakeUp_IRQHandler       /* ETH Wake up */  \n\
+	.word   BB_IRQHandler              /* BLE BB */  \n\
+	.word   LLE_IRQHandler             /* BLE LLE */  \n\
+	.word   TIM5_IRQHandler            /* TIM5 */  \n\
+	.word   UART4_IRQHandler           /* UART4 */  \n\
+	.word   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */  \n\
+	.word   OSC32KCal_IRQHandler       /* OSC32KCal */  \n\
+	.word   OSCWakeUp_IRQHandler       /* OSC Wake Up */ \n "
+#endif //CH32V20x variants
 //defined(CH32V20x)
 #elif defined(CH32V30x)
-	#if defined(CH32V30x_D8)
-	"	.word   SysTick_Handler            /* SysTick */ \n \
-		.word   0 \n \
-		.word   SW_Handler                 /* SW */ \n \
-		.word   0 \n \
-		/* External Interrupts */ \n \
-		.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
-		.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
-		.word   TAMPER_IRQHandler          /* TAMPER */ \n \
-		.word   RTC_IRQHandler             /* RTC */ \n \
-		.word   FLASH_IRQHandler           /* Flash */ \n \
-		.word   RCC_IRQHandler             /* RCC */ \n \
-		.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
-		.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
-		.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
-		.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
-		.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
-		.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
-		.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
-		.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
-		.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
-		.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
-		.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
-		.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
-		.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
-		.word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */ \n \
-		.word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */ \n \
-		.word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */ \n \
-		.word   CAN1_SCE_IRQHandler        /* CAN1 SCE */ \n \
-		.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
-		.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
-		.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
-		.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
-		.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
-		.word   TIM2_IRQHandler            /* TIM2 */ \n \
-		.word   TIM3_IRQHandler            /* TIM3 */ \n \
-		.word   TIM4_IRQHandler            /* TIM4 */ \n \
-		.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
-		.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
-		.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
-		.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
-		.word   SPI1_IRQHandler            /* SPI1 */ \n \
-		.word   SPI2_IRQHandler            /* SPI2 */ \n \
-		.word   USART1_IRQHandler          /* USART1 */ \n \
-		.word   USART2_IRQHandler          /* USART2 */ \n \
-		.word   USART3_IRQHandler          /* USART3 */ \n \
-		.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
-		.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
-		.word   0 \n \
-		.word   TIM8_BRK_IRQHandler        /* TIM8 Break */ \n \
-		.word   TIM8_UP_IRQHandler         /* TIM8 Update */ \n \
-		.word   TIM8_TRG_COM_IRQHandler    /* TIM8 Trigger and Commutation */ \n \
-		.word   TIM8_CC_IRQHandler         /* TIM8 Capture Compare */ \n \
-		.word   RNG_IRQHandler             /* RNG */ \n \
-		.word   0 \n \
-		.word   SDIO_IRQHandler            /* SDIO */ \n \
-		.word   TIM5_IRQHandler            /* TIM5 */ \n \
-		.word   SPI3_IRQHandler            /* SPI3 */ \n \
-		.word   UART4_IRQHandler           /* UART4 */ \n \
-		.word   UART5_IRQHandler           /* UART5 */ \n \
-		.word   TIM6_IRQHandler            /* TIM6 */ \n \
-		.word   TIM7_IRQHandler            /* TIM7 */ \n \
-		.word   DMA2_Channel1_IRQHandler   /* DMA2 Channel 1 */ \n \
-		.word   DMA2_Channel2_IRQHandler   /* DMA2 Channel 2 */ \n \
-		.word   DMA2_Channel3_IRQHandler   /* DMA2 Channel 3 */ \n \
-		.word   DMA2_Channel4_IRQHandler   /* DMA2 Channel 4 */ \n \
-		.word   DMA2_Channel5_IRQHandler   /* DMA2 Channel 5 */ \n \
-		.word   0 \n \
-		.word   0 \n \
-		.word   0 \n \
-		.word   0 \n \
-		.word   0 \n \
-		.word   0 \n \
-		.word   USBFS_IRQHandler          /* USBFS */ \n \
-		.word   0 \n \
-		.word   0 \n \
-		.word   0 \n \
-		.word   UART6_IRQHandler           /* UART6 */ \n \
-		.word   UART7_IRQHandler           /* UART7 */ \n \
-		.word   UART8_IRQHandler           /* UART8 */ \n \
-		.word   TIM9_BRK_IRQHandler        /* TIM9 Break */ \n \
-		.word   TIM9_UP_IRQHandler         /* TIM9 Update */ \n \
-		.word   TIM9_TRG_COM_IRQHandler    /* TIM9 Trigger and Commutation */ \n \
-		.word   TIM9_CC_IRQHandler         /* TIM9 Capture Compare */ \n \
-		.word   TIM10_BRK_IRQHandler       /* TIM10 Break */ \n \
-		.word   TIM10_UP_IRQHandler        /* TIM10 Update */ \n \
-		.word   TIM10_TRG_COM_IRQHandler   /* TIM10 Trigger and Commutation */ \n \
-		.word   TIM10_CC_IRQHandler        /* TIM10 Capture Compare */ \n \
-		.word   DMA2_Channel6_IRQHandler   /* DMA2 Channel 6 */ \n \
-		.word   DMA2_Channel7_IRQHandler   /* DMA2 Channel 7 */ \n \
-		.word   DMA2_Channel8_IRQHandler   /* DMA2 Channel 8 */ \n \
-		.word   DMA2_Channel9_IRQHandler   /* DMA2 Channel 9 */ \n \
-		.word   DMA2_Channel10_IRQHandler  /* DMA2 Channel 10 */ \n \
-		.word   DMA2_Channel11_IRQHandler  /* DMA2 Channel 11 */ \n "
-		//defined(CH32V30x_D8)
-	#elif defined(CH32V30x_D8C)
-	"	.word   SysTick_Handler            /* SysTick */ \n \
-		.word   0 \n \
-		.word   SW_Handler                 /* SW */ \n \
-		.word   0 \n \
-		/* External Interrupts */ \n \
-		.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
-		.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
-		.word   TAMPER_IRQHandler          /* TAMPER */ \n \
-		.word   RTC_IRQHandler             /* RTC */ \n \
-		.word   FLASH_IRQHandler           /* Flash */ \n \
-		.word   RCC_IRQHandler             /* RCC */ \n \
-		.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
-		.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
-		.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
-		.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
-		.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
-		.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
-		.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
-		.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
-		.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
-		.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
-		.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
-		.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
-		.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
-		.word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */ \n \
-		.word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */ \n \
-		.word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */ \n \
-		.word   CAN1_SCE_IRQHandler        /* CAN1 SCE */ \n \
-		.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
-		.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
-		.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
-		.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
-		.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
-		.word   TIM2_IRQHandler            /* TIM2 */ \n \
-		.word   TIM3_IRQHandler            /* TIM3 */ \n \
-		.word   TIM4_IRQHandler            /* TIM4 */ \n \
-		.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
-		.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
-		.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
-		.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
-		.word   SPI1_IRQHandler            /* SPI1 */ \n \
-		.word   SPI2_IRQHandler            /* SPI2 */ \n \
-		.word   USART1_IRQHandler          /* USART1 */ \n \
-		.word   USART2_IRQHandler          /* USART2 */ \n \
-		.word   USART3_IRQHandler          /* USART3 */ \n \
-		.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
-		.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
-		.word   USBWakeUp_IRQHandler       /* USB Wakeup from suspend */ \n \
-		.word   TIM8_BRK_IRQHandler        /* TIM8 Break */ \n \
-		.word   TIM8_UP_IRQHandler         /* TIM8 Update */ \n \
-		.word   TIM8_TRG_COM_IRQHandler    /* TIM8 Trigger and Commutation */ \n \
-		.word   TIM8_CC_IRQHandler         /* TIM8 Capture Compare */ \n \
-		.word   RNG_IRQHandler             /* RNG */ \n \
-		.word   0 \n \
-		.word   SDIO_IRQHandler            /* SDIO */ \n \
-		.word   TIM5_IRQHandler            /* TIM5 */ \n \
-		.word   SPI3_IRQHandler            /* SPI3 */ \n \
-		.word   UART4_IRQHandler           /* UART4 */ \n \
-		.word   UART5_IRQHandler           /* UART5 */ \n \
-		.word   TIM6_IRQHandler            /* TIM6 */ \n \
-		.word   TIM7_IRQHandler            /* TIM7 */ \n \
-		.word   DMA2_Channel1_IRQHandler   /* DMA2 Channel 1 */ \n \
-		.word   DMA2_Channel2_IRQHandler   /* DMA2 Channel 2 */ \n \
-		.word   DMA2_Channel3_IRQHandler   /* DMA2 Channel 3 */ \n \
-		.word   DMA2_Channel4_IRQHandler   /* DMA2 Channel 4 */ \n \
-		.word   DMA2_Channel5_IRQHandler   /* DMA2 Channel 5 */ \n \
-		.word   ETH_IRQHandler             /* ETH */ \n \
-		.word   ETHWakeUp_IRQHandler       /* ETH WakeUp */ \n \
-		.word   CAN2_TX_IRQHandler         /* CAN2 TX */ \n \
-		.word   CAN2_RX0_IRQHandler        /* CAN2 RX0 */ \n \
-		.word   CAN2_RX1_IRQHandler        /* CAN2 RX1 */ \n \
-		.word   CAN2_SCE_IRQHandler        /* CAN2 SCE */ \n \
-		.word   USBFS_IRQHandler           /* USBFS */ \n \
-		.word   USBFSWakeup_IRQHandler     /* USBHS Wakeup */ \n \
-		.word   USBFS_IRQHandler           /* USBHS */ \n \
-		.word   DVP_IRQHandler             /* DVP */ \n \
-		.word   UART6_IRQHandler           /* UART6 */ \n \
-		.word   UART7_IRQHandler           /* UART7 */ \n \
-		.word   UART8_IRQHandler           /* UART8 */ \n \
-		.word   TIM9_BRK_IRQHandler        /* TIM9 Break */ \n \
-		.word   TIM9_UP_IRQHandler         /* TIM9 Update */ \n \
-		.word   TIM9_TRG_COM_IRQHandler    /* TIM9 Trigger and Commutation */ \n \
-		.word   TIM9_CC_IRQHandler         /* TIM9 Capture Compare */ \n \
-		.word   TIM10_BRK_IRQHandler       /* TIM10 Break */ \n \
-		.word   TIM10_UP_IRQHandler        /* TIM10 Update */ \n \
-		.word   TIM10_TRG_COM_IRQHandler   /* TIM10 Trigger and Commutation */ \n \
-		.word   TIM10_CC_IRQHandler        /* TIM10 Capture Compare */ \n \
-		.word   DMA2_Channel6_IRQHandler   /* DMA2 Channel 6 */ \n \
-		.word   DMA2_Channel7_IRQHandler   /* DMA2 Channel 7 */ \n \
-		.word   DMA2_Channel8_IRQHandler   /* DMA2 Channel 8 */ \n \
-		.word   DMA2_Channel9_IRQHandler   /* DMA2 Channel 9 */ \n \
-		.word   DMA2_Channel10_IRQHandler  /* DMA2 Channel 10 */ \n \
-		.word   DMA2_Channel11_IRQHandler  /* DMA2 Channel 11 */ \n "
-	//defined(CH32V30x_D8C)
-	#endif
+#if defined(CH32V30x_D8)
+"	.word   SysTick_Handler            /* SysTick */ \n \
+	.word   0 \n \
+	.word   SW_Handler                 /* SW */ \n \
+	.word   0 \n \
+	/* External Interrupts */ \n \
+	.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
+	.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
+	.word   TAMPER_IRQHandler          /* TAMPER */ \n \
+	.word   RTC_IRQHandler             /* RTC */ \n \
+	.word   FLASH_IRQHandler           /* Flash */ \n \
+	.word   RCC_IRQHandler             /* RCC */ \n \
+	.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
+	.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
+	.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
+	.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
+	.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
+	.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
+	.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
+	.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
+	.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
+	.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
+	.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
+	.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
+	.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
+	.word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */ \n \
+	.word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */ \n \
+	.word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */ \n \
+	.word   CAN1_SCE_IRQHandler        /* CAN1 SCE */ \n \
+	.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
+	.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
+	.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
+	.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
+	.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
+	.word   TIM2_IRQHandler            /* TIM2 */ \n \
+	.word   TIM3_IRQHandler            /* TIM3 */ \n \
+	.word   TIM4_IRQHandler            /* TIM4 */ \n \
+	.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
+	.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
+	.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
+	.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
+	.word   SPI1_IRQHandler            /* SPI1 */ \n \
+	.word   SPI2_IRQHandler            /* SPI2 */ \n \
+	.word   USART1_IRQHandler          /* USART1 */ \n \
+	.word   USART2_IRQHandler          /* USART2 */ \n \
+	.word   USART3_IRQHandler          /* USART3 */ \n \
+	.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
+	.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
+	.word   0 \n \
+	.word   TIM8_BRK_IRQHandler        /* TIM8 Break */ \n \
+	.word   TIM8_UP_IRQHandler         /* TIM8 Update */ \n \
+	.word   TIM8_TRG_COM_IRQHandler    /* TIM8 Trigger and Commutation */ \n \
+	.word   TIM8_CC_IRQHandler         /* TIM8 Capture Compare */ \n \
+	.word   RNG_IRQHandler             /* RNG */ \n \
+	.word   0 \n \
+	.word   SDIO_IRQHandler            /* SDIO */ \n \
+	.word   TIM5_IRQHandler            /* TIM5 */ \n \
+	.word   SPI3_IRQHandler            /* SPI3 */ \n \
+	.word   UART4_IRQHandler           /* UART4 */ \n \
+	.word   UART5_IRQHandler           /* UART5 */ \n \
+	.word   TIM6_IRQHandler            /* TIM6 */ \n \
+	.word   TIM7_IRQHandler            /* TIM7 */ \n \
+	.word   DMA2_Channel1_IRQHandler   /* DMA2 Channel 1 */ \n \
+	.word   DMA2_Channel2_IRQHandler   /* DMA2 Channel 2 */ \n \
+	.word   DMA2_Channel3_IRQHandler   /* DMA2 Channel 3 */ \n \
+	.word   DMA2_Channel4_IRQHandler   /* DMA2 Channel 4 */ \n \
+	.word   DMA2_Channel5_IRQHandler   /* DMA2 Channel 5 */ \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   USBFS_IRQHandler          /* USBFS */ \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   0 \n \
+	.word   UART6_IRQHandler           /* UART6 */ \n \
+	.word   UART7_IRQHandler           /* UART7 */ \n \
+	.word   UART8_IRQHandler           /* UART8 */ \n \
+	.word   TIM9_BRK_IRQHandler        /* TIM9 Break */ \n \
+	.word   TIM9_UP_IRQHandler         /* TIM9 Update */ \n \
+	.word   TIM9_TRG_COM_IRQHandler    /* TIM9 Trigger and Commutation */ \n \
+	.word   TIM9_CC_IRQHandler         /* TIM9 Capture Compare */ \n \
+	.word   TIM10_BRK_IRQHandler       /* TIM10 Break */ \n \
+	.word   TIM10_UP_IRQHandler        /* TIM10 Update */ \n \
+	.word   TIM10_TRG_COM_IRQHandler   /* TIM10 Trigger and Commutation */ \n \
+	.word   TIM10_CC_IRQHandler        /* TIM10 Capture Compare */ \n \
+	.word   DMA2_Channel6_IRQHandler   /* DMA2 Channel 6 */ \n \
+	.word   DMA2_Channel7_IRQHandler   /* DMA2 Channel 7 */ \n \
+	.word   DMA2_Channel8_IRQHandler   /* DMA2 Channel 8 */ \n \
+	.word   DMA2_Channel9_IRQHandler   /* DMA2 Channel 9 */ \n \
+	.word   DMA2_Channel10_IRQHandler  /* DMA2 Channel 10 */ \n \
+	.word   DMA2_Channel11_IRQHandler  /* DMA2 Channel 11 */ \n "
+//defined(CH32V30x_D8)
+#elif defined(CH32V30x_D8C)
+"	.word   SysTick_Handler            /* SysTick */ \n \
+	.word   0 \n \
+	.word   SW_Handler                 /* SW */ \n \
+	.word   0 \n \
+	/* External Interrupts */ \n \
+	.word   WWDG_IRQHandler            /* Window Watchdog */ \n \
+	.word   PVD_IRQHandler             /* PVD through EXTI Line detect */ \n \
+	.word   TAMPER_IRQHandler          /* TAMPER */ \n \
+	.word   RTC_IRQHandler             /* RTC */ \n \
+	.word   FLASH_IRQHandler           /* Flash */ \n \
+	.word   RCC_IRQHandler             /* RCC */ \n \
+	.word   EXTI0_IRQHandler           /* EXTI Line 0 */ \n \
+	.word   EXTI1_IRQHandler           /* EXTI Line 1 */ \n \
+	.word   EXTI2_IRQHandler           /* EXTI Line 2 */ \n \
+	.word   EXTI3_IRQHandler           /* EXTI Line 3 */ \n \
+	.word   EXTI4_IRQHandler           /* EXTI Line 4 */ \n \
+	.word   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */ \n \
+	.word   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */ \n \
+	.word   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */ \n \
+	.word   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */ \n \
+	.word   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */ \n \
+	.word   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */ \n \
+	.word   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */ \n \
+	.word   ADC1_2_IRQHandler          /* ADC1_2 */ \n \
+	.word   USB_HP_CAN1_TX_IRQHandler  /* USB HP and CAN1 TX */ \n \
+	.word   USB_LP_CAN1_RX0_IRQHandler /* USB LP and CAN1RX0 */ \n \
+	.word   CAN1_RX1_IRQHandler        /* CAN1 RX1 */ \n \
+	.word   CAN1_SCE_IRQHandler        /* CAN1 SCE */ \n \
+	.word   EXTI9_5_IRQHandler         /* EXTI Line 9..5 */ \n \
+	.word   TIM1_BRK_IRQHandler        /* TIM1 Break */ \n \
+	.word   TIM1_UP_IRQHandler         /* TIM1 Update */ \n \
+	.word   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */ \n \
+	.word   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */ \n \
+	.word   TIM2_IRQHandler            /* TIM2 */ \n \
+	.word   TIM3_IRQHandler            /* TIM3 */ \n \
+	.word   TIM4_IRQHandler            /* TIM4 */ \n \
+	.word   I2C1_EV_IRQHandler         /* I2C1 Event */ \n \
+	.word   I2C1_ER_IRQHandler         /* I2C1 Error */ \n \
+	.word   I2C2_EV_IRQHandler         /* I2C2 Event */ \n \
+	.word   I2C2_ER_IRQHandler         /* I2C2 Error */ \n \
+	.word   SPI1_IRQHandler            /* SPI1 */ \n \
+	.word   SPI2_IRQHandler            /* SPI2 */ \n \
+	.word   USART1_IRQHandler          /* USART1 */ \n \
+	.word   USART2_IRQHandler          /* USART2 */ \n \
+	.word   USART3_IRQHandler          /* USART3 */ \n \
+	.word   EXTI15_10_IRQHandler       /* EXTI Line 15..10 */ \n \
+	.word   RTCAlarm_IRQHandler        /* RTC Alarm through EXTI Line */ \n \
+	.word   USBWakeUp_IRQHandler       /* USB Wakeup from suspend */ \n \
+	.word   TIM8_BRK_IRQHandler        /* TIM8 Break */ \n \
+	.word   TIM8_UP_IRQHandler         /* TIM8 Update */ \n \
+	.word   TIM8_TRG_COM_IRQHandler    /* TIM8 Trigger and Commutation */ \n \
+	.word   TIM8_CC_IRQHandler         /* TIM8 Capture Compare */ \n \
+	.word   RNG_IRQHandler             /* RNG */ \n \
+	.word   0 \n \
+	.word   SDIO_IRQHandler            /* SDIO */ \n \
+	.word   TIM5_IRQHandler            /* TIM5 */ \n \
+	.word   SPI3_IRQHandler            /* SPI3 */ \n \
+	.word   UART4_IRQHandler           /* UART4 */ \n \
+	.word   UART5_IRQHandler           /* UART5 */ \n \
+	.word   TIM6_IRQHandler            /* TIM6 */ \n \
+	.word   TIM7_IRQHandler            /* TIM7 */ \n \
+	.word   DMA2_Channel1_IRQHandler   /* DMA2 Channel 1 */ \n \
+	.word   DMA2_Channel2_IRQHandler   /* DMA2 Channel 2 */ \n \
+	.word   DMA2_Channel3_IRQHandler   /* DMA2 Channel 3 */ \n \
+	.word   DMA2_Channel4_IRQHandler   /* DMA2 Channel 4 */ \n \
+	.word   DMA2_Channel5_IRQHandler   /* DMA2 Channel 5 */ \n \
+	.word   ETH_IRQHandler             /* ETH */ \n \
+	.word   ETHWakeUp_IRQHandler       /* ETH WakeUp */ \n \
+	.word   CAN2_TX_IRQHandler         /* CAN2 TX */ \n \
+	.word   CAN2_RX0_IRQHandler        /* CAN2 RX0 */ \n \
+	.word   CAN2_RX1_IRQHandler        /* CAN2 RX1 */ \n \
+	.word   CAN2_SCE_IRQHandler        /* CAN2 SCE */ \n \
+	.word   USBFS_IRQHandler           /* USBFS */ \n \
+	.word   USBFSWakeup_IRQHandler     /* USBHS Wakeup */ \n \
+	.word   USBFS_IRQHandler           /* USBHS */ \n \
+	.word   DVP_IRQHandler             /* DVP */ \n \
+	.word   UART6_IRQHandler           /* UART6 */ \n \
+	.word   UART7_IRQHandler           /* UART7 */ \n \
+	.word   UART8_IRQHandler           /* UART8 */ \n \
+	.word   TIM9_BRK_IRQHandler        /* TIM9 Break */ \n \
+	.word   TIM9_UP_IRQHandler         /* TIM9 Update */ \n \
+	.word   TIM9_TRG_COM_IRQHandler    /* TIM9 Trigger and Commutation */ \n \
+	.word   TIM9_CC_IRQHandler         /* TIM9 Capture Compare */ \n \
+	.word   TIM10_BRK_IRQHandler       /* TIM10 Break */ \n \
+	.word   TIM10_UP_IRQHandler        /* TIM10 Update */ \n \
+	.word   TIM10_TRG_COM_IRQHandler   /* TIM10 Trigger and Commutation */ \n \
+	.word   TIM10_CC_IRQHandler        /* TIM10 Capture Compare */ \n \
+	.word   DMA2_Channel6_IRQHandler   /* DMA2 Channel 6 */ \n \
+	.word   DMA2_Channel7_IRQHandler   /* DMA2 Channel 7 */ \n \
+	.word   DMA2_Channel8_IRQHandler   /* DMA2 Channel 8 */ \n \
+	.word   DMA2_Channel9_IRQHandler   /* DMA2 Channel 9 */ \n \
+	.word   DMA2_Channel10_IRQHandler  /* DMA2 Channel 10 */ \n \
+	.word   DMA2_Channel11_IRQHandler  /* DMA2 Channel 11 */ \n "
+//defined(CH32V30x_D8C)
+#endif
 #else
 #error Unknown MCU family!
 #endif 


### PR DESCRIPTION
Fix for #424
New `InterruptVectorDefault()` definitions according to WCH's startup code examples.