### PR TITLE
Clean up minichlink makefile

### DIFF
--- a/minichlink/Makefile
+++ b/minichlink/Makefile
@@ -58,4 +58,4 @@ inspect_bootloader : minichlink
 	riscv64-unknown-elf-objdump -S -D test.bin -b binary -m riscv:rv32 | less
 
 clean :
-	rm -rf $(TOOLS)
+	rm -rf $(TOOLS) minichlink.exe


### PR DESCRIPTION
This change cleans up the Makefile a bit.

From @unicab369 on discord we know that minichlink compiles fine on Clang, so it's safe to not hardcode the compiler and instead pull it from $(CC)

Remove the platform (windows) CFLAGS and LDFLAGS and just override them in the conditional like it's done for macos.

Remove the .exe build instructions. Make on Windows will actually handle this for us. If we're building an executable it will append it with .exe. Likewise for executions, deletions and so on.

Add minichlink.dll to the default build to mirror the steps for *nix. Prior it had to be invoked explicitly.

Remove the makefile itself from rule dependencies. Doesn't hurt but makes no sense. How do we invoke a build step from the makefile without the makefile existing.