### PR TITLE
Add timeout to `WaitForDebuggerToAttach`

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1578,9 +1578,17 @@ void SetupDebugPrintf()
 	*DMDATA0 = 0x80;
 }
 
-void WaitForDebuggerToAttach()
+int WaitForDebuggerToAttach( int timeout_ms )
 {
-	while( ((*DMDATA0) & 0x80) );
+	const uint32_t start = SysTick->CNT;
+	const uint32_t ticks_per_ms = (FUNCONF_SYSTEM_CORE_CLOCK / 1000);
+	const uint32_t timeout = timeout_ms * ticks_per_ms;
+
+	while( (*DMDATA0) & 0x80 ) {
+		if( (SysTick->CNT - start) > timeout ) return 1;
+	}
+
+	return 0;
 }
 
 #endif

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1580,15 +1580,30 @@ void SetupDebugPrintf()
 
 int WaitForDebuggerToAttach( int timeout_ms )
 {
-	const uint32_t start = SysTick->CNT;
-	const uint32_t ticks_per_ms = (FUNCONF_SYSTEM_CORE_CLOCK / 1000);
-	const uint32_t timeout = timeout_ms * ticks_per_ms;
+
+#if defined(CH32V20x) || defined(CH32V30x)
+	#define systickcnt_t uint64_t
+	#define SYSTICKCNT SysTick->CNT
+#elif defined(CH32V10x) || defined(CH32X03x)
+	#define systickcnt_t uint32_t
+	#define SYSTICKCNT SysTick->CNTL
+#else
+	#define systickcnt_t uint32_t
+	#define SYSTICKCNT SysTick->CNT
+#endif
+
+	const systickcnt_t start = SYSTICKCNT;
+	const systickcnt_t ticks_per_ms = (FUNCONF_SYSTEM_CORE_CLOCK / 1000);
+	const systickcnt_t timeout = timeout_ms * ticks_per_ms;
 
 	while( (*DMDATA0) & 0x80 ) {
-		if( (SysTick->CNT - start) > timeout ) return 1;
+		if( (SYSTICKCNT - start) > timeout ) return 1;
 	}
 
 	return 0;
+
+#undef systickcnt_t
+#undef SYSTICKCNT
 }
 
 #endif

--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -13988,7 +13988,8 @@ void SystemInit(void);
 
 void SetupUART( int uartBRR );
 
-void WaitForDebuggerToAttach();
+// Returns 1 if timeout reached, 0 otherwise.
+int WaitForDebuggerToAttach( int timeout_ms );
 
 // Just a definition to the internal _write function.
 int _write(int fd, const char *buf, int size);

--- a/examples/self_modify_code/self_modify_code.c
+++ b/examples/self_modify_code/self_modify_code.c
@@ -85,7 +85,8 @@ int main()
 {
 	SystemInit();
 
-	WaitForDebuggerToAttach();
+	// Wait 60s for debugger to attach
+	(void)WaitForDebuggerToAttach(60*1000);
 
 	// Enable GPIOs
 	RCC->APB2PCENR |= RCC_APB2Periph_GPIOD | RCC_APB2Periph_GPIOC;


### PR DESCRIPTION
Added timeout in milliseconds argument and a return value to indicate weather timeout was reached.

Possible future enhancements:
 - disable debug `printf` if timeout reached by default.