### PR TITLE
Improve Non-Aligned Read Performance

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -2786,35 +2786,33 @@ int DefaultReadBinaryBlob( void * dev, uint32_t address_to_read_from, uint32_t r
 		{
 			if( remain >= 1 )
 			{
-			    uint8_t rw;
-			    r = MCF.ReadByte( dev, rpos, &rw );
-			    if( r ) return r;
-			    memcpy( blob, &rw, 1 );
-			    blob += 1;
-			    rpos += 1;
-			    remain -= 1;
+				uint8_t rw;
+				r = MCF.ReadByte( dev, rpos, &rw );
+				if( r ) return r;
+				memcpy( blob, &rw, 1 );
+				blob += 1;
+				rpos += 1;
+				remain -= 1;
 			}
-        
 			if( ( rpos & 1 ) && remain >= 1 )
 			{
-			    uint8_t rw;
-			    r = MCF.ReadByte( dev, rpos, &rw );
-			    if( r ) return r;
-			    memcpy( blob, &rw, 1 );
-			    blob += 1;
-			    rpos += 1;
-			    remain -= 1;
+				uint8_t rw;
+				r = MCF.ReadByte( dev, rpos, &rw );
+				if( r ) return r;
+				memcpy( blob, &rw, 1 );
+				blob += 1;
+				rpos += 1;
+				remain -= 1;
 			}
-			
 			if( ( rpos & 2 ) && remain >= 2 )
 			{
-			    uint16_t rw;
-			    r = MCF.ReadHalfWord( dev, rpos, &rw );
-			    if( r ) return r;
-			    memcpy( blob, &rw, 2 );
-			    blob += 2;
-			    rpos += 2;
-			    remain -= 2;
+				uint16_t rw;
+				r = MCF.ReadHalfWord( dev, rpos, &rw );
+				if( r ) return r;
+				memcpy( blob, &rw, 2 );
+				blob += 2;
+				rpos += 2;
+				remain -= 2;
 			}
 		}
 	}


### PR DESCRIPTION
This update speeds up non-aligned reads. Commands such as ```minichlink -r + 0x03 1200```, which previously took several seconds to complete, now finish almost instantly. The improvement is modest on native Linux systems but much more noticeable when running under WSL.