### PR TITLE
examples/tim2_pwm_remap: fix logic error in timer remapping.

### DIFF
--- a/examples/tim2_pwm_remap/tim2_pwm_remap.c
+++ b/examples/tim2_pwm_remap/tim2_pwm_remap.c
@@ -127,7 +127,7 @@ void t2pwm_setpw(uint8_t chl, uint16_t width)
  *****************************************************************************************/
 void ToggleRemap(void) {
 	if(AFIO->PCFR1 & AFIO_PCFR1_TIM2_REMAP_FULLREMAP) {
-		AFIO->PCFR1 &= AFIO_PCFR1_TIM2_REMAP_NOREMAP;   //clear remapping bits
+		AFIO->PCFR1 &= ~AFIO_PCFR1_TIM2_REMAP_FULLREMAP;   //clear remapping bits
 		printf("Standard Mapping!\r\n");
 	}
 	else {


### PR DESCRIPTION
Small fix for `ToggleRemap()` in `examples/tim2_pwm_remap/tim2_pwm_remap.c`.