### PR TITLE
Fix warnings in macOS

### DIFF
--- a/minichlink/pgm-b003fun.c
+++ b/minichlink/pgm-b003fun.c
@@ -471,7 +471,7 @@ static int B003FunSetupInterface( void * dev )
 	
 	uint32_t one;
 	int two;
-	uint8_t read_protection;
+	uint8_t read_protection = 0;
 	MCF.ReadWord( dev, 0x4002201c, &one );
 	MCF.ReadWord( dev, 0x40022020, (uint32_t*)&two );
 	

--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -19,7 +19,7 @@ struct LinkEProgrammerStruct
 	libusb_device_handle * devh;
 	int lasthaltmode; // For non-003 chips
 };
-
+#if !FORCE_EXTERNAL_CHIP_DETECTION
 static int checkChip(enum RiscVChip chip) {
 	switch(chip) {
 		case CHIP_UNKNOWN:
@@ -44,11 +44,14 @@ static int checkChip(enum RiscVChip chip) {
 			return -1; // Not supported yet
 	}
 }
+#endif // !FORCE_EXTERNAL_CHIP_DETECTION
 
 // For non-ch32v003 chips.
+#if !FORCE_EXTERNAL_CHIP_DETECTION
 //static int LEReadBinaryBlob( void * d, uint32_t offset, uint32_t amount, uint8_t * readbuff );
 static int InternalLinkEHaltMode( void * d, int mode );
 static int LEWriteBinaryBlob( void * d, uint32_t address_to_write, uint32_t len, const uint8_t * blob );
+#endif // !FORCE_EXTERNAL_CHIP_DETECTION
 
 #define WCHTIMEOUT 5000
 #define WCHCHECK(x) if( (status = x) ) { fprintf( stderr, "Bad USB Operation on " __FILE__ ":%d (%d)\n", __LINE__, status ); exit( status ); }
@@ -954,6 +957,7 @@ struct BootloaderBlob * GetFlashLoader( enum RiscVChip chip )
 	}
 }
 
+#if !FORCE_EXTERNAL_CHIP_DETECTION
 static int InternalLinkEHaltMode( void * d, int mode )
 {
 	libusb_device_handle * dev = ((struct LinkEProgrammerStruct*)d)->devh;
@@ -1061,3 +1065,4 @@ static int LEWriteBinaryBlob( void * d, uint32_t address_to_write, uint32_t len,
 
 	return 0;
 }
+#endif // !FORCE_EXTERNAL_CHIP_DETECTION


### PR DESCRIPTION
Was getting the following warnings in macOS:
```
pgm-wch-linke.c:23:12: warning: unused function 'checkChip' [-Wunused-function]
static int checkChip(enum RiscVChip chip) {
           ^
pgm-wch-linke.c:983:12: warning: unused function 'LEWriteBinaryBlob' [-Wunused-function]
static int LEWriteBinaryBlob( void * d, uint32_t address_to_write, uint32_t len, const uint8_t * blob )
           ^
2 warnings generated.
pgm-b003fun.c:478:6: warning: variable 'read_protection' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
        if( (one & 2) || two != -1 ) read_protection = 1;
            ^~~~~~~~~~~~~~~~~~~~~~
pgm-b003fun.c:486:45: note: uninitialized use occurs here
        fprintf( stderr, "Read protection: %s\n", (read_protection > 0)?"enabled":"disabled" );
                                                   ^~~~~~~~~~~~~~~
pgm-b003fun.c:478:2: note: remove the 'if' if its condition is always true
        if( (one & 2) || two != -1 ) read_protection = 1;
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pgm-b003fun.c:474:25: note: initialize the variable 'read_protection' to silence this warning
        uint8_t read_protection;
                               ^
                                = '\0'
1 warning generated.
```