### PR TITLE
CH32V30x: Fix PLL_MULTIPLICATION definition for ch32v303

### DIFF
--- a/ch32v003fun/ch32v003fun.h
+++ b/ch32v003fun/ch32v003fun.h
@@ -6073,7 +6073,7 @@ typedef struct
 #define RCC_PLLMULL14                           ((uint32_t)0x00300000) /* PLL input clock*14 */
 #define RCC_PLLMULL15                           ((uint32_t)0x00340000) /* PLL input clock*15 */
 #define RCC_PLLMULL16                           ((uint32_t)0x00380000) /* PLL input clock*16 */
-#if defined(CH32V20x)
+#if defined(CH32V20x) || defined(CH32V30x_D8)
 #define RCC_PLLMULL18                           ((uint32_t)0x003C0000) /* PLL input clock*18 */
 #endif
 
@@ -13972,7 +13972,7 @@ void DefaultIRQHandler( void ) __attribute__((section(".text.vector_handler"))) 
 				#define PLL_MULTIPLICATION RCC_PLLMULL15
 			#elif FUNCONF_PLL_MULTIPLIER == 16
 				#define PLL_MULTIPLICATION RCC_PLLMULL16
-			#elif defined(CH32V20x) && FUNCONF_PLL_MULTIPLIER == 18
+			#elif (defined(CH32V20x) || defined(CH32V30x_D8)) && FUNCONF_PLL_MULTIPLIER == 18
 				#define PLL_MULTIPLICATION RCC_PLLMULL18
 			#else
 				#error "Invalid PLL multiplier"


### PR DESCRIPTION
When compiling for a ch32v303 (which is part of the ch32v30x_D8), the build was failing because `FUNCONF_PLL_MULTIPLIER` is set to 18 (for all ch32v30x), but the code test for 18 only for the ch32v20x. This cause the build to errors with the message "Invalid PLL multiplier".

I also modified the condition before the declaration of `RCC_PLLMULL18`, to include all ch32v30x_D8.

I didn't really test directly the modifications, as I used this with Zephyr, which use the macros `RCC_PLLMul_x` (they have the same value as the macros `RCC_PLLMULLx`, I don't really understand the difference).