### PR TITLE
Udev rules and related documentation

### DIFF
--- a/minichlink/99-minichlink.rules
+++ b/minichlink/99-minichlink.rules
@@ -1,19 +1,28 @@
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8010", GROUP="plugdev", MODE="0660"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8010", GROUP="dialout", MODE="0660"
 
 # Programmer in ARM mode
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8012", GROUP="plugdev", MODE="0660"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8012", GROUP="dialout", MODE="0660"
 
 # Programmer in IAP mode
 SUBSYSTEM=="usb", ATTRS{idVendor}=="4348", ATTRS{idProduct}=="55e0", GROUP="plugdev", MODE="0660"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="4348", ATTRS{idProduct}=="55e0", GROUP="dialout", MODE="0660"
 
 SUBSYSTEM=="usb", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="4004", GROUP="plugdev", MODE="0660"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="4004", GROUP="dialout", MODE="0660"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="4004", GROUP="plugdev", MODE="0660"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="4004", GROUP="dialout", MODE="0660"
 
 # rv003usb bootloader
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="b003", GROUP="plugdev", MODE="0660"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="b003", GROUP="dialout", MODE="0660"
 #KERNEL=="hiddev*", SUBSYSTEM=="usbmisc", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="b003", GROUP="plugdev", MODE="0660"
+#KERNEL=="hiddev*", SUBSYSTEM=="usbmisc", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="b003", GROUP="dialout", MODE="0660"
 
 # ch32v003 programming rvswdio dongle
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1206", ATTRS{idProduct}=="5d10", GROUP="plugdev", MODE="0660"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1206", ATTRS{idProduct}=="5d10", GROUP="dialout", MODE="0660"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1206", ATTRS{idProduct}=="5d10", GROUP="plugdev", MODE="0660"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1206", ATTRS{idProduct}=="5d10", GROUP="dialout", MODE="0660"
 

--- a/minichlink/README.md
+++ b/minichlink/README.md
@@ -2,7 +2,8 @@
 
 A free, open mechanism to use the CH-LinkE $4 programming dongle for the CH32V003.
 
-If on Linux, make sure to install the `99-WCH-LinkE.rules` build rule to `/etc/udev/rules.d/`
+If on Linux, make sure to install the provided udev rules rule to `/etc/udev/rules.d/`.
+This can be done by issuing `make install_udev_rules` as root. The makefile target will also tell the udev daemon to reload the new rules and re-evaluate them on already attached devices, essentially saving you a reboot/replug.
 
 On Windows, if you need to you can install the WinUSB driver over the WCH interface 1.
 

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -137,12 +137,12 @@ int main( int argc, char ** argv )
 			for( i = 0; i < gl; i++ )
 			{
 				struct group * gr = getgrgid( groups[i] );
-				if( strcmp( gr->gr_name, "plugdev" ) == 0 )
+				if( strcmp( gr->gr_name, "plugdev" ) == 0 || strcmp( gr->gr_name, "dialout" ) == 0 )
 					break;
 			}
 			if( i == gl )
 			{
-				printf( "WARNING: You are not in the plugdev group, the canned udev rules will not work on your system.\n" );
+				printf( "WARNING: You are not in the plugdev/dialout group, the canned udev rules will not work on your system.\n" );
 			}
 		}
 	}


### PR DESCRIPTION
From my understanding, udev should simply match the first available group, so specifying duplicates like this should not be a problem. However, a sed/envsubst solution might be better from a maintainer point of view. Tested and working on F41 (dialout), but needs a check on a plugdev system.