### PR TITLE
minichlink: Active polling of Ardulink device

### DIFF
--- a/minichlink/ardulink.c
+++ b/minichlink/ardulink.c
@@ -103,15 +103,18 @@ int ArdulinkSetupInterface( void * dev )
 	// Let the bootloader do its thing.
 	MCF.DelayUS(dev, 3UL*1000UL*1000UL);
 
+	serial_dev_write(&((ardulink_ctx_t*)dev)->serial, "?", 1);
+
 	if (serial_dev_read(&((ardulink_ctx_t*)dev)->serial, &first, 1) == -1) {
 		perror("read");
 		return -1;
 	}
 
-	if (first != '!') {
+	if (first != '!' && first != '+') {
 		fprintf(stderr, "Ardulink: not the sync character.\n");
 		return -1;
 	}
+	serial_dev_flush_rx(&((ardulink_ctx_t*)dev)->serial);
 
 	return 0;
 }


### PR DESCRIPTION
Hi !

This PR allows to actively poll an Ardulink device instead of waiting for the '!' character.
The poll is done using the '?' command, which returns a '+' character.

Submitting this because the tool I develop uses a bus pirate-like interface. Switching to ardulink mode requires the user quit the terminal to run minichlink, and the initial '!' usually gets lost.

I also thought about changing the serial port behavior in minichlink (using timeouts on serial reads), but this solution is simplier and works on the original ardulink as well.