### PR TITLE
Add CH5xx support to PIO integration

### DIFF
--- a/.github/gen_ldscript.py
+++ b/.github/gen_ldscript.py
@@ -8,9 +8,20 @@ def get_ld_defines(chip_name: str):
     target_mcu: str = ""
     mcu_package: int = 0
     target_mcu_ld: int = 0
-    if chip_name.startswith("ch32v003"):
-        target_mcu = "CH32V003"
-        target_mcu_ld = 0
+    if chip_name.startswith("ch32v00"):
+        target_mcu = chip_name.upper()[0:len("ch32v00x")]
+        mcu_package = 1
+        if "003" in chip_name:
+            target_mcu_ld = 0
+        elif "002" in chip_name:
+            target_mcu_ld = 5
+        elif "004" in chip_name or "005" in chip_name:
+            target_mcu_ld = 6
+        elif "006" in chip_name or "007" in chip_name:
+            target_mcu_ld = 7
+        else:
+            sys.stdout.write("Unknown CH32V00x variant %s\n" % chip_name)
+            env.Exit(-1)
     else:
         mcu_package = 1
         if chip_name.startswith("ch32v10"):
@@ -90,8 +101,57 @@ def get_ld_defines(chip_name: str):
             elif "rb" in chip_name:
                 mcu_package = 2
             target_mcu_ld = 3
+        elif chip_name.startswith("ch57"):
+            # CH570 / CH571 / CH572 / CH573
+            target_mcu = "CH57X"
+            if "570" in chip_name:
+                mcu_package = 0
+            elif "571" in chip_name:
+                mcu_package = 1
+            elif "572" in chip_name:
+                mcu_package = 2
+            elif "573" in chip_name:
+                mcu_package = 3
+            else:
+                sys.stdout.write("Unknown CH57x variant %s\n" % chip_name)
+                env.Exit(-1)
+            target_mcu_ld = 10
+        elif chip_name.startswith("ch58"):
+            # CH582 / CH583 / CH584 / CH585
+            target_mcu = "CH58X"
+            if "582" in chip_name:
+                mcu_package = 2
+            elif "583" in chip_name:
+                mcu_package = 3
+            elif "584" in chip_name:
+                mcu_package = 4
+            elif "585" in chip_name:
+                mcu_package = 5
+            else:
+                sys.stdout.write("Unknown CH58x variant %s\n" % chip_name)
+                env.Exit(-1)
+            target_mcu_ld = 8
+        elif chip_name.startswith("ch59"):
+            # CH591 / CH592
+            target_mcu = "CH59X"
+            if "591" in chip_name:
+                mcu_package = 1
+            elif "592" in chip_name:
+                mcu_package = 2
+            else:
+                sys.stdout.write("Unknown CH59x variant %s\n" % chip_name)
+                env.Exit(-1)
+            target_mcu_ld = 9
+        elif chip_name.startswith("ch32h41"):
+            target_mcu = chip_name.upper()[0:len("ch32h41x")]
+            mcu_package = 1
+            if "416" in chip_name:
+                mcu_package = 2
+            elif "415" in chip_name:
+                mcu_package = 3
+            target_mcu_ld = 11
         else:
-            sys.stdout.write("Unkonwn MCU %s\n" % chip_name)
+            sys.stdout.write("Unknown MCU %s\n" % chip_name)
             env.Exit(-1)
     return (target_mcu, mcu_package, target_mcu_ld)
 
@@ -100,6 +160,15 @@ board = env.BoardConfig()
 chip_name = str(board.get("build.mcu", "")).lower()
 # retrieve needed macro values
 target_mcu, mcu_package, target_mcu_ld = get_ld_defines(chip_name)
+
+# some header files also use these macros, so inject them
+env.Append(
+    CPPDEFINES=[
+        ("TARGET_MCU", target_mcu),
+        ("MCU_PACKAGE", mcu_package),
+        ("TARGET_MCU_LD", target_mcu_ld)
+    ]
+)
 
 # Let the LD script be generated right before the .elf is built
 env.AddPreAction(

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,12 +8,18 @@ platform = https://github.com/Community-PIO-CH32V/platform-ch32v.git
 monitor_speed = 115200
 ; default upload and debug protocol is "wch-link", using OpenOCD and
 ; expecting a WCH-LinkE programming adapter.
-; To use minichlink, uncomment this
+; To use minichlink (handles WCH-Link(E), USB ISP and some others), uncomment this
 ;upload_protocol = minichlink
+; can also use minichlink for SWD debugging. beware: step over not working
+; correctly, only use "set breakpoint" and "continue".
+;debug_tool = minichlink
 ; additionally uncomment this to use ardulink on a specific COM port
 ;upload_flags =
 ;  -c
 ;  COM3
+; to use USB ISP uploader (usually for CH5xx, V20x, V30x), uncomment this
+; remember to replug the device in bootloader mode for it to be visible
+;upload_protocol = isp
 
 ; for examples that use ch32fun as their base
 [fun_base]
@@ -50,6 +56,17 @@ extends = fun_base
 build_flags = ${fun_base.build_flags} -DCH32X03x -std=gnu11
 build_unflags = -std=gnu99
 board = genericCH32X035C8T6
+
+[fun_base_5xx]
+extends = fun_base
+build_flags = ${fun_base.build_flags} -DCH5xx -std=gnu11
+build_unflags = -std=gnu99
+; select the exact chip here!
+;board = genericCH570D
+;board = genericCH572Q
+;board = genericCH573F
+board = genericCH582F
+;board = genericCH592X
 
 ; If creating a new example:
 ; 1. Add new [env:name]
@@ -297,3 +314,27 @@ build_src_filter = ${fun_base.build_src_filter} +<examples_x035/usbdevice/usbdev
 [env:x035_usbpd_sink]
 extends = fun_base_x035
 build_src_filter = ${fun_base.build_src_filter} +<examples_x035/usbpd_sink/usbpd_sink.c>
+
+[env:ch5xx_blink]
+extends = fun_base_5xx
+build_src_filter = ${fun_base.build_src_filter} +<examples_ch5xx/blink>
+
+[env:ch5xx_usbfs_cdc_tty]
+extends = fun_base_5xx
+build_src_filter = ${fun_base.build_src_filter} +<examples_usb/USBFS/usbfs_cdc_tty>
+
+[env:ch5xx_boot_button]
+extends = fun_base_5xx
+build_src_filter = ${fun_base.build_src_filter} +<examples_ch5xx/boot_button>
+
+[env:ch5xx_ble_beacon]
+extends = fun_base_5xx
+build_src_filter = ${fun_base.build_src_filter} +<examples_ch5xx/ble_beacon>
+
+[env:ch5xx_iSLER]
+extends = fun_base_5xx
+build_src_filter = ${fun_base.build_src_filter} +<examples_ch5xx/iSLER>
+
+[env:ch5xx_debugprintfdemo]
+extends = fun_base_5xx
+build_src_filter = ${fun_base.build_src_filter} +<examples_ch5xx/debugprintfdemo>


### PR DESCRIPTION
Adds CH5xx compilation support into the supporting PlatformIO scripts, along with syncing others (ch32v00x, ch32hxx). Supporting chip identification macros have been added in https://github.com/Community-PIO-CH32V/platform-ch32v/commit/4dfe4d53ce157c98c288f6ed416b6a448522e7b7. 

Tested against CH582F board. Working blinky, USB printf, BLE beacon and iSLEr and firmware.

<img width="540" height="762" alt="grafik" src="https://github.com/user-attachments/assets/528913b4-7a12-4c19-af90-fae766961ff0" />
