### PR TITLE
Add CH59x MCU_PACKAGE to CFLAGS

### DIFF
--- a/ch32fun/ch32fun.mk
+++ b/ch32fun/ch32fun.mk
@@ -268,6 +268,7 @@ else ifeq ($(findstring CH59,$(TARGET_MCU)),CH59) # CH592 1
 	else ifeq ($(findstring 592, $(TARGET_MCU_PACKAGE)), 592)
 		MCU_PACKAGE:=2
 	endif
+	CFLAGS+=-DMCU_PACKAGE=$(MCU_PACKAGE)
 
 	# Package
 	ifeq ($(findstring D, $(TARGET_MCU_PACKAGE)), D)


### PR DESCRIPTION
Just a tiny change to make for ch59x, so they are in line with the other ch5xx and packages like iSLER can know which ch59x it is compiling for.