### PR TITLE
Fix HIDAPI on macOS

### DIFF
--- a/minichlink/Makefile
+++ b/minichlink/Makefile
@@ -17,10 +17,10 @@ else
 		LDFLAGS:=-lpthread -lusb-1.0 -ludev
 	endif
 	ifeq ($(OS_NAME),darwin)
-		LDFLAGS:=-lpthread -lusb-1.0 -framework CoreFoundation -framework IOKit
+		LDFLAGS:=-lpthread -lusb-1.0 -lhidapi -framework CoreFoundation -framework IOKit
 		CFLAGS:=-O0 -Wall -Wno-asm-operand-widths -Wno-deprecated-declarations -Wno-deprecated-non-prototype -D__MACOSX__ -DCH32V003 -I.
-		INCLUDES:=$(shell pkg-config --cflags-only-I libusb-1.0)
-		LIBINCLUDES:=$(shell pkg-config --libs-only-L libusb-1.0)
+		INCLUDES:=$(shell pkg-config --cflags-only-I libusb-1.0) $(shell pkg-config --cflags-only-I hidapi)
+		LIBINCLUDES:=$(shell pkg-config --libs-only-L libusb-1.0) $(shell pkg-config --libs-only-L hidapi)
 		INCS:=$(INCLUDES) $(LIBINCLUDES)
 	endif
 endif

--- a/minichlink/pgm-esp32s2-ch32xx.c
+++ b/minichlink/pgm-esp32s2-ch32xx.c
@@ -1,5 +1,13 @@
 #include <stdint.h>
+
+#ifdef __APPLE__
+#include <hidapi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#else
 #include "hidapi.c"
+#endif
 #include "minichlink.h"
 
 struct ESP32ProgrammerStruct


### PR DESCRIPTION
I was not able to detect the usb bootloader using the implementation of hidapi bundled with the project on macOS 14.6.1 on M1.
I was able to enumerate the device, but hid_open() would return a null pointer.
Long story short, the version of `hidapi.c` is too old to work on macOS, but linking with hidapi provided by homebew works.