### PR TITLE
ch5xx: add USBFSReset

### DIFF
--- a/examples_ch5xx/boot_button/boot_button.c
+++ b/examples_ch5xx/boot_button/boot_button.c
@@ -3,8 +3,8 @@
  * Most ch5xx dev boards come with a "boot" or "download" button, when this
  * is pressed the chip resets and executes the ISP bootloader which presents
  * itself on USB to the host.
- * NOTE: this does not work together with "FUNCONF_USE_USBPRINTF"! For use
- * in combination with that refer to the examples_usb/USBFS/usbfs_cdc_tty demo.
+ * NOTE: if "FUNCONF_USE_USBPRINTF" is used, a call to USBFSReset() is needed
+ *       just before jump_isprom()
  */
 
 #include "ch32fun.h"

--- a/examples_usb/USBFS/usbfs_cdc_tty/usbfs_cdc_tty.c
+++ b/examples_usb/USBFS/usbfs_cdc_tty/usbfs_cdc_tty.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include "fsusb.h"
 
-#if defined(CH57x) && (MCU_PACKAGE == 0 || MCU_PACKAGE == 2) // ch570/2
+#ifdef CH570_CH572
 #define PIN_LED    PA9
 #define PIN_BUTTON PA1
 #define BUTTON_PRESSED funDigitalRead( PIN_BUTTON )
@@ -34,19 +34,20 @@ int main()
 	funPinMode( PIN_LED,    GPIO_CFGLR_OUT_10Mhz_PP ); // Set PIN_LED to output
 	funPinMode( PIN_BUTTON, GPIO_CFGLR_IN_PUPD ); // Set PIN_BUTTON to input
 
-	if( BUTTON_PRESSED ) {
-		blink(5);
-		jump_isprom();
-	}
-
 	USBFSSetup();
 	blink(1);
 
 	int i = 0;
 	while(1) {
-		if(run) {
-			printf("Press 'p' to pause counting, 'c' to continue, 1,2, or 3 to blink. %d\r", i++);
+		if( BUTTON_PRESSED ) {
+			blink(5);
+			USBFSReset();
+			jump_isprom();
 		}
-		Delay_Ms(100);
+
+		if(run) {
+			printf("Counting: %d\r", i++);
+		}
+		Delay_Ms(333);
 	}
 }

--- a/extralibs/fsusb.c
+++ b/extralibs/fsusb.c
@@ -912,6 +912,23 @@ int USBFSSetup()
 	return 0;
 }
 
+#ifdef CH5xx
+void USBFSReset()
+{
+	NVIC_DisableIRQ( USB_IRQn );
+#if defined (CH570_CH572)
+	R16_PIN_ALTERNATE &= ~(RB_PIN_USB_EN | RB_UDP_PU_EN);
+#elif defined (CH584_CH585)
+	R16_PIN_CONFIG &= ~(RB_PIN_USB_EN | RB_UDP_PU_EN);
+#else
+	R16_PIN_ANALOG_IE &= ~(RB_PIN_USB_IE | RB_PIN_USB_DP_PU);
+#endif
+	USBFS->BASE_CTRL = USBFS_UC_RESET_SIE | USBFS_UC_CLR_ALL;
+	USBFS->BASE_CTRL = 0x00;
+	Delay_Us(10);
+}
+#endif
+
 static inline uint8_t * USBFS_GetEPBufferIfAvailable( int endp )
 {
 	if( USBFSCTX.USBFS_Endp_Busy[ endp ] ) return 0;


### PR DESCRIPTION
This is needed to enable jumping to ISP rom if `FUNCONF_USE_USBPRINTF` is used.