### PR TITLE
fix CH582_CH582 typo in SysTick

### DIFF
--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -1529,7 +1529,7 @@ void SetupDebugPrintf( void )
 int WaitForDebuggerToAttach( int timeout_ms )
 {
 
-#if defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x) || defined(CH571_CH573) || defined(CH582_CH582) || defined(CH591_CH592)
+#if defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x) || defined(CH571_CH573) || defined(CH582_CH583) || defined(CH591_CH592)
 	#define systickcnt_t uint64_t
 	#define SYSTICKCNT SysTick->CNT
 #elif defined(CH32V10x) || defined(CH570_CH572) || defined(CH584_CH585)
@@ -1579,7 +1579,7 @@ void DelaySysTick( uint32_t n )
 #if defined(CH32V003) || defined(CH32V00x)
 	uint32_t targend = SysTick->CNT + n;
 	while( ((int32_t)( SysTick->CNT - targend )) < 0 );
-#elif defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x) || defined(CH582_CH582) || defined(CH591_CH592)
+#elif defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x) || defined(CH582_CH583) || defined(CH591_CH592)
 	uint64_t targend = SysTick->CNT + n;
 	while( ((int64_t)( SysTick->CNT - targend )) < 0 );
 #elif defined(CH32V10x) || defined(CH570_CH572) || defined(CH584_CH585)


### PR DESCRIPTION
The SysTick code got a CH582_CH582 typo in #673, this fixes that (and makes uni happy!)