### PR TITLE
Support riscv64-linux-gnu toolchain prefix

### DIFF
--- a/ch32fun/ch32fun.mk
+++ b/ch32fun/ch32fun.mk
@@ -14,6 +14,8 @@ ifneq ($(shell $(WHICH) riscv64-unknown-elf-gcc 2>$(NULLDEV)),)
 	PREFIX_DEFAULT:=riscv64-unknown-elf
 else ifneq ($(shell $(WHICH) riscv-none-elf-gcc 2>$(NULLDEV)),)
 	PREFIX_DEFAULT:=riscv-none-elf
+else ifneq ($(shell $(WHICH) riscv64-linux-gnu-gcc 2>$(NULLDEV)),)
+	PREFIX_DEFAULT:=riscv64-linux-gnu
 else ifeq ($(OS_NAME),netbsd)
 	# assume using pkgsrc/cross/riscv64-none-elf-gcc and
 	# pkgsrc/cross/riscv64-none-elf-binutils


### PR DESCRIPTION
This is the toolchain referenced in the Fedora section of the wiki.