### PR TITLE
Fix missing USART constants for CH32X03x

### DIFF
--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -2673,13 +2673,15 @@ typedef struct
 #if defined(CH32V10x) || defined(CH32V30x)
 #define SPI3                					((SPI_TypeDef *) SPI3_BASE)
 #endif
+#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
 #define USART2                                  ((USART_TypeDef *)USART2_BASE)
 #define USART3                                  ((USART_TypeDef *)USART3_BASE)
 #define UART4                                   ((USART_TypeDef *)UART4_BASE)
 #if defined(CH32V10x) || defined(CH32V30x)
 #define UART5               					((USART_TypeDef *) UART5_BASE)
 #endif
-#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
+#endif // defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x)
 #define I2C1                                    ((I2C_TypeDef *)I2C1_BASE)
 #if defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x)
 #define I2C2                                    ((I2C_TypeDef *)I2C2_BASE)


### PR DESCRIPTION
Noticed that although the USAR(T)?_BASE constants where defined, the USAR(T)? constants weren't for the CH32X03x.

Verified USART3 on my CH32X035. The rest I haven't tested yet, but seems to match the reference manual.

Oh and the 4th UART peripheral is called USART4 on CH32X035, not UART4. Might be nice to fix that as well, but for now the extra USART peripherals are at least accessible with this PR.