### PR TITLE
HSUSB flow control for OUT (Rx) transfers

### DIFF
--- a/extralibs/hsusb.h
+++ b/extralibs/hsusb.h
@@ -374,7 +374,7 @@ struct _USBState;
 
 // Provided functions:
 int USBHSSetup();
-static inline int USBHS_SendEndpointNEW( int endp, uint8_t* data, int len, int copy);
+static inline int USBHS_SendEndpointNEW( int endp, const uint8_t* data, int len, int copy);
 static inline uint8_t * USBHS_GetEPBufferIfAvailable( int endp );
 static inline int USBHS_SendEndpoint( int endp, int len );
 static inline int USBHS_SendACK( int endp, int tx );
@@ -393,6 +393,10 @@ void HandleHidUserReportOutComplete( struct _USBState * ctx );
 __HIGH_CODE int HandleInRequest( struct _USBState * ctx, int endp, uint8_t * data, int len );
 __HIGH_CODE void HandleDataOut( struct _USBState * ctx, int endp, uint8_t * data, int len );
 __HIGH_CODE int HandleSetupCustom( struct _USBState * ctx, int setup_code);
+#endif
+
+#if FUSB_OUT_FLOW_CONTROL > 0
+void USBHS_RxReady(int endp);
 #endif
 
 typedef enum


### PR DESCRIPTION
Implements flow control for data OUT transfers.

Tested on CH32V305, should also work on devices with `USBHS_IMPL==2`, but I have no one to test.

I would also like to implement hardware double buffering to improve speed, but until I get the time to do that, this works.