### PR TITLE
iSLER: fix frame length in tx buffers in the demos

### DIFF
--- a/examples_ch5xx/ble_beacon/ble_beacon.c
+++ b/examples_ch5xx/ble_beacon/ble_beacon.c
@@ -22,9 +22,8 @@
 // The advertisement to be sent. The MAC address should be in the first 6 bytes in reversed byte order,
 // after that any BLE flag can be used.
 __attribute__((aligned(4))) uint8_t adv[] = {
-		0x02, 0x11, // header for LL: PDU + frame length
+		0x02, 0x0f, // header for LL: PDU + frame length
 		0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // MAC (reversed)
-		0x03, 0x19, 0x00, 0x00, // 0x19: "Appearance", 0x00, 0x00: "Unknown"
 		0x08, 0x09, 'c', 'h', '3', '2', 'f', 'u', 'n'}; // 0x09: "Complete Local Name"
 uint8_t adv_channels[] = {37,38,39};
 

--- a/examples_ch5xx/iSLER/iSLER.c
+++ b/examples_ch5xx/iSLER/iSLER.c
@@ -20,9 +20,8 @@
 #define REPORT_ALL 1 // if 0 only report received Find My advertisements
 
 __attribute__((aligned(4))) uint8_t adv[] = {
-		0x02, 0x11, // header for LL: PDU + frame length
+		0x02, 0x0d, // header for LL: PDU + frame length
 		0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // MAC (reversed)
-		0x03, 0x19, 0x00, 0x00, // 0x19: "Appearance", 0x00, 0x00: "Unknown"
 		0x06, 0x09, 'R', 'X', ':', '?', '?'}; // 0x09: "Complete Local Name"
 
 // BLE advertisements are sent on channels 37, 38 and 39


### PR DESCRIPTION
The iSLER demos have a faulty length byte in the tx buffers, which results in proper BLE clients discarding them upon reception. This causes apps like nRF Connect to not display the advertisements sent by the demos, leading to frustration by new people trying this out.