### PR TITLE
Add H41x build support to PlatformIO project file

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -68,6 +68,19 @@ build_unflags = -std=gnu99
 board = genericCH582F
 ;board = genericCH592X
 
+[fun_base_h41x]
+extends = fun_base
+; for a yet unknown reason, firmware does not work with -msave-restore. disable it.
+build_flags = ${fun_base.build_flags} -DCH32H417 -DDISABLED_FLOAT -std=gnu11 -mno-save-restore
+build_unflags = -std=gnu99 -msave-restore
+; for floating point support, comment above build_flags and uncomment these 
+;build_flags = ${fun_base.build_flags} -DCH32H417 -std=gnu11  -mno-save-restore
+;board_build.march = rv32imafc_zba_zbb_zbc_zbs_xw
+;board_build.mabi = ilp32f
+
+; select the exact chip here!
+board = genericCH32H417QEU6
+
 ; If creating a new example:
 ; 1. Add new [env:name]
 ; 2. Set the extends to the fun_base_{003, 103, 203, 307, x035} as needed
@@ -338,3 +351,23 @@ build_src_filter = ${fun_base.build_src_filter} +<examples_ch5xx/iSLER>
 [env:ch5xx_debugprintfdemo]
 extends = fun_base_5xx
 build_src_filter = ${fun_base.build_src_filter} +<examples_ch5xx/debugprintfdemo>
+
+[env:h41x_blink_and_mco]
+extends = fun_base_h41x
+build_src_filter = ${fun_base.build_src_filter} +<examples_h41x/blink_and_mco>
+
+[env:h41x_debugprintfdemo]
+extends = fun_base_h41x
+build_src_filter = ${fun_base.build_src_filter} +<examples_h41x/debugprintfdemo>
+
+[env:h41x_dual_hello_world]
+extends = fun_base_h41x
+build_src_filter = ${fun_base.build_src_filter} +<examples_h41x/dual_hello_world>
+
+[env:h41x_regular]
+extends = fun_base_h41x
+build_src_filter = ${fun_base.build_src_filter} +<examples_h41x/regular>
+
+[env:h41x_uartdemo]
+extends = fun_base_h41x
+build_src_filter = ${fun_base.build_src_filter} +<examples_h41x/uartdemo>


### PR DESCRIPTION
Not ready to merge yet because the H41x firmware just crashes or hangs after some time (as does it with the firmware built by the regular `make`), likely because of per-CPU SysTick discrepencies.

Otherwise, it does build the firmware normally, supporting both the floating point and non-floating point type.