### PR TITLE
[PIO] Fix include path for assembly files

### DIFF
--- a/.github/add_include.py
+++ b/.github/add_include.py
@@ -21,4 +21,5 @@ for filter in src_filters:
 # propagate to all construction environments
 for e in env, projenv, DefaultEnvironment():
    e.Append(CCFLAGS=[("-I", example_folder)])
+   e.Append(ASFLAGS=[("-I", example_folder)])
    e.Append(CPPPATH=[example_folder])


### PR DESCRIPTION
Needed for e.g. rv003usb.S that expects that it can find funconfig.h. This repo does not yet have any example that uses assembly files that need an include from an example folder, this is prophylactic (and the correct behavior).