### PR TITLE
Add a {} guard to get rid of gcc warning when compile for ch32v208

### DIFF
--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -1856,7 +1856,7 @@ void SystemInit( void )
 	#endif
 
 	// Values lifted from the EVT.  There is little to no documentation on what this does.
-	while(!(RCC->CTLR&RCC_HSERDY));
+	while(!(RCC->CTLR&RCC_HSERDY)) {};
 
 	#if defined(CH32V003)
 		RCC->CFGR0 = RCC_PLLSRC_HSE_Mul2 | RCC_SW_HSE;


### PR DESCRIPTION
Without these brackets gcc would fire an annoying warning when compile for ch32v208:

```
Compiling .pio/build/208_test/ch32v003fun/ch32fun/ch32fun.o
ch32v003fun/ch32fun/ch32fun.c: In function 'SystemInit':
ch32v003fun/ch32fun/ch32fun.c:1859:9: warning: this 'while' clause does not guard... [-Wmisleading-indentation]
 1859 |         while(!(RCC->CTLR&RCC_HSERDY));
      |         ^~~~~
In file included from ch32v003fun/ch32fun/ch32fun.h:348,
                 from ch32v003fun/ch32fun/ch32fun.c:93:
ch32v003fun/ch32fun/ch32v20xhw.h:1412:49: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'while'
 1412 | #define RCC                                     ((RCC_TypeDef *)RCC_BASE)
      |                                                 ^
ch32v003fun/ch32fun/ch32fun.c:1864:17: note: in expansion of macro 'RCC'
 1864 |                 RCC->CFGR0 = BASE_CFGR0 | RCC_PLLSRC_HSE | RCC_PLLXTPRE_HSE;
      |                 ^~~
```