### PR TITLE
Fixed issue that causes USART2 not to function on V005/6/7

### DIFF
--- a/ch32fun/ch32x00xhw.h
+++ b/ch32fun/ch32x00xhw.h
@@ -621,13 +621,13 @@ typedef struct
 /* Operational Amplifier and Comparator */
 typedef struct
 {
-  __IO uint32_t CFGR1;
-  __IO uint32_t CTLR1;
-  __IO uint32_t CFGR2;
-  __IO uint32_t CTLR2;
-  __IO uint32_t OPA_KEY;
-  __IO uint32_t CMP_KEY;
-  __IO uint32_t POLL_KEY;
+    __IO uint32_t CFGR1;
+    __IO uint32_t CTLR1;
+    __IO uint32_t CFGR2;
+    __IO uint32_t CTLR2;
+    __IO uint32_t OPA_KEY;
+    __IO uint32_t CMP_KEY;
+    __IO uint32_t POLL_KEY;
 } OPA_TypeDef;
 
 


### PR DESCRIPTION
## What's Changed
* Fixed USART2_BASE address, it was (APB2PERIPH_BASE + 0x4400), but its actually at (APB1PERIPH_BASE + 0x4400)
* Fixed issue where AFIO_PCFR1_USART2_RM_0/1/2 were all ((uint32_t)0x00700000) instead of their respective bit values
* Added bitmasks for AFIO_PCFR1_SWCFG_0/1/2
* Added bitmask for RCC_HPRE_0
* Added RCC_APB1Periph_TIM3
* Changed EXTEN_BASE from ((uint32_t)0x40023800) to (AHBPERIPH_BASE + 0x3800). They are the same address
* Fixed indentation issues on a few lines