### PR TITLE
Stack Usage Example

### DIFF
--- a/projects/stack_usage/Makefile
+++ b/projects/stack_usage/Makefile
@@ -1,0 +1,14 @@
+all : flash
+
+TARGET:=stack_usage
+
+TARGET_MCU?=CH32V003
+# TARGET_MCU:=CH570
+# TARGET_MCU_PACKAGE:=CH570D
+include ../../ch32fun/ch32fun.mk
+
+CFLAGS += -fno-omit-frame-pointer -fno-optimize-sibling-calls
+
+flash : cv_flash
+clean : cv_clean
+

--- a/projects/stack_usage/README.md
+++ b/projects/stack_usage/README.md
@@ -1,0 +1,18 @@
+# Stack Info Example
+
+This example shows how to measure runtime stack usage using a canary value.
+The stack is filled with a canary value (0xDEADBEEF) and after a few operations,
+the stack is scanned to see how much of the canary value has been overwritten,
+indicating the maximum stack depth used.
+
+The second part of the example shows a call trace (frame pointer backtrace) of a recursive
+function with random depth.
+
+RA is the return address. You can use the following command to get the function name from the
+address (replace `<address>` with the actual address):
+
+```sh
+riscv32-unknown-elf-addr2line -f -e *.elf <address>
+```
+> [!NOTE]
+> Your toolchain prefix may vary.

--- a/projects/stack_usage/funconfig.h
+++ b/projects/stack_usage/funconfig.h
@@ -1,0 +1,17 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+// Place configuration items here, you can see a full list in ch32fun/ch32fun.h
+// To reconfigure to a different processor, update TARGET_MCU in the  Makefile
+#if defined(CH570_CH572)
+#define FUNCONF_USE_HSI           0 // CH5xx does not have HSI
+#define FUNCONF_USE_HSE           1
+#define CLK_SOURCE_CH5XX          CLK_SOURCE_PLL_60MHz // default so not really needed
+#define FUNCONF_SYSTEM_CORE_CLOCK 60 * 1000 * 1000     // keep in line with CLK_SOURCE_CH5XX
+
+#define FUNCONF_DEBUG_HARDFAULT   1
+#define FUNCONF_USE_CLK_SEC       0
+#endif
+
+#endif
+

--- a/projects/stack_usage/stack_usage.c
+++ b/projects/stack_usage/stack_usage.c
@@ -1,0 +1,113 @@
+#include "ch32fun.h"
+#include <stdio.h>
+
+#define RANDOM_STRENGTH 2
+#include "lib_rand.h"
+
+#define CANARY 0xF0CACC1A
+
+// stack start and end defined in the linker script
+extern uint32_t _eusrstack;
+extern uint32_t end;
+
+static inline void *get_stack_pointer()
+{
+	register void *sp asm( "sp" );
+	return sp;
+}
+
+
+void print_stacktrace()
+{
+	volatile uintptr_t *fp;
+	asm volatile( "mv %0, s0" : "=r"( fp ) );
+
+	int depth = 0;
+
+	printf( "Stack Trace:\n" );
+	while ( fp )
+	{
+		uintptr_t ra = *( fp - 1 );
+		uintptr_t *nextfp = (void *)*( fp - 2 );
+
+		printf( "  Frame %d: FP=0x%x, RA=0x%x\n", depth, (uintptr_t)nextfp, ra );
+
+		fp = (void *)nextfp;
+		if ( fp == (uintptr_t *)&_eusrstack )
+		{
+			printf( "Done\n" );
+			break;
+		}
+
+		if ( ++depth > 20 )
+		{
+			printf( "Stack trace depth limit reached.\n" );
+			break;
+		}
+	}
+}
+
+void fill_canary( uint32_t canary )
+{
+	uint32_t *p = get_stack_pointer();
+	printf( "Filling canary from 0x%lx to 0x%lx\n", (uint32_t)p, (uint32_t)&end );
+
+	while ( --p > &end )
+	{
+		*p = canary;
+	}
+}
+
+void *get_stack_watermark( uint32_t canary )
+{
+	const uint32_t *const top = get_stack_pointer();
+	uint32_t *p = &end;
+	while ( ++p < top )
+	{
+		if ( *p != canary )
+		{
+			break;
+		}
+	}
+	return p;
+}
+
+void test_function( int depth )
+{
+	if ( ( rand() & 0xf ) != 0 )
+	{
+		test_function( depth + 1 );
+	}
+	else
+	{
+		printf( "Reached depth %d, printing stack trace:\n", depth );
+		print_stacktrace();
+	}
+}
+
+int main()
+{
+	SystemInit();
+	funAnalogInit();
+	seed( funAnalogRead( 1 ) );
+
+	void *const initial_sp = get_stack_pointer();
+
+	printf( "Initial SP:  0x%lx\n", (uint32_t)initial_sp );
+
+	printf( "Stack Start: 0x%lx\n", (uint32_t)&_eusrstack );
+	printf( "Stack End:   0x%lx\n", (uint32_t)&end );
+
+	fill_canary( CANARY );
+
+	printf( "Hello, Stack Usage!\n" );
+
+	const void *const used_stack = get_stack_watermark( CANARY );
+	const size_t used_bytes = (size_t)initial_sp - (size_t)used_stack;
+	printf( "Used Stack: %u bytes\n", (unsigned int)used_bytes );
+
+	test_function( 0 );
+
+	while ( 1 )
+		;
+}


### PR DESCRIPTION
A simple example to show how you might go about measuring stack usage at runtime.
I've also added a call stack trace for fun.

The stack usage calculation may be off slightly.

Example output:
```
Terminal started

Initial SP:  0x200007ec
Stack Start: 0x20000800
Stack End:   0x20000008
Filling canary from 0x200007ec to 0x20000008
Hello, Stack Usage!
Used Stack: 52 bytes
Reached depth 17, printing stack trace:
Stack Trace:
  Frame 0: FP=0x200006ec, RA=0x8a4
  Frame 1: FP=0x200006fc, RA=0x8a4
  Frame 2: FP=0x2000070c, RA=0x8a4
  Frame 3: FP=0x2000071c, RA=0x8a4
  Frame 4: FP=0x2000072c, RA=0x8a4
  Frame 5: FP=0x2000073c, RA=0x8a4
  Frame 6: FP=0x2000074c, RA=0x8a4
  Frame 7: FP=0x2000075c, RA=0x8a4
  Frame 8: FP=0x2000076c, RA=0x8a4
  Frame 9: FP=0x2000077c, RA=0x8a4
  Frame 10: FP=0x2000078c, RA=0x8a4
  Frame 11: FP=0x2000079c, RA=0x8a4
  Frame 12: FP=0x200007ac, RA=0x8a4
  Frame 13: FP=0x200007bc, RA=0x8a4
  Frame 14: FP=0x200007cc, RA=0x8a4
  Frame 15: FP=0x200007dc, RA=0x8a4
  Frame 16: FP=0x200007ec, RA=0x8a4
  Frame 17: FP=0x20000800, RA=0xa84
Done

Minichlink Closing
```