### PR TITLE
changing standard mode of the CH32x035 to machine mode

### DIFF
--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -1023,6 +1023,13 @@ void handle_reset( void )
 	or a0, a0, a3\n\
 	csrw mtvec, a0\n" 
 	: : : "a0", "a3", "memory");
+//This changes the standard mode of the CH32x035 to machine mode
+#if defined ( CH32X03x )
+asm volatile(
+"	li t0, 0x1888\n\
+	csrw mstatus, t0\n\
+");
+#endif
 
 	// Careful: Use registers to prevent overwriting of self-data.
 	// This clears out BSS.


### PR DESCRIPTION
According to the reference manual, ch32x035 has a PMP and is by default in user mode which prevents from reading some registers, mstatus for example.
This change set the default mode to machine mode.