### PR TITLE
Add CH584_CH585 CRC check

### DIFF
--- a/extralibs/iSLER.h
+++ b/extralibs/iSLER.h
@@ -814,6 +814,10 @@ int iSLERCRCOK() {
 	uint8_t *tx_buf = (uint8_t*)LLE_BUF;
 	int len = tx_buf[1];
 	return (int8_t)!(tx_buf[len + 5] & 0x10);
+#elif defined(CH584_CH585)
+	uint8_t *tx_buf = (uint8_t*)LLE_BUF;
+	int len = tx_buf[1];
+	return (int8_t)((tx_buf[len + 5] & 0x11) == 0x01);
 #else
 	// Unimplemented!
 	return -1;

--- a/extralibs/iSLER.h
+++ b/extralibs/iSLER.h
@@ -810,14 +810,10 @@ int iSLERRSSI() {
 
 __HIGH_CODE
 int iSLERCRCOK() {
-#ifdef CH570_CH572
+#if defined(CH570_CH572) || defined(CH584_CH585)
 	uint8_t *tx_buf = (uint8_t*)LLE_BUF;
 	int len = tx_buf[1];
 	return (int8_t)!(tx_buf[len + 5] & 0x10);
-#elif defined(CH584_CH585)
-	uint8_t *tx_buf = (uint8_t*)LLE_BUF;
-	int len = tx_buf[1];
-	return (int8_t)((tx_buf[len + 5] & 0x11) == 0x01);
 #else
 	// Unimplemented!
 	return -1;


### PR DESCRIPTION
in MounRiver IDE, RFIP_ReadCrc is decompiled as

```
0x200013b0 lw a5, - 1944(gp)
0x200013b4 lw a5,56 (a5)
0x200013b6 .4byte 0x4857d793
0x200013ba bnez a5,0x200013de <RFIP_ReadCrc+32>
0x200013bc lbu a5,1(a0)
0x200013be li a4,1
0x200013c0 add a0,a0, a5
0x200013c2 lbu a5, 5(a0)
0x200013C4 li a0,17
0x200013c6 andi a5, a5,17
0x200013c8 bne a5,a4,0x200013d2 <RFIP_ReadCrc+34>
0x200013cc li a0,0 
0x200013ce ret
0x200013d0 li a0,1
0x200013d2 ret
```
A0 is LLE_BUF
A5 address RAM is 0x4000c100, which is BB_BASE

C code should be

```
uint32_t RFIP_ReadCrc(uint8_t *RxBuf)
{
    // Baseband status register
    if ((*(volatile uint32_t *)0x4000C138 >> 5) & 1)
    {
        return 1;
    }

    // Skip descriptor/header
    RxBuf += RxBuf[1];

    // Read packet status byte
    if ((RxBuf[5] & 0x11) == 1)
    {
        return 0;   // CRC OK
    }

    return 17;      // CRC fail / invalid
}
```

in my test, BB14(BBSTATUS) bit 5 always keeps 1, so we just check the CRC byte.

