### PR TITLE
Set _i2c_slave_struct.size1 and .size2 to volatile

### DIFF
--- a/examples/i2c_slave/README.md
+++ b/examples/i2c_slave/README.md
@@ -84,5 +84,3 @@ SetupSecondaryI2CSlave(0x42, i2c_registers2, sizeof(i2c_registers2), onWrite2, o
 The function arguments are identical to the normal `SetupI2CSlave` function. The secondary I2C address acts like a completely separate I2C device with it's own registers.
 
 Calling `SetupSecondaryI2CSlave` with the I2C address set to 0 disables listening on the secondary address.
-
-It is recommended to react to register writes using the `onWrite` callback and not by reading the registers array from main(). There is a chance the compiler will optimize away your code if you do that.

--- a/examples/i2c_slave/i2c_slave.h
+++ b/examples/i2c_slave/i2c_slave.h
@@ -40,9 +40,9 @@ struct _i2c_slave_state {
     uint8_t offset;
     uint8_t position;
     volatile uint8_t* volatile registers1;
-    uint8_t size1;
+    volatile uint8_t size1;
     volatile uint8_t* volatile registers2;
-    uint8_t size2;
+    volatile uint8_t size2;
     i2c_write_callback_t write_callback1;
     i2c_read_callback_t read_callback1;
     bool read_only1;


### PR DESCRIPTION
This discourages the compiler from optimizing out the initialization of these fields. If this initialization is skipped, they default to 0, which causes `I2C1_EV_IRQHandler` to cycle endlessly since the data register will never be read due to the size check failing...

(This "optimization" may occur when the `i2c_registers` array is referenced outside of the `onWrite()` callback, such as in `main()`.)