### PR TITLE
Fix some warnings from clangd in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@
 minichlink/minichlink
 minichlink/minichlink.so
 compile_commands.json
-.clangd
 .cache
 ch32v003fun/generated_*.ld

--- a/build_scripts/README.md
+++ b/build_scripts/README.md
@@ -1,3 +1,3 @@
 Scripts serve to build / clean all examples at once.  
 
-`build_all_clangd.sh` uses bear to additionally generate a `compile_commands.yaml` for each example so the C/C++ language server clangd can be aware of the paths in the makefiles.
+`build_all_clangd.sh` uses bear to additionally generate a `compile_commands.json` for each example so the C/C++ language server clangd can be aware of the paths in the makefiles.

--- a/ch32v003fun/ch32v003fun.c
+++ b/ch32v003fun/ch32v003fun.c
@@ -213,11 +213,24 @@ WEAK int wctomb(char *s, wchar_t wc)
 	return wcrtomb(s, wc, 0);
 }
 #endif
-WEAK size_t strlen(const char *s) { const char *a = s;for (; *s; s++);return s-a; }
+WEAK size_t strlen(const char *s)
+{
+	const char *a = s;
+	for (; *s; s++);
+	return s-a;
+}
 WEAK size_t strnlen(const char *s, size_t n) { const char *p = memchr(s, 0, n); return p ? (size_t)(p-s) : n;}
 WEAK void *memset(void *dest, int c, size_t n) { unsigned char *s = dest; for (; n; n--, s++) *s = c; return dest; }
-WEAK char *strcpy(char *d, const char *s) { for (; (*d=*s); s++, d++); return d; }
-WEAK char *strncpy(char *d, const char *s, size_t n) { for (; n && (*d=*s); n--, s++, d++); return d; }
+WEAK char *strcpy(char *d, const char *s)
+{
+	for (; (*d=*s); s++, d++);
+	return d;
+}
+WEAK char *strncpy(char *d, const char *s, size_t n)
+{
+	for (; n && (*d=*s); n--, s++, d++);
+	return d;
+}
 WEAK int strcmp(const char *l, const char *r)
 {
 	for (; *l==*r && *l; l++, r++);

--- a/ch32v003fun/ch32v003fun.mk
+++ b/ch32v003fun/ch32v003fun.mk
@@ -218,11 +218,9 @@ gdbclient :
 clangd :
 	make clean
 	bear -- make build
-	@echo "CompileFlags:" > .clangd
-	@echo "  Remove: [-march=*, -mabi=*]" >> .clangd
 
 clangd_clean :
-	rm -f compile_commands.json .clangd
+	rm -f compile_commands.json
 	rm -rf .cache
 
 FLASH_COMMAND?=$(MINICHLINK)/minichlink -w $< $(WRITE_SECTION) -b

--- a/examples/debugprintfdemo/.vscode/settings.json
+++ b/examples/debugprintfdemo/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "clangd.arguments": ["--compile-commands-dir=."],
     "cmake.configureOnOpen": false,
     "makefile.launchConfigurations": [
         {
@@ -10,6 +11,6 @@
     "editor.insertSpaces": false,
     "editor.tabSize": 4,
     "files.associations": {
-        "ch32v003fun.h": "c"
+        "*.h": "c"
     },
 }

--- a/examples/template/.vscode/settings.json
+++ b/examples/template/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "clangd.arguments": ["--compile-commands-dir=."],
     "cmake.configureOnOpen": false,
     "makefile.launchConfigurations": [
         {
@@ -10,6 +11,6 @@
     "editor.insertSpaces": false,
     "editor.tabSize": 4,
     "files.associations": {
-        "ch32v003fun.h": "c"
+        "*.h": "c"
     },
 }


### PR DESCRIPTION
Set explicit `--compile-commands-dir` clangd argument in VS Code settings so that `compile_commands.json` will be used also for `ch32v003fun.c` which is outside the example directory.

Don't create `.clangd` files that filter out the `-march` and `-mabi` options. This is not necessary on recent clangd versions (I'm using 18), and the ABI has to be known to generate correct warnings. Additionally, that filter didn't work for files outside the current directory, similar the the first issue mentioned.

Finally, re-format the string handling functions that had clang complaining about empty `for` bodies.

The remaining warnings are due to two things: Firstly naked functions which contain C code. These would have to be re-written in assembly (at least a wrapper to call a C function), and I'm don't know RISC-V assembly. The other issue is a mismatch between how `uint32_t` is defined in clang vs gcc.
![image](https://github.com/user-attachments/assets/9c1176ca-aacc-433f-af34-6cdc651a0ad4)