### PR TITLE
Add USBD extralib, CDC TTY usbprintf demo

### DIFF
--- a/examples_usb/README.md
+++ b/examples_usb/README.md
@@ -1,3 +1,7 @@
 # Universal USB examples
 
-This folder contains examples for different USB peripherals that can be found in WCH RiscV chips. Currently there are 3 implementations of USB 2.0 protocol in WHC's hardware: USBFS, USBD and USBHS. The most common of them is USBFS - it can be found in all chips that have hardware USB. It can be used in a device mode and in most cases also in host mode. USBD can only be used in device mode and it has different impelemtation. USBHS (USBHD) is only present on CH32V305/307/317 and also on CH585.
+This folder contains examples for different USB peripherals that can be found in WCH RiscV chips. Currently there are 3 implementations of USB 2.0 protocol in WHC's hardware: USBFS, USBD and USBHS.
+The most common of them is USBFS - it can be found in all chips that have hardware USB. It can be used in a device mode and in most cases also in host mode.
+USBD can only be used in device mode and it has different impelemtation. USBHS (USBHD) is only present on CH32V305/307/317 and also on CH585.
+There is one USBD example (tty), to show that it is possible to work with the peripheral, but if possible avoid it and use one of the others.
+This was only added to support USB on those awesome and cheap v208 Ethernet boards that have the wrong USB pins brought out.

--- a/examples_usb/USBD/usbd_cdc_tty/Makefile
+++ b/examples_usb/USBD/usbd_cdc_tty/Makefile
@@ -1,0 +1,10 @@
+all : flash
+
+TARGET:=usbd_cdc_tty
+TARGET_MCU:=CH32V208
+TARGET_MCU_PACKAGE:=CH32V208WBU6
+
+include ../../../ch32fun/ch32fun.mk
+
+flash : cv_flash
+clean : cv_clean

--- a/examples_usb/USBD/usbd_cdc_tty/README.md
+++ b/examples_usb/USBD/usbd_cdc_tty/README.md
@@ -1,0 +1,2 @@
+# USB CDC TTY
+This example creates a `/dev/ttyACM0` (or higher number if something went wrong on 0) which you can monitor for messages, and send simple one-character commands to.

--- a/examples_usb/USBD/usbd_cdc_tty/funconfig.h
+++ b/examples_usb/USBD/usbd_cdc_tty/funconfig.h
@@ -1,0 +1,10 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+#define FUNCONF_USE_DEBUGPRINTF     0 // can only have one printf
+#define FUNCONF_DEBUG_HARDFAULT     0
+#define FUNCONF_USE_USBPRINTF       1
+#define FUNCONF_USE_HSI             0
+#define FUNCONF_USE_HSE             1
+
+#endif

--- a/examples_usb/USBD/usbd_cdc_tty/usb_config.h
+++ b/examples_usb/USBD/usbd_cdc_tty/usb_config.h
@@ -1,0 +1,172 @@
+#ifndef _USB_CONFIG_H
+#define _USB_CONFIG_H
+
+#include "funconfig.h"
+#include "ch32fun.h"
+
+#define FUSB_CONFIG_EPS       4 // Include EP0 in this count
+#define FUSB_EP1_MODE         1 // TX (IN)
+#define FUSB_EP2_MODE        -1 // RX (OUT)
+#define FUSB_EP3_MODE         1 // TX (IN)
+#define FUSB_USER_HANDLERS    1
+
+#include "usb_defines.h"
+
+#define FUSB_USB_VID 0x1209
+#define FUSB_USB_PID 0xd035
+#define FUSB_USB_REV 0x0007
+#define FUSB_STR_MANUFACTURER u"ch32fun"
+#define FUSB_STR_PRODUCT      u"USB TTY"
+#define FUSB_STR_SERIAL       u"007"
+
+//Taken from http://www.usbmadesimple.co.uk/ums_ms_desc_dev.htm
+static const uint8_t device_descriptor[] = {
+	18, //bLength - Length of this descriptor
+	1,  //bDescriptorType - Type (Device)
+	0x10, 0x01, //bcdUSB - The highest USB spec version this device supports (USB1.1)
+	0x02, //bDeviceClass - Device Class
+	0x0, //bDeviceSubClass - Device Subclass
+	0x0, //bDeviceProtocol - Device Protocol  (000 = use config descriptor)
+	64, //bMaxPacketSize - Max packet size for EP0
+  (uint8_t)(FUSB_USB_VID), (uint8_t)(FUSB_USB_VID >> 8), //idVendor - ID Vendor
+	(uint8_t)(FUSB_USB_PID), (uint8_t)(FUSB_USB_PID >> 8), //idProduct - ID Product
+	(uint8_t)(FUSB_USB_REV), (uint8_t)(FUSB_USB_REV >> 8), //bcdDevice - Device Release Number
+	1, //iManufacturer - Index of Manufacturer string
+	2, //iProduct - Index of Product string
+	3, //iSerialNumber - Index of Serial string
+	1, //bNumConfigurations - Max number of configurations (if more then 1, you can switch between them)
+};
+
+/* Configuration Descriptor Set */
+static const uint8_t config_descriptor[ ] =
+{
+  0x09,        // bLength
+  0x02,        // bDescriptorType (Configuration)
+  0x43, 0x00,  // wTotalLength 67
+  0x02,        // bNumInterfaces 2
+  0x01,        // bConfigurationValue
+  0x00,        // iConfiguration (String Index)
+  0x80,        // bmAttributes
+  0x32,        // bMaxPower 100mA
+
+  0x09,        // bLength
+  0x04,        // bDescriptorType - Interface
+  0x00,        // bInterfaceNumber - 0
+  0x00,        // bAlternateSetting
+  0x01,        // bNumEndpoints - 1
+  0x02,        // bInterfaceClass - CDC
+  0x02,        // bInterfaceSubClass - Abstract Control Model (Table 4 in CDC120.pdf)
+  0x01,        // bInterfaceProtocol - AT Commands: V.250 etc (Table 5)
+  0x00,        // iInterface (String Index)
+
+  // Setting up CDC interface (Table 18)
+  0x05,        // bLength
+  0x24,        // bDescriptorType - CS_INTERFACE (Table 12)
+  0x00,        // bDescriptorSubType - Header Functional Descriptor (Table 13)
+  0x10, 0x01,  // bcdCDC - USB version - USB1.1
+  // Call Management Functional Descriptor
+  0x05,        // bLength
+  0x24,        // bDescriptorType - CS_INTERFACE
+  0x01,        // bDescriptorSubType - Call Management Functional Descriptor (Table 13)
+  0x00,        // bmCapabilities: (Table 3 in PSTN120.pdf)
+  // Bit 0 — Device handles call management itself:
+  //  1 = device handles call management (e.g. call setup, termination, etc.)
+  //  0 = host handles it
+  // Bit 1 — Device can send/receive call management information over a Data Class interface:
+  //  1 = can use the Data Class interface for call management
+  //  0 = must use the Communication Class interface
+  0x01,        // bDataInterface - Indicates that multiplexed commands are handled via data interface 01h (same value as used in the UNION Functional Descriptor)
+  // Abstract Control Management Functional Descriptor
+  0x04,        // bLength
+  0x24,        // bDescriptorType - CS_INTERFACE
+  0x02,        // bDescriptorSubType - Abstract Control Management Functional Descriptor (Table 13)
+  0x02,        // bmCapabilities - Device supports the request combination of Set_Line_Coding, Set_Control_Line_State, Get_Line_Coding, and the notification Serial_State (Table 4 in PSTN120.pdf)
+  // Union Descriptor Functional Descriptor
+  0x05,        // bLength
+  0x24,        // bDescriptorType - CS_INTERFACE
+  0x06,        // bDescriptorSubType - Union Descriptor Functional Descriptor (Table 13)
+  0x00,        // bControlInterface (Interface number of the control (Communications Class) interface)
+  0x01,        // bSubordinateInterface0 (Interface number of the subordinate (Data Class) interface)
+  // Setting up EP1 for CDC config interface 
+  0x07,        // bLength
+  0x05,        // bDescriptorType (Endpoint)
+  0x81,        // bEndpointAddress (IN/D2H)
+  0x03,        // bmAttributes (Interrupt)
+  0x40, 0x00,  // wMaxPacketSize 64
+  0x01,        // bInterval 1 (unit depends on device speed)
+
+  // Transmission interface with two bulk endpoints
+  0x09,        // bLength
+  0x04,        // bDescriptorType (Interface)
+  0x01,        // bInterfaceNumber 1
+  0x00,        // bAlternateSetting
+  0x02,        // bNumEndpoints 2
+  0x0A,        // bInterfaceClass
+  0x00,        // bInterfaceSubClass
+  0x00,        // bInterfaceProtocol - Transparent
+  0x00,        // iInterface (String Index)
+  // EP2 - device to host
+  0x07,        // bLength
+  0x05,        // bDescriptorType (Endpoint)
+  0x02,        // bEndpointAddress (OUT/H2D)
+  0x02,        // bmAttributes (Bulk)
+  0x40, 0x00,  // wMaxPacketSize 64
+  0x00,        // bInterval 0 (unit depends on device speed)
+  // EP3 - host to device
+  0x07,        // bLength
+  0x05,        // bDescriptorType (Endpoint)
+  0x83,        // bEndpointAddress (IN/D2H)
+  0x02,        // bmAttributes (Bulk)
+  0x40, 0x00,  // wMaxPacketSize 64
+  0x00,        // bInterval 0 (unit depends on device speed)
+
+  // 67 bytes
+};
+
+struct usb_string_descriptor_struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint16_t wString[];
+};
+const static struct usb_string_descriptor_struct language __attribute__((section(".rodata"))) = {
+	4,
+	3,
+	{0x0409}  // Language ID - English US (look in USB_LANGIDs)
+};
+const static struct usb_string_descriptor_struct string1 __attribute__((section(".rodata")))  = {
+	sizeof(FUSB_STR_MANUFACTURER),
+	3,  // bDescriptorType - String Descriptor (0x03)
+	FUSB_STR_MANUFACTURER
+};
+const static struct usb_string_descriptor_struct string2 __attribute__((section(".rodata")))  = {
+	sizeof(FUSB_STR_PRODUCT),
+	3,
+	FUSB_STR_PRODUCT
+};
+const static struct usb_string_descriptor_struct string3 __attribute__((section(".rodata")))  = {
+	sizeof(FUSB_STR_SERIAL),
+	3,
+	FUSB_STR_SERIAL
+};
+
+// This table defines which descriptor data is sent for each specific
+// request from the host (in wValue and wIndex).
+const static struct descriptor_list_struct {
+	uint32_t	lIndexValue;  // (uint16_t)Index of a descriptor in config or Language ID for string descriptors | (uint8_t)Descriptor type | (uint8_t)Type of string descriptor
+	const uint8_t	*addr;
+	uint8_t		length;
+} descriptor_list[] = {
+	{0x00000100, device_descriptor, sizeof(device_descriptor)},
+	{0x00000200, config_descriptor, sizeof(config_descriptor)},
+	// {0x00002100, config_descriptor + 18, 9 }, // Not sure why, this seems to be useful for Windows + Android.
+
+	{0x00000300, (const uint8_t *)&language, 4},
+	{0x04090301, (const uint8_t *)&string1, string1.bLength},
+	{0x04090302, (const uint8_t *)&string2, string2.bLength},
+	{0x04090303, (const uint8_t *)&string3, string3.bLength}
+};
+#define DESCRIPTOR_LIST_ENTRIES ((sizeof(descriptor_list))/(sizeof(struct descriptor_list_struct)) )
+
+
+#endif
+

--- a/examples_usb/USBD/usbd_cdc_tty/usbd_cdc_tty.c
+++ b/examples_usb/USBD/usbd_cdc_tty/usbd_cdc_tty.c
@@ -1,0 +1,76 @@
+#include "ch32fun.h"
+#include <stdio.h>
+#include <string.h>
+#include "usbd.h"
+
+#define PIN_LED PC0 // activity LED on rj45
+
+uint8_t run = 0; // print stuff or not
+
+void blink(int n) {
+	for(int i = n-1; i >= 0; i--) {
+		funDigitalWrite( PIN_LED, FUN_LOW ); // Turn on LED
+		Delay_Ms(33);
+		funDigitalWrite( PIN_LED, FUN_HIGH ); // Turn off LED
+		if(i) Delay_Ms(33);
+	}
+}
+
+// this is hacky, it implements the USBFS sender called in ch32fun.c
+// we do it like this for now, because the USBFS peripheral is preferred
+// over the USBD interface implemented here
+int USBFS_SendEndpointNEW( int endp, uint8_t* data, int len, int copy) {
+	return USBD_SendEndpoint(endp, data, len);
+}
+
+// this callback is mandatory when FUNCONF_USE_USBPRINTF is defined,
+// can be empty though
+void handle_usbd_input(int numbytes, uint8_t *data) {
+	if(numbytes == 1) {
+		switch(data[0]) {
+		case '1':
+			blink(1);
+			break;
+		case '2':
+			blink(2);
+			break;
+		case '3':
+			blink(3);
+			break;
+		case 'c':
+			run = 1;
+			break;
+		case 'p':
+			run = 0;
+			break;
+		}
+	}
+	else {
+		_write(0, (const char*)data, numbytes);
+	}
+}
+
+
+int main()
+{
+	SystemInit();
+
+	funGpioInitAll();
+
+	funPinMode( PIN_LED, GPIO_CFGLR_OUT_10Mhz_PP ); // Set PIN_LED to output
+
+	USBDSetup();
+	blink(5);
+	printf("CPU speed: %dMHz\n", ((FUNCONF_SYSTEM_CORE_CLOCK)/1000000));
+
+	int i = 0;
+	while(1) {
+		poll_input(); // check if there is input from the tty
+
+		if(run) {
+			printf("Counting: %d\r", i++);
+		}
+
+		Delay_Ms(100);
+	}
+}

--- a/extralibs/usbd.c
+++ b/extralibs/usbd.c
@@ -1,0 +1,527 @@
+#include "usbd.h"
+#include <string.h>
+
+// loosely based on https://github.com/ArcaneNibble/wch-uf2/blob/main/bootloader.c
+// this would not exist if it was not for ArcaneNibble's efforts (I don't know how else to credit that)
+
+struct _USBState USBDCTX;
+
+#define BTABLE_OFFSET 0
+
+static void PMA_Write(uint16_t pma_addr, const uint8_t *buffer, int len) {
+	volatile uint32_t *pma = (volatile uint32_t *)(USBD_PMA_BASE + pma_addr);
+	for (int i = 0; i < len; i += 2) {
+		uint16_t val = buffer[i];
+		if (i + 1 < len) {
+			val |= (uint16_t)buffer[i + 1] << 8;
+		}
+		*pma++ = val;
+	}
+}
+
+static void PMA_Read(uint16_t pma_addr, uint8_t *buffer, int len) {
+	volatile uint32_t *pma = (volatile uint32_t *)(USBD_PMA_BASE + pma_addr);
+	for (int i = 0; i < len; i += 2) {
+		uint32_t val = *pma++;
+		buffer[i] = val & 0xFF;
+		if (i + 1 < len) {
+			buffer[i + 1] = (val >> 8) & 0xFF;
+		}
+	}
+}
+
+static void SetPMA_TxCount(int ep, int count) {
+	int pma_idx = (ep *4) + 1;
+	((uint32_t*)USBD_PMA_BASE)[pma_idx] = count;
+}
+
+static int GetPMA_RxCount(int ep) {
+	int pma_idx = (ep *4) + 3;
+	return ((uint32_t*)USBD_PMA_BASE)[pma_idx] & 0x3FF;
+}
+
+static inline void SetEPR_Status(int ep, uint16_t mask, uint16_t value) {
+	uint16_t reg = USBD->EPR[ep];
+	uint16_t current_stat = reg & mask;
+	uint16_t toggle = current_stat ^ value;
+	
+	uint16_t write_val = (reg & (USBD_EPR_EA | USBD_EPR_EP_TYPE_MASK | USBD_EPR_EP_KIND));
+	write_val |= toggle;
+	write_val |= (USBD_EPR_CTR_RX | USBD_EPR_CTR_TX);
+	
+	USBD->EPR[ep] = write_val;
+}
+
+static inline void SetEPR_TxStatus(int ep, uint16_t status) {
+	SetEPR_Status(ep, USBD_EPR_STAT_TX_MASK, status);
+}
+
+static inline void SetEPR_RxStatus(int ep, uint16_t status) {
+	SetEPR_Status(ep, USBD_EPR_STAT_RX_MASK, status);
+}
+
+// ISR
+void USB_LP_CAN1_RX0_IRQHandler(void) __attribute__((interrupt));
+void USB_LP_CAN1_RX0_IRQHandler(void) {
+	uint32_t istr = USBD->ISTR;
+
+	if (istr & USBD_ISTR_CTR) {
+		// Correct Transfer
+		int ep = istr & USBD_ISTR_EP_ID;
+		uint32_t epr = USBD->EPR[ep];
+
+		if (epr & USBD_EPR_CTR_RX) {
+			// Setup or Out
+			if (ep == 0 && (epr & USBD_EPR_SETUP)) {
+				// SETUP Packet
+				PMA_Read(USBDCTX.pma_offset[0][1], CTRL0BUFF, 8);
+
+				USBDCTX.pCtrlPayloadPtr = 0;
+
+				// Parse
+				USBDCTX.USBD_SetupReqType = pUSBD_SetupReqPak->bmRequestType;
+				USBDCTX.USBD_SetupReqCode = pUSBD_SetupReqPak->bRequest;
+				USBDCTX.USBD_SetupReqLen = pUSBD_SetupReqPak->wLength;
+				USBDCTX.USBD_IndexValue = (pUSBD_SetupReqPak->wIndex << 16) | pUSBD_SetupReqPak->wValue;
+
+				int len = 0;
+
+				if ((USBDCTX.USBD_SetupReqType & USB_REQ_TYP_MASK) == USB_REQ_TYP_STANDARD) {
+					switch (USBDCTX.USBD_SetupReqCode) {
+					case USB_GET_DESCRIPTOR:
+						// Simple Descriptor Search (User must define descriptor_list and DESCRIPTOR_LIST_ENTRIES)
+						const struct descriptor_list_struct *e = descriptor_list;
+						const struct descriptor_list_struct *e_end = e + DESCRIPTOR_LIST_ENTRIES;
+						int found = 0;
+						for (; e != e_end; e++) {
+							if (e->lIndexValue == USBDCTX.USBD_IndexValue) {
+								USBDCTX.pCtrlPayloadPtr = (uint8_t*)e->addr;
+								len = e->length;
+								found = 1;
+								break;
+							}
+						}
+						if(!found) {
+							goto stall;
+						}
+						
+						if (len > USBDCTX.USBD_SetupReqLen) {
+							len = USBDCTX.USBD_SetupReqLen;
+						}
+						USBDCTX.USBD_SetupReqLen = len;
+						
+						// Send first chunk
+						int send_len = (len > DEF_USBD_UEP0_SIZE) ? DEF_USBD_UEP0_SIZE : len;
+						PMA_Write(USBDCTX.pma_offset[0][0], USBDCTX.pCtrlPayloadPtr, send_len);
+						SetPMA_TxCount(0, send_len);
+						SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+						USBDCTX.pCtrlPayloadPtr += send_len;
+						USBDCTX.USBD_SetupReqLen -= send_len;
+						break;
+
+					case USB_SET_ADDRESS:
+						USBDCTX.USBD_DevAddr = (uint8_t)(USBDCTX.USBD_IndexValue & 0xFF);
+						// Zero Length Packet IN
+						SetPMA_TxCount(0, 0);
+						SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+						break;
+
+					case USB_SET_CONFIGURATION:
+						 USBDCTX.USBD_DevConfig = (uint8_t)(USBDCTX.USBD_IndexValue & 0xFF);
+						 USBDCTX.USBD_DevEnumStatus = 1;
+						 SetPMA_TxCount(0, 0);
+						 SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+						 break;
+
+					case USB_GET_STATUS:
+						CTRL0BUFF[0] = 0x00;
+						CTRL0BUFF[1] = 0x00;
+						PMA_Write(USBDCTX.pma_offset[0][0], CTRL0BUFF, 2);
+						SetPMA_TxCount(0, 2);
+						SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+						// We sent everything, set remaining len to 0 so CTR_TX enables RX for Status Stage
+						USBDCTX.USBD_SetupReqLen = 0; 
+						break;
+
+					case USB_GET_INTERFACE:
+						CTRL0BUFF[0] = 0x00;
+						PMA_Write(USBDCTX.pma_offset[0][0], CTRL0BUFF, 1);
+						SetPMA_TxCount(0, 1);
+						SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+						USBDCTX.USBD_SetupReqLen = 0; 
+						break;
+
+					case USB_GET_CONFIGURATION:
+						CTRL0BUFF[0] = USBDCTX.USBD_DevConfig;
+						PMA_Write(USBDCTX.pma_offset[0][0], CTRL0BUFF, 1);
+						SetPMA_TxCount(0, 1);
+						SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+						USBDCTX.USBD_SetupReqLen = 0; 
+						break;
+
+					default:
+						// Basic ACK for unhandled standards
+						SetPMA_TxCount(0, 0);
+						SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+						break;
+					}
+				}
+				else {
+					// Vendor/Class
+#if FUSB_USER_HANDLERS
+					len = HandleSetupCustom(&USBDCTX, USBDCTX.USBD_SetupReqCode);
+					if (len >= 0) {
+						if (USBDCTX.USBD_SetupReqType & DEF_UEP_IN) {
+							USBDCTX.USBD_SetupReqLen = len;
+							int send_len = (len > DEF_USBD_UEP0_SIZE) ? DEF_USBD_UEP0_SIZE : len;
+							
+							if(USBDCTX.pCtrlPayloadPtr) {
+								PMA_Write(USBDCTX.pma_offset[0][0], USBDCTX.pCtrlPayloadPtr, send_len);
+							}
+							else {
+								PMA_Write(USBDCTX.pma_offset[0][0], CTRL0BUFF, send_len);
+							}
+
+							SetPMA_TxCount(0, send_len);
+							SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+							USBDCTX.pCtrlPayloadPtr += send_len;
+							USBDCTX.USBD_SetupReqLen -= send_len;
+						}
+						else {
+							// OUT Data expected or Just Status IN
+							if (USBDCTX.USBD_SetupReqLen > 0) {
+								SetEPR_RxStatus(0, USBD_EPR_STAT_RX_VALID);
+								SetEPR_TxStatus(0, USBD_EPR_STAT_TX_NAK);
+							}
+							else {
+								SetPMA_TxCount(0, 0);
+								SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+							}
+						}
+					}
+					else {
+						goto stall;
+					}
+#else
+					goto stall;
+#endif
+				}
+			}
+			else {
+				// OUT Packet
+				int rx_len = GetPMA_RxCount(ep);
+				PMA_Read(USBDCTX.pma_offset[ep][1], USBDCTX.ENDPOINTS[ep], rx_len);
+
+				if (ep == 0) {
+					if(USBDCTX.USBD_SetupReqLen > 0) {
+						// Data Stage OUT
+
+						USBDCTX.USBD_SetupReqLen -= rx_len;
+						// Handle Data...
+#if FUSB_USER_HANDLERS
+						HandleDataOut(&USBDCTX, 0, USBDCTX.ENDPOINTS[0], rx_len);
+#endif
+						if (USBDCTX.USBD_SetupReqLen <= 0) {
+							// Status Stage IN
+							USBDCTX.USBD_SetupReqLen = 0; // Ensure clean state
+							SetPMA_TxCount(0, 0);
+							SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+							SetEPR_RxStatus(0, USBD_EPR_STAT_RX_VALID);
+						}
+						else {
+							SetEPR_RxStatus(0, USBD_EPR_STAT_RX_VALID);
+						}
+					}
+					else {
+						// Status Stage OUT (for IN transfer)
+						// Just ACK
+						SetEPR_RxStatus(0, USBD_EPR_STAT_RX_VALID);
+					}
+				}
+				else {
+#if FUSB_USER_HANDLERS
+					HandleDataOut(&USBDCTX, ep, USBDCTX.ENDPOINTS[ep], rx_len);
+#endif
+					SetEPR_RxStatus(ep, USBD_EPR_STAT_RX_VALID);
+				}
+			}
+
+			// Clear CTR_RX (Write 0 to RX, 1 to TX)
+			uint16_t wVal = USBD->EPR[ep] & (USBD_EPR_EA | USBD_EPR_EP_TYPE_MASK | USBD_EPR_EP_KIND);
+			USBD->EPR[ep] = wVal | USBD_EPR_CTR_TX;
+		}
+
+		if (epr & USBD_EPR_CTR_TX) {
+			// IN Complete
+			USBDCTX.USBD_Endp_Busy[ep] = 0;
+			
+			if (ep == 0) {
+				if (USBDCTX.USBD_SetupReqCode == USB_SET_ADDRESS) {
+					USBD->DADDR = 0x80 | USBDCTX.USBD_DevAddr;
+				}
+
+				if (USBDCTX.USBD_SetupReqLen > 0) {
+					// More data to send
+					int send_len = (USBDCTX.USBD_SetupReqLen > DEF_USBD_UEP0_SIZE) ? DEF_USBD_UEP0_SIZE : USBDCTX.USBD_SetupReqLen;
+					PMA_Write(USBDCTX.pma_offset[0][0], USBDCTX.pCtrlPayloadPtr, send_len);
+					SetPMA_TxCount(0, send_len);
+					SetEPR_TxStatus(0, USBD_EPR_STAT_TX_VALID);
+					USBDCTX.pCtrlPayloadPtr += send_len;
+					USBDCTX.USBD_SetupReqLen -= send_len;
+				}
+				else {
+					// End of transfer, ready for next SETUP
+					SetEPR_RxStatus(0, USBD_EPR_STAT_RX_VALID);
+				}
+			}
+			else {
+#if FUSB_USER_HANDLERS
+				HandleInRequest(&USBDCTX, ep, USBDCTX.ENDPOINTS[ep], 0);
+#endif
+			}
+
+			// Clear CTR_TX (Write 0 to TX, 1 to RX)
+			uint16_t wVal = USBD->EPR[ep] & (USBD_EPR_EA | USBD_EPR_EP_TYPE_MASK | USBD_EPR_EP_KIND);
+			USBD->EPR[ep] = wVal | USBD_EPR_CTR_RX;
+		}
+
+		USBD->ISTR = ~USBD_ISTR_CTR;
+		return;
+
+	stall:
+		SetEPR_TxStatus(0, USBD_EPR_STAT_TX_STALL);
+		SetEPR_RxStatus(0, USBD_EPR_STAT_RX_STALL);
+		// Clear CTR
+		uint16_t wVal = (epr & (USBD_EPR_EA | USBD_EPR_EP_TYPE_MASK | USBD_EPR_EP_KIND)); 
+		USBD->EPR[ep] = wVal; 
+	}
+
+	// Check for Reset
+	if (istr & USBD_ISTR_RESET) {
+		USBD->ISTR = ~USBD_ISTR_RESET;
+
+		// Reset Logic
+		USBD->BTABLE = BTABLE_OFFSET;
+		USBDCTX.USBD_DevConfig = 0;
+		USBDCTX.USBD_DevAddr = 0;
+		USBDCTX.USBD_DevEnumStatus = 0;
+
+		// Initialize Endpoints
+		for(int i = 0; i < FUSB_CONFIG_EPS; i++) {
+			USBDCTX.USBD_Endp_Busy[i] = 0;
+			// Clear EPR
+			USBD->EPR[i] = i;
+		}
+
+		// Configure EP0
+		SetEPR_Status(0, USBD_EPR_EP_TYPE_MASK, USBD_EPR_EP_TYPE_CTRL);
+		SetEPR_Status(0, USBD_EPR_STAT_RX_MASK, USBD_EPR_STAT_RX_VALID);
+		SetEPR_Status(0, USBD_EPR_STAT_TX_MASK, USBD_EPR_STAT_TX_NAK);
+
+		// Configure Other EPs based on FUSB_EPx_MODE
+		for(int i = 1; i < FUSB_CONFIG_EPS; i++) {
+			if (USBDCTX.endpoint_mode[i] != USBD_EP_OFF) {
+				// Set type Bulk (default for now, can be changed)
+				SetEPR_Status(i, USBD_EPR_EP_TYPE_MASK, USBD_EPR_EP_TYPE_BULK);
+				// Set address
+				USBD->EPR[i] = (USBD->EPR[i] & ~USBD_EPR_EA) | i;
+
+				if(USBDCTX.endpoint_mode[i] == USBD_EP_RX) {
+					SetEPR_RxStatus(i, USBD_EPR_STAT_RX_VALID);
+					SetEPR_TxStatus(i, USBD_EPR_STAT_TX_DIS);
+				}
+				else if(USBDCTX.endpoint_mode[i] == USBD_EP_TX) {
+					SetEPR_RxStatus(i, USBD_EPR_STAT_RX_DIS);
+					SetEPR_TxStatus(i, USBD_EPR_STAT_TX_NAK);
+				}
+			}
+		}
+
+		USBD->DADDR = 0x80; // Enable Function
+	}
+
+	// Check for Suspend
+	if (istr & USBD_ISTR_SUSP) {
+		USBD->ISTR = ~USBD_ISTR_SUSP;
+		USBDCTX.USBD_DevSleepStatus |= 0x02;
+		// Optional: Enter Low Power Mode here if FUSB_SUPPORTS_SLEEP is set
+		// USBD->CNTR |= USBD_CNTR_FSUSP;
+	}
+
+	// Check for Wakeup
+	if (istr & USBD_ISTR_WKUP) {
+		USBD->ISTR = ~USBD_ISTR_WKUP;
+		USBDCTX.USBD_DevSleepStatus &= ~0x02;
+		// USBD->CNTR &= ~USBD_CNTR_FSUSP;
+	}
+
+	// Check for ESOF (Expected Start Of Frame)
+	if (istr & USBD_ISTR_ESOF) {
+		USBD->ISTR = ~USBD_ISTR_ESOF;
+	}
+
+	// Check for SOF
+	if (istr & USBD_ISTR_SOF) {
+		USBD->ISTR = ~USBD_ISTR_SOF;
+	}
+
+	// Error!
+	if (istr & USBD_ISTR_ERR) {
+		USBD->ISTR = ~USBD_ISTR_ERR;
+	}
+
+	return;
+}
+
+void USBD_InternalFinishSetup() {
+	// Set BTABLE Address
+	USBD->BTABLE = BTABLE_OFFSET;
+
+	USBDCTX.endpoint_mode[0] = USBD_EP_RTX;
+	// Config from defines
+#if FUSB_EP1_MODE
+	USBDCTX.endpoint_mode[1] = FUSB_EP1_MODE;
+#endif
+#if FUSB_EP2_MODE
+	USBDCTX.endpoint_mode[2] = FUSB_EP2_MODE;
+#endif
+#if FUSB_EP3_MODE
+	USBDCTX.endpoint_mode[3] = FUSB_EP3_MODE;
+#endif
+#if FUSB_EP4_MODE
+	USBDCTX.endpoint_mode[4] = FUSB_EP4_MODE;
+#endif
+#if FUSB_EP5_MODE
+	USBDCTX.endpoint_mode[5] = FUSB_EP5_MODE;
+#endif
+#if FUSB_EP6_MODE
+	USBDCTX.endpoint_mode[6] = FUSB_EP6_MODE;
+#endif
+#if FUSB_EP7_MODE
+	USBDCTX.endpoint_mode[7] = FUSB_EP7_MODE;
+#endif
+
+	uint16_t pma_ptr = 64; // start packet buffers after btable (8 endpoint with 16 bytes each, but 8 bytes logical)
+	for (int i = 0; i < FUSB_CONFIG_EPS; i++) {
+		// Calculate offsets
+		uint32_t* btable_entry = (uint32_t*)(USBD_PMA_BASE + (i*16)); // 4 entries = 16 bytes per ep in btable
+
+		if (USBDCTX.endpoint_mode[i] == USBD_EP_TX || USBDCTX.endpoint_mode[i] == USBD_EP_RTX) {
+			USBDCTX.pma_offset[i][0] = pma_ptr *2; // why *2??
+			btable_entry[0] = pma_ptr; // ADDRx_TX
+			btable_entry[1] = 0; // COUNTx_TX
+			pma_ptr += DEF_USBD_UEP0_SIZE;
+		}
+		if (USBDCTX.endpoint_mode[i] == USBD_EP_RX || USBDCTX.endpoint_mode[i] == USBD_EP_RTX) {
+			USBDCTX.pma_offset[i][1] = pma_ptr *2; // why *2??
+			btable_entry[2] = pma_ptr; // ADDRx_RX
+			btable_entry[3] = 0x8400; // COUNTx_RX BL_SIZE=1 (32byte), NUM_BLOCK=1 -> 64 bytes
+			pma_ptr += DEF_USBD_UEP0_SIZE;
+		}
+
+		// USBD RAM is 512 bytes
+		if (pma_ptr > 512) {
+			printf("CRITICAL: USBD PMA OVERFLOW (%d)\n", pma_ptr);
+		}
+	}
+}
+
+int USBDSetup() {
+	// Enable Clocks
+#ifdef CH32V20x
+	RCC->CFGR0 = (RCC->CFGR0 & ~0xff0000) | (0b10101000 << 16); // what's this now??
+
+	// As recommended in the manual, output low on these pins before enabling USB
+	RCC->APB2PCENR |= (1 << 2);
+	GPIOA->CFGHR = (GPIOA->CFGHR & ~(0xff << 12)) | (0b00100010 << 12);
+	GPIOA->BSHR = (1 << 27) | (1 << 28);
+
+	RCC->APB2PCENR |= RCC_AFIOEN | RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA;
+	RCC->AHBPCENR = RCC_AHBPeriph_SRAM;
+	RCC->APB1PCENR |= RCC_USBEN;
+#endif
+
+	// Power On
+	USBD->CNTR = USBD_CNTR_FRES; // Force Reset
+	USBD->CNTR = 0;
+
+	// Wait
+	for(volatile int i=0; i<1000; i++);
+
+	USBD_InternalFinishSetup();
+
+	EXTEN->EXTEN_CTR |= EXTEN_USBD_PU_EN;
+
+	USBD->CNTR = USBD_CNTR_CTRM | USBD_CNTR_RESETM | USBD_CNTR_SUSPM | USBD_CNTR_WKUPM;
+	USBD->ISTR = 0; // reset all interrupt flags
+	NVIC_EnableIRQ(USB_LP_CAN1_RX0_IRQn);
+
+	return 0;
+}
+
+int USBD_SendEndpoint(int endp, uint8_t *data, int len) {
+	if (USBDCTX.USBD_Endp_Busy[endp]) return -1;
+
+	USBDCTX.USBD_Endp_Busy[endp] = 1;
+
+	PMA_Write(USBDCTX.pma_offset[endp][0], data, len);
+	SetPMA_TxCount(endp, len);
+	SetEPR_TxStatus(endp, USBD_EPR_STAT_TX_VALID);
+
+	return 0;
+}
+
+#if defined( FUNCONF_USE_USBPRINTF ) && FUNCONF_USE_USBPRINTF
+int HandleInRequest( struct _USBState *ctx, int endp, uint8_t *data, int len ) {
+	return 0;
+}
+
+static uint8_t usb_inputbuffer[DEF_USBD_UEP0_SIZE]; // this can be extended if polling rate is low
+static int usb_inbuf_idx;
+void HandleDataOut( struct _USBState *ctx, int endp, uint8_t *data, int len ) {
+	if ( endp == 0 ) {
+		ctx->USBD_SetupReqLen = 0; // To ACK
+	}
+	else if( endp == 2 ) {
+		// discard oldest if polling is too slow
+		int headroom = (sizeof(usb_inputbuffer) - usb_inbuf_idx) - len;
+		if(headroom < 0) {
+			// not enough space left, free up some
+			int offset = -headroom;
+			for(int i = offset; i < sizeof(usb_inputbuffer); i++) {
+				usb_inputbuffer[i -offset] = usb_inputbuffer[i];
+			}
+			usb_inbuf_idx -= offset;
+		}
+
+		for(int i = 0; i < len; i++) {
+			usb_inputbuffer[usb_inbuf_idx++] = data[i];
+		}
+	}
+}
+
+void handle_usbd_input( int numbytes, uint8_t * data );
+void poll_input() {
+	if(usb_inbuf_idx) {
+		handle_usbd_input(usb_inbuf_idx, usb_inputbuffer);
+		usb_inbuf_idx = 0;
+	}
+}
+
+int HandleSetupCustom( struct _USBState *ctx, int setup_code ) {
+	int ret = -1;
+	if ( ctx->USBD_SetupReqType & USB_REQ_TYP_CLASS ) {
+		switch ( setup_code ) {
+			case CDC_SET_LINE_CODING:
+			case CDC_SET_LINE_CTLSTE:
+			case CDC_SEND_BREAK: ret = ( ctx->USBD_SetupReqLen ) ? ctx->USBD_SetupReqLen : -1; break;
+			case CDC_GET_LINE_CODING: ret = ctx->USBD_SetupReqLen; break;
+			default: ret = 0; break;
+		}
+	}
+	else {
+		ret = 0; // Go to STALL
+	}
+	return ret;
+}
+#endif // FUNCONF_USE_USBPRINTF

--- a/extralibs/usbd.h
+++ b/extralibs/usbd.h
@@ -1,0 +1,178 @@
+#ifndef _USBD_H
+#define _USBD_H
+
+#include <stdint.h>
+#include "ch32fun.h"
+#include "usb_defines.h"
+#include "usb_config.h"
+
+
+// Register Bit Definitions
+#define USBD_CNTR_CTRM          0x8000
+#define USBD_CNTR_PMAOVRM       0x4000
+#define USBD_CNTR_ERRM          0x2000
+#define USBD_CNTR_WKUPM         0x1000
+#define USBD_CNTR_SUSPM         0x0800
+#define USBD_CNTR_RESETM        0x0400
+#define USBD_CNTR_SOFM          0x0200
+#define USBD_CNTR_ESOFM         0x0100
+#define USBD_CNTR_RESUME        0x0010
+#define USBD_CNTR_FSUSP         0x0008
+#define USBD_CNTR_LP_MODE       0x0004
+#define USBD_CNTR_PDWN          0x0002
+#define USBD_CNTR_FRES          0x0001
+
+#define USBD_ISTR_CTR           0x8000
+#define USBD_ISTR_PMAOVR        0x4000
+#define USBD_ISTR_ERR           0x2000
+#define USBD_ISTR_WKUP          0x1000
+#define USBD_ISTR_SUSP          0x0800
+#define USBD_ISTR_RESET         0x0400
+#define USBD_ISTR_SOF           0x0200
+#define USBD_ISTR_ESOF          0x0100
+#define USBD_ISTR_DIR           0x0010
+#define USBD_ISTR_EP_ID         0x000F
+
+#define USBD_EPR_CTR_RX         0x8000
+#define USBD_EPR_DTOG_RX        0x4000
+#define USBD_EPR_STAT_RX_MASK   0x3000
+#define USBD_EPR_STAT_RX_DIS    0x0000
+#define USBD_EPR_STAT_RX_STALL  0x1000
+#define USBD_EPR_STAT_RX_NAK    0x2000
+#define USBD_EPR_STAT_RX_VALID  0x3000
+#define USBD_EPR_SETUP          0x0800
+#define USBD_EPR_EP_TYPE_MASK   0x0600
+#define USBD_EPR_EP_TYPE_BULK   0x0000
+#define USBD_EPR_EP_TYPE_CTRL   0x0200
+#define USBD_EPR_EP_TYPE_ISO    0x0400
+#define USBD_EPR_EP_TYPE_INT    0x0600
+#define USBD_EPR_EP_KIND        0x0100
+#define USBD_EPR_CTR_TX         0x0080
+#define USBD_EPR_DTOG_TX        0x0040
+#define USBD_EPR_STAT_TX_MASK   0x0030
+#define USBD_EPR_STAT_TX_DIS    0x0000
+#define USBD_EPR_STAT_TX_STALL  0x0010
+#define USBD_EPR_STAT_TX_NAK    0x0020
+#define USBD_EPR_STAT_TX_VALID  0x0030
+#define USBD_EPR_EA             0x000F
+
+// Packet Memory Area (PMA)
+// On CH32V20x/F103, PMA is 512 bytes, accessed as 16-bit words spaced by 32-bits.
+// Base 0x40006000.
+#define USBD_PMA_BASE           0x40006000
+#define USBD_PMA_SIZE           512 
+
+// Helper for requests
+#define USB_REQ_TYP_MASK        0x60
+#define USB_REQ_TYP_STANDARD    0x00
+#define USB_REQ_TYP_CLASS       0x20
+#define USB_REQ_TYP_VENDOR      0x40
+
+#define USB_REQ_RECIP_MASK      0x1F
+#define USB_REQ_RECIP_DEVICE    0x00
+#define USB_REQ_RECIP_IFACE     0x01
+#define USB_REQ_RECIP_ENDP      0x02
+
+#define DEF_USBD_UEP0_SIZE      64
+#define DEF_UEP_IN              0x80
+#define DEF_UEP_OUT             0x00
+
+// Context Structure
+struct _USBState;
+
+// API Functions
+int USBDSetup();
+int USBD_SendEndpoint(int endp, uint8_t *data, int len);
+
+// Internal/Callback Functions (User must implement some if FUSB_USER_HANDLERS is set)
+#if FUSB_HID_USER_REPORTS
+int HandleHidUserGetReportSetup(struct _USBState *ctx, tusb_control_request_t *req);
+int HandleHidUserSetReportSetup(struct _USBState *ctx, tusb_control_request_t *req);
+void HandleHidUserReportDataOut(struct _USBState *ctx, uint8_t *data, int len);
+int HandleHidUserReportDataIn(struct _USBState *ctx, uint8_t *data, int len);
+void HandleHidUserReportOutComplete(struct _USBState *ctx);
+#endif
+
+#if FUSB_USER_HANDLERS
+int HandleInRequest(struct _USBState *ctx, int endp, uint8_t *data, int len);
+void HandleDataOut(struct _USBState *ctx, int endp, uint8_t *data, int len);
+int HandleSetupCustom(struct _USBState *ctx, int setup_code);
+#endif
+
+typedef enum
+{
+	USBD_EP_OFF = 0,
+	USBD_EP_RX  = -1,
+	USBD_EP_TX  = 1,
+	USBD_EP_RTX = 2,
+} USBD_EP_mode;
+
+// Configuration defaults
+#ifndef FUSB_EP1_MODE
+#define FUSB_EP1_MODE 0
+#endif
+#ifndef FUSB_EP2_MODE
+#define FUSB_EP2_MODE 0
+#endif
+#ifndef FUSB_EP3_MODE
+#define FUSB_EP3_MODE 0
+#endif
+#ifndef FUSB_EP4_MODE
+#define FUSB_EP4_MODE 0
+#endif
+#ifndef FUSB_EP5_MODE
+#define FUSB_EP5_MODE 0
+#endif
+#ifndef FUSB_EP6_MODE
+#define FUSB_EP6_MODE 0
+#endif
+#ifndef FUSB_EP7_MODE
+#define FUSB_EP7_MODE 0
+#endif
+#ifndef FUSB_CONFIG_EPS
+#define FUSB_CONFIG_EPS 5
+#endif
+#ifndef FUSB_HID_INTERFACES
+#define FUSB_HID_INTERFACES 0
+#endif
+
+struct _USBState
+{
+	// Setup Request
+	uint8_t  USBD_SetupReqCode;
+	uint8_t  USBD_SetupReqType;
+	uint16_t USBD_SetupReqLen;
+	uint32_t USBD_IndexValue;
+
+	// Device Status
+	uint8_t  USBD_DevConfig;
+	uint8_t  USBD_DevAddr;
+	uint8_t  USBD_DevSleepStatus;
+	uint8_t  USBD_DevEnumStatus;
+
+	uint8_t* pCtrlPayloadPtr;
+
+	// Buffers in main RAM (synced to PMA by library)
+	uint8_t ENDPOINTS[FUSB_CONFIG_EPS][DEF_USBD_UEP0_SIZE];
+
+	USBD_EP_mode endpoint_mode[FUSB_CONFIG_EPS+1];
+
+	#define CTRL0BUFF               (USBDCTX.ENDPOINTS[0])
+	#define pUSBD_SetupReqPak       ((tusb_control_request_t*)CTRL0BUFF)
+
+#if FUSB_HID_INTERFACES > 0
+	uint8_t USBD_HidIdle[FUSB_HID_INTERFACES];
+	uint8_t USBD_HidProtocol[FUSB_HID_INTERFACES];
+#endif
+	volatile uint8_t USBD_Endp_Busy[FUSB_CONFIG_EPS];
+	volatile uint8_t USBD_errata_dont_send_endpoint_in_window;
+
+	// Internal: Map logical endpoints to PMA addresses
+	uint16_t pma_offset[FUSB_CONFIG_EPS][2]; // [ep][0=TX, 1=RX]
+};
+
+extern struct _USBState USBDCTX;
+
+#include "usbd.c"
+
+#endif


### PR DESCRIPTION
Several chips that have hw USB also have the USBD peripheral. ch32fun already has an extralib for USBFS, which is available on all hw USB enabled chips, but some also have this USBD peripheral. While USBFS is preferred since it has more functionality, some dev boards only have the USBD pins broken out on pads.
One very prominent example is the ch32v208 boards on ali with Ethernet for less than $3.

This package adds support for this USBD peripheral, and an `usbprintf` demo using CDC TTY.

The code in the USBD extralib is heavily inspired by R's work in https://github.com/ArcaneNibble/wch-uf2.