### PR TITLE
Enable `Zicsr` in `__get_MEPC()`

### DIFF
--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -13513,10 +13513,13 @@ static inline void __set_MSCRATCH(uint32_t value)
  */
 static inline uint32_t __get_MEPC(void)
 {
-    uint32_t result;
-
-	__ASM volatile("csrr %0," "mepc" : "=r"(result));
-    return (result);
+	uint32_t result;
+	__ASM volatile(
+#if __GNUC__ > 10
+	".option arch, +zicsr\n"
+#endif
+	"csrr %0," "mepc" : "=r"(result));
+	return (result);
 }
 
 /*********************************************************************


### PR DESCRIPTION
Fix `__get_MEPC()` so that, like other CSR get/set helper functions, it enables `Zicsr` extension for GCC > 10.

Fixes:

- https://github.com/cnlohr/ch32v003fun/issues/483