### PR TITLE
CI: also build test examples_usb/USBFS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build all examples (max 10 in parallel)
         run: |
           set -e
-          find examples* -maxdepth 2 -name Makefile \
+          find examples* -maxdepth 3 -name Makefile \
             | parallel -j 10 '
                 dir=$(dirname {});
                 echo "============================"


### PR DESCRIPTION
Currently the build test only finds Makefiles in demos directly in the `examples_*` directories, but the `examples_usb` has one extra level: `USBFS`. This change increases the search depth by one to also catch the USB demos.