### PR TITLE
minichlink: fix missing ch584 detection

### DIFF
--- a/minichlink/chips.c
+++ b/minichlink/chips.c
@@ -774,6 +774,7 @@ const struct RiscVChip_s * chip_collection[] = {
 	&ch581,
 	&ch582,
 	&ch583,
+	&ch584,
 	&ch585,
 	&ch591,
 	&ch592,


### PR DESCRIPTION
CH584 was being detected as ch585, as the and masking makes them "match" because it didn't check the more explicit 584 from the list first.