### PR TITLE
Move the gp register, to allow the compiler to leverage gp to access …

### DIFF
--- a/ch32fun/ch32fun.ld
+++ b/ch32fun/ch32fun.ld
@@ -173,11 +173,11 @@ SECTIONS
     .data :
     {
       . = ALIGN(4);
+      __global_pointer$ = . + 0x3fc; /* This gets set in the startup code.  This allows -mrelax'd code to be smaller by acting as a sort of quick reference in the gp register. */
       *(.gnu.linkonce.r.*)
       *(.data .data.*)
       *(.gnu.linkonce.d.*)
       . = ALIGN(8);
-      PROVIDE( __global_pointer$ = . + 0x800 );
       *(.sdata .sdata.*)
       *(.sdata2*)
       *(.gnu.linkonce.s.*)


### PR DESCRIPTION
…the first part of ram.  This produces smaller executables in general.  I don't know why the original startup code pointed at 0x20000800.  You can reach all of the first part of ram by setting it to 0x200003fc