### PR TITLE
replaced direct pin call with gpio variable

### DIFF
--- a/examples/dma_gpio_ws2812/dma_gpio_ws2812.c
+++ b/examples/dma_gpio_ws2812/dma_gpio_ws2812.c
@@ -192,7 +192,7 @@ int main()
 
 
 	// GPIO D0 Output (where we are connecting our LED)
-	funPinMode( PD0, GPIO_CFGLR_OUT_10Mhz_PP );
+	funPinMode( gpio_pin, GPIO_CFGLR_OUT_10Mhz_PP );
 
 	// Setup visual effect
 	for( i = 0; i < NR_LEDS; i++ ) phases[i] = i<<8;


### PR DESCRIPTION
There was a stray pin call that wasn't using the gpio_pin variable in the dma_gpio_ws2812b example for the CH32V003.