### PR TITLE
Fix C function declaration being included for assembler files

### DIFF
--- a/ch32fun/ch32fun.h
+++ b/ch32fun/ch32fun.h
@@ -896,18 +896,6 @@ extern "C" {
 #define TimeElapsed32(now,start)  ((int32_t)((uint32_t)(now)-(uint32_t)(start)))
 #define TimeElapsed32u(now,start)  ((uint32_t)((uint32_t)(now)-(uint32_t)(start)))
 
-// #define funSysTick32() is defined per-architecture.
-
-// Get a 64-bit timestamp.  Please in general try to use 32-bit timestamps
-// whenever possible.  Use functions that automatically handle rollover
-// correctly like TimeElapsed32( start, end ).  Only use this in cases where
-// you must act on time periods exceeding 2^31 ticks.
-//
-// Also, if you are on a platform without a hardware 64-bit timer, you must
-// call this function at least once every 2^32 ticks to make sure MSBs aren't
-// lost.
-uint64_t funSysTick64( void );
-
 // Add a certain number of nops.  Note: These are usually executed in pairs
 // and take two cycles, so you typically would use 0, 2, 4, etc.
 #define ADD_N_NOPS( n ) asm volatile( ".rept " #n "\nc.nop\n.endr" );
@@ -1045,6 +1033,17 @@ void DefaultIRQHandler( void ) __attribute__((section(VECTOR_HANDLER_SECTION))) 
 
 void DelaySysTick( uint32_t n );
 
+// #define funSysTick32() is defined per-architecture.
+
+// Get a 64-bit timestamp.  Please in general try to use 32-bit timestamps
+// whenever possible.  Use functions that automatically handle rollover
+// correctly like TimeElapsed32( start, end ).  Only use this in cases where
+// you must act on time periods exceeding 2^31 ticks.
+//
+// Also, if you are on a platform without a hardware 64-bit timer, you must
+// call this function at least once every 2^32 ticks to make sure MSBs aren't
+// lost.
+uint64_t funSysTick64( void );
 
 // Depending on a LOT of factors, it's about 6 cycles per n.
 // **DO NOT send it zero or less.**


### PR DESCRIPTION
Fixes rv003usb's inability to build against the latest ch32fun framework version.

Breakage introduced in https://github.com/cnlohr/ch32fun/pull/837 by cnlohr.

https://github.com/cnlohr/rv003usb/blob/69729219e526156aba57985224adcc5869e6854d/rv003usb/rv003usb.S#L3

Before:

```
Compiling .pio\build\genericCH32V003F4U6\rv003usbASM\rv003usb.o
Compiling .pio\build\genericCH32V003F4U6\lib788\rv003usb\rv003usb.o
Compiling .pio\build\genericCH32V003F4U6\src\demo_composite_hid.o
C:\Users\Max\.platformio\packages\framework-ch32v003fun\ch32fun/ch32fun.h: Assembler messages:
C:\Users\Max\.platformio\packages\framework-ch32v003fun\ch32fun/ch32fun.h:909: Error: unrecognized opcode `uint64_t funSysTick64(void)'
*** [.pio\build\genericCH32V003F4U6\rv003usbASM\rv003usb.o] Error 1
```

After:

```c
Compiling .pio\build\genericCH32V003F4U6\rv003usbASM\rv003usb.o
Compiling .pio\build\genericCH32V003F4U6\lib788\rv003usb\rv003usb.o
Compiling .pio\build\genericCH32V003F4U6\src\demo_composite_hid.o
C:\Users\Max\.platformio\packages\framework-ch32v003fun\ch32fun\ch32fun.c: In function 'funSysTick64':
C:\Users\Max\.platformio\packages\framework-ch32v003fun\ch32fun\ch32fun.c:1905:11: warning: format '%d' expects argument of type 'int', but argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
 1905 | printf( "%d %d\n", lastBase, high );
      |          ~^        ~~~~~~~~
      |           |        |
      |           int      uint32_t {aka long unsigned int}
      |          %ld
C:\Users\Max\.platformio\packages\framework-ch32v003fun\ch32fun\ch32fun.c:1905:14: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
 1905 | printf( "%d %d\n", lastBase, high );
      |             ~^               ~~~~
      |              |               |
      |              int             uint32_t {aka long unsigned int}
      |             %ld
Building C:\Users\Max\.platformio\platforms\ch32v\examples\ch32fun-rv003usb-composite-hid\.pio\build\genericCH32V003F4U6\ldscript.ld
Linking .pio\build\genericCH32V003F4U6\firmware.elf
Building C:\Users\Max\.platformio\platforms\ch32v\examples\ch32fun-rv003usb-composite-hid\.pio\build\genericCH32V003F4U6/firmware.lst
Building C:\Users\Max\.platformio\platforms\ch32v\examples\ch32fun-rv003usb-composite-hid\.pio\build\genericCH32V003F4U6/firmware.debug.lst
Checking size .pio\build\genericCH32V003F4U6\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [=         ]   7.0% (used 144 bytes from 2048 bytes)
Flash: [==        ]  15.6% (used 2556 bytes from 16384 bytes)
Building .pio\build\genericCH32V003F4U6\firmware.bin
=============================================================================== [SUCCESS] Took 3.90 seconds ===============================================================================
```