### PR TITLE
additions to make PortE work on ch32v307VCT6

### DIFF
--- a/ch32fun/ch32fun.h
+++ b/ch32fun/ch32fun.h
@@ -967,7 +967,7 @@ RV_STATIC_INLINE void funPinMode(u32 pin, GPIOModeTypeDef mode)
 #define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC ); }
 #define funPinMode( pin, mode ) { *((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3)) = ( (*((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3))) & (~(0xf<<(4*((pin)&0x7))))) | ((mode)<<(4*((pin)&0x7))); }
 #elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32L103)
-#define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC | RCC_APB2Periph_GPIOD ); }
+#define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC | RCC_APB2Periph_GPIOD | RCC_APB2Periph_GPIOE ); }
 #define funPinMode( pin, mode ) { *((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3)) = ( (*((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3))) & (~(0xf<<(4*((pin)&0x7))))) | ((mode)<<(4*((pin)&0x7))); }
 #define funGpioInitB() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOB ); }
 #elif defined(CH32H41x)

--- a/ch32fun/ch32v30xhw.h
+++ b/ch32fun/ch32v30xhw.h
@@ -10586,6 +10586,22 @@ typedef struct
 #define PD13 61
 #define PD14 62
 #define PD15 63
+#define	PE0	64
+#define	PE1	65
+#define	PE2	66
+#define	PE3	67
+#define	PE4	68
+#define	PE5	69
+#define	PE6	70
+#define	PE7	71
+#define	PE8	72
+#define	PE9	73
+#define	PE10 74
+#define	PE11 75
+#define	PE12 76
+#define	PE13 77
+#define	PE14 78
+#define	PE15 79
 
 /*
  * This file contains various parts of the official WCH EVT Headers which


### PR DESCRIPTION
These additions were necessary to make the function funGpioInitAll() and funDigitalWrite() to work as expected for PortE on a board with a ch32v307VCT6. I've tested funDigitalWrite() for each pin on port E and verified the expected operation in hardware with a scope.