### PR TITLE
Fix copy-paste error in Ardulink init

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -45,7 +45,7 @@ void * MiniCHLinkInitAsDLL( struct MiniChlinkFunctions ** MCFO, const init_hints
 		else if( strcmp( specpgm, "b003boot" ) == 0 )
 			dev = TryInit_B003Fun();
 		else if( strcmp( specpgm, "ardulink" ) == 0 )
-			dev = TryInit_B003Fun();
+			dev = TryInit_Ardulink(init_hints);
 	}
 	else
 	{


### PR DESCRIPTION
Discovered by @monte-monte in https://github.com/cnlohr/ch32v003fun/compare/master...monte-monte:ch32v003fun:usb_terminal, looks like a clear bug.

Used when explicitly giving `./minichlink -C arduilink`