### PR TITLE
Fix CI building wrong projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
                 echo "============================"
                 echo "Building example: $dir"
                 echo "============================"
-                (cd "$dir" && make V=1 -j3 "$(basename "$dir").elf" && riscv64-unknown-elf-size "$(basename "$dir").elf")
+                (cd "$dir" && make V=1 -j3 "$(basename "$dir").elf" 2>&1 && riscv64-unknown-elf-size "$(basename "$dir").elf")
             '
   build-all-windows:
     runs-on: windows-latest


### PR DESCRIPTION
Fixes cases where we tried to build testbench Makefiles intended for Linux and not a firmware.

Also makes `make` errors show up in log. (Though they may be further up in the log due to parallelism.)