### PR TITLE
Add missing register definitions and align ASM macros for CH5xx

### DIFF
--- a/ch32fun/ch5xxhw.h
+++ b/ch32fun/ch5xxhw.h
@@ -929,10 +929,10 @@ typedef enum
 #define SAFE_ACCESS_SIG0    0x00                      // WO: safe accessing sign value for disable
 #define SYS_SAFE_ACCESS(a)  do { R8_SAFE_ACCESS_SIG = SAFE_ACCESS_SIG1; \
 								 R8_SAFE_ACCESS_SIG = SAFE_ACCESS_SIG2; \
-								 asm volatile ("nop\nnop"); \
+								 __ASM volatile ("nop\nnop"); \
 								 {a} \
 								 R8_SAFE_ACCESS_SIG = SAFE_ACCESS_SIG0; \
-								 asm volatile ("nop\nnop"); } while(0)
+								 __ASM volatile ("nop\nnop"); } while(0)
 
 #define R8_CHIP_ID          (*((vu8*)0x40001041))     // RF, chip ID register
 #define R8_SAFE_ACCESS_ID   (*((vu8*)0x40001042))     // RF, safe accessing ID register
@@ -2682,13 +2682,13 @@ RV_STATIC_INLINE void jump_isprom()
 #if (defined(CH570_CH572) || defined(CH584_CH585) || defined(CH591_CH592))
 	memset((void*)ISPROM_BSS_ADDRESS, 0, ISPROM_BSS_SIZE); // clear .bss
 
-	asm( "la gp, " ISPROM_IN_RAM_GLOBALPOINTER "\n"
+	__ASM( "la gp, " ISPROM_IN_RAM_GLOBALPOINTER "\n"
 		 ".option arch, +zicsr\n"
 		 "li t0, " ISPROM_IN_RAM_ENTRYPOINT "\n"
 		 "csrw mepc, t0\n" // __set_MEPC is not available here
 		 "mret\n");
 #elif defined(CH582_CH583)
-	asm( "la gp, " ISPROM_GLOBALPOINTER "\n"
+	__ASM( "la gp, " ISPROM_GLOBALPOINTER "\n"
 		 "j " ISPROM_ENTRYPOINT "\n");
 #endif
 }

--- a/ch32fun/ch5xxhw.h
+++ b/ch32fun/ch5xxhw.h
@@ -248,147 +248,170 @@ typedef struct {
 #endif
 
 typedef struct {
-    __IO uint32_t INT_EN;       // 90
-    __IO uint32_t INT_MODE;     // 94
-    uint32_t RESERVED0;         // 98
-    __IO uint32_t INT_IF;       // 9C
-    __IO uint32_t PA_DIR;       // A0
-    __IO uint32_t PA_PIN;       // A4
-    __IO uint32_t PA_OUT;       // A8
-    __IO uint32_t PA_CLR;       // AC
-    __IO uint32_t PA_PU;        // B0
-    __IO uint32_t PA_PD_DRV;    // B4
-    __IO uint32_t PA_SET;       // B8
+    __IO uint32_t INT_EN;        // 0
+#if defined(CH570_CH572)
+    __IO uint16_t INT_MODE;      // 4H
+    __IO uint16_t INT_EDGE_TYPE; // 6H
+#else
+    __IO uint32_t INT_MODE;      // 4H
+#endif
+#if defined(CH59x)
+    __IO uint32_t INT_EDGE_TYPE; // 8H
+#else
+    uint32_t RESERVED0;          // 8H
+#endif
+    __IO uint32_t INT_IF;        // CH
+    __IO uint32_t PA_DIR;        // 10H
+    __IO uint32_t PA_PIN;        // 14H
+    __IO uint32_t PA_OUT;        // 18H
+    __IO uint32_t PA_CLR;        // 1CH
+    __IO uint32_t PA_PU;         // 20H
+    __IO uint32_t PA_PD_DRV;     // 24H
+#if !defined(CH582_CH583) && !defined(CH571_CH573)
+    __IO uint32_t PA_SET;        // 28H
+#else
+    uint32_t RESERVED1;          // 28H
+#endif
 #if defined(CH571_CH573) || defined(CH58x) || defined(CH59x)
-    uint32_t RESERVED1;         // BC
-    __IO uint32_t PB_DIR;       // C0
-    __IO uint32_t PB_PIN;       // C4
-    __IO uint32_t PB_OUT;       // C8
-    __IO uint32_t PB_CLR;       // CC
-    __IO uint32_t PB_PU;        // D0
-    __IO uint32_t PB_PD_DRV;    // D4
-    __IO uint32_t PB_SET;       // D8
+    uint32_t RESERVED2;          // 2CH
+    __IO uint32_t PB_DIR;        // 30H
+    __IO uint32_t PB_PIN;        // 34H
+    __IO uint32_t PB_OUT;        // 38H
+    __IO uint32_t PB_CLR;        // 3CH
+    __IO uint32_t PB_PU;         // 40H
+    __IO uint32_t PB_PD_DRV;     // 44H
+#if !defined(CH582_CH583) && !defined(CH571_CH573)
+    __IO uint32_t PB_SET;        // 48H
 #endif
 } GPIO_TypeDef;
 
 #ifndef CH571_CH573
 typedef struct {
-    __IO uint16_t CTRL1;         // 0
-    uint16_t RESERVED0;          // 2
-    __IO uint16_t CTRL2;         // 4
-    uint16_t RESERVED1;          // 6
-    __IO uint16_t OADDR1;        // 8
-    uint16_t RESERVED2;          // A
-    __IO uint16_t OADDR2;        // C
-    uint16_t RESERVED3;          // E
-    __IO uint16_t DATAR;         // 10
-    uint16_t RESERVED4;          // 12
-    __IO uint16_t STAR1;         // 14
-    uint16_t RESERVED5;          // 16
-    __IO uint16_t STAR2;         // 18
-    uint16_t RESERVED6;          // 1A
-    __IO uint16_t CKCFGR;        // 1C
-    uint16_t RESERVED7;          // 1E
-    __IO uint16_t RTR;           // 20
+    __IO uint16_t CTRL1;         // 0H
+    uint16_t RESERVED0;          // 2H
+    __IO uint16_t CTRL2;         // 4H
+    uint16_t RESERVED1;          // 6H
+    __IO uint16_t OADDR1;        // 8H
+    uint16_t RESERVED2;          // AH
+    __IO uint16_t OADDR2;        // CH
+    uint16_t RESERVED3;          // EH
+    __IO uint16_t DATAR;         // 10H
+    uint16_t RESERVED4;          // 12H
+    __IO uint16_t STAR1;         // 14H
+    uint16_t RESERVED5;          // 16H
+    __IO uint16_t STAR2;         // 18H
+    uint16_t RESERVED6;          // 1AH
+    __IO uint16_t CKCFGR;        // 1CH
+    uint16_t RESERVED7;          // 1EH
+    __IO uint16_t RTR;           // 20H
 } I2C_TypeDef;
 #endif
 
 #ifdef CH570_CH572
 typedef struct {
-    __IO uint16_t CTRL;          // 0
-    __IO uint8_t INT_EN;         // 2
-    __IO uint8_t INT_FLAG;       // 3
-    __IO uint16_t SCAN_NUMB;     // 4
+    __IO uint16_t CTRL;          // 0H
+    __IO uint8_t INT_EN;         // 2H
+    __IO uint8_t INT_FLAG;       // 3H
+    __IO uint16_t SCAN_NUMB;     // 4H
 } KeyScan_TypeDef;
 #endif
 
 typedef struct {
-    __IO uint8_t OUT_EN;         // 0
-    __IO uint8_t OUT_POLAR;      // 1
-    __IO uint8_t CONFIG;         // 2
+    __IO uint8_t OUT_EN;         // 0H
+    __IO uint8_t OUT_POLAR;      // 1H
+    __IO uint8_t CONFIG;         // 2H
 #ifdef CH570_CH572
-    __IO uint8_t DMA_CTRL;       // 3
-    __IO uint8_t PWM1_DATA;      // 4
-    __IO uint8_t PWM2_DATA;      // 5
-    __IO uint8_t PWM3_DATA;      // 6
-    uint8_t RESERVED0[5];        // 7
-    __IO uint8_t INT_EN;         // C
-    __IO uint8_t INT_FLAG;       // D
-    uint16_t RESERVED1;          // E
-    __IO uint8_t PWM4_DATA;      // 10
-    __IO uint8_t PWM5_DATA;      // 11
-    uint16_t RESERVED2;          // 12
-    __IO uint16_t CYC_VALUE;     // 14
-    __IO uint16_t CYC1_VALUE;    // 16
-    __IO uint16_t CLOCK_DIV;     // 18
-    uint16_t RESERVED3;          // 1A
-    __IO uint32_t DMA_NOW;       // 1C
-    __IO uint32_t DMA_BEG;       // 20
-    __IO uint32_t DMA_END;       // 24
+    __IO uint8_t DMA_CTRL;       // 3H
+    __IO uint8_t PWM1_DATA;      // 4H
+    __IO uint8_t PWM2_DATA;      // 5H
+    __IO uint8_t PWM3_DATA;      // 6H
+    uint8_t RESERVED0[5];        // 7H
+    __IO uint8_t INT_EN;         // CH
+    __IO uint8_t INT_FLAG;       // DH
+    uint16_t RESERVED1;          // EH
+    __IO uint8_t PWM4_DATA;      // 10H
+    __IO uint8_t PWM5_DATA;      // 11H
+    uint16_t RESERVED2;          // 12H
+    __IO uint16_t CYC_VALUE;     // 14H
+    __IO uint16_t CYC1_VALUE;    // 16H
+    __IO uint16_t CLOCK_DIV;     // 18H
+    uint16_t RESERVED3;          // 1AH
+    __IO uint32_t DMA_NOW;       // 1CH
+    __IO uint32_t DMA_BEG;       // 20H
+    __IO uint32_t DMA_END;       // 24H
 #else
-    __IO uint8_t CLOCK_DIV;      // 3
-    __IO uint8_t PWM4_DATA;      // 4
-    __IO uint8_t PWM5_DATA;      // 5
-    __IO uint8_t PWM6_DATA;      // 6
-    __IO uint8_t PWM7_DATA;      // 7
-    __IO uint8_t PWM8_DATA;      // 8
-    __IO uint8_t PWM9_DATA;      // 9
-    __IO uint8_t PWM10_DATA;     // A
-    __IO uint8_t PWM11_DATA;     // B
-    __IO uint8_t INT_CTRL;       // C
+    __IO uint8_t CLOCK_DIV;      // 3H
+    __IO uint8_t PWM4_DATA;      // 4H
+    __IO uint8_t PWM5_DATA;      // 5H
+    __IO uint8_t PWM6_DATA;      // 6H
+    __IO uint8_t PWM7_DATA;      // 7H
+    __IO uint8_t PWM8_DATA;      // 8H
+    __IO uint8_t PWM9_DATA;      // 9H
+    __IO uint8_t PWM10_DATA;     // AH
+    __IO uint8_t PWM11_DATA;     // BH
+    __IO uint8_t INT_CTRL;       // CH
 #if defined(CH584_CH585) || defined(CH591_CH592)
-    uint8_t RESERVED0[3];        // D
-    __IO uint32_t REG_DATA8;     // 10
-    __IO uint32_t REG_CYCLE;     // 14
+    uint8_t RESERVED0[3];        // DH
+    __IO uint32_t REG_DATA8;     // 10H
+    __IO uint32_t REG_CYCLE;     // 14H
 #endif
 #endif
 } PWM_TypeDef;
 
 typedef struct {
-    __IO uint8_t CTRL_MOD;         // 0
-    __IO uint8_t CTRL_CFG;         // 1
-    __IO uint8_t INTER_EN;         // 2
-    __IO uint8_t CLKDIV_SLAVEPRE;  // 3
-    __IO uint8_t BUFFER;           // 4
-    __IO uint8_t RUN_FLAG;         // 5
-    __IO uint8_t INT_FLAG;         // 6
-    __IO uint8_t FIFO_COUNT;       // 7
+    __IO uint8_t CTRL_MOD;         // 0H
+    __IO uint8_t CTRL_CFG;         // 1H
+    __IO uint8_t INTER_EN;         // 2H
+    __IO uint8_t CLKDIV_SLAVE_PRE; // 3H
+    __IO uint8_t BUFFER;           // 4H
+    __IO uint8_t RUN_FLAG;         // 5H
+    __IO uint8_t INT_FLAG;         // 6H
+    __IO uint8_t FIFO_COUNT;       // 7H
 #ifdef CH570_CH572
-    __IO uint8_t INT_TYPE;         // 8
-    __IO uint8_t INTER1_EN;        // 9
-    __IO uint8_t INTER1_FLAG;      // A
+    __IO uint8_t INT_TYPE;         // 8H
+    __IO uint8_t INTER1_EN;        // 9H
+    __IO uint8_t INTER1_FLAG;      // AH
 #else
-    uint8_t RESERVED0[3];          // 8
+    uint8_t RESERVED0[3];          // 8H
 #endif
-    __IO uint16_t TOTAL_CNT;       // C
-    uint16_t RESERVED1;            // E
-    __IO uint8_t FIFO;             // 10
-    uint8_t RESERVED2[2];          // 11
-    __IO uint8_t COUNT1;           // 13
-    __IO uint16_t DMA_NOW;         // 14
-    uint16_t RESERVED3;            // 16
-    __IO uint16_t DMA_BEG;         // 18
-    uint16_t RESERVED4;            // 1A
-    __IO uint16_t DMA_END;         // 1C
+    __IO uint16_t TOTAL_CNT;       // CH
+    uint16_t RESERVED1;            // EH
+    __IO uint8_t FIFO;             // 10H
+    uint8_t RESERVED2[2];          // 11H
+    __IO uint8_t COUNT1;           // 13H
+    __IO uint16_t DMA_NOW;         // 14H
+    uint16_t RESERVED3;            // 16H
+    __IO uint16_t DMA_BEG;         // 18H
+    uint16_t RESERVED4;            // 1AH
+    __IO uint16_t DMA_END;         // 1CH
 } SPI_TypeDef;
 
 typedef struct {
-    __IO uint8_t CTRL_MOD;       // 0
-    __IO uint8_t CTRL_DMA;       // 1
-    __IO uint8_t INTER_EN;       // 2
-    uint8_t RESERVED0;           // 3
-    __IO uint8_t PWM_MOD;        // 4
-    uint8_t RESERVED1;           // 5
-    __IO uint8_t INT_FLAG;       // 6
-    __IO uint8_t FIFO_COUNT;     // 7
-    __IO uint32_t COUNT;         // 8
-    __IO uint32_t CNT_END;       // C
-    __IO uint32_t FIFO;          // 10
-    __IO uint16_t DMA_NOW;       // 14
-    uint16_t RESERVED2;          // 16
-    __IO uint16_t DMA_BEG;       // 18
-    uint16_t RESERVED3;          // 1A
-    __IO uint16_t DMA_END;       // 1C
+    __IO uint8_t CTRL_MOD;       // 0H
+    __IO uint8_t CTRL_DMA;       // 1H
+    __IO uint8_t INTER_EN;       // 2H
+    uint8_t RESERVED0;           // 3H
+    __IO uint8_t PWM_MOD;        // 4H
+    uint8_t RESERVED1;           // 5H
+    __IO uint8_t INT_FLAG;       // 6H
+    __IO uint8_t FIFO_COUNT;     // 7H
+    __IO uint32_t COUNT;         // 8H
+    __IO uint32_t CNT_END;       // CH
+    __IO uint32_t FIFO;          // 10H
+    __IO uint16_t DMA_NOW;       // 14H
+    uint16_t RESERVED2;          // 16H
+    __IO uint16_t DMA_BEG;       // 18H
+    uint16_t RESERVED3;          // 1AH
+    __IO uint16_t DMA_END;       // 1CH
+#if defined(CH570_CH572)
+    uint16_t RESERVED4;          // 1EH
+    __IO uint8_t ENC_REG_CTRL;   // 20H
+    __IO uint8_t ENC_INTER_EN;   // 21H
+    __IO uint8_t ENC_INTER_FLAG; // 22H
+    uint8_t RESERVED5;           // 23H
+    __IO uint32_t ENC_REG_CEND;  // 24H
+    __IO uint32_t ENC_REG_CCNT;  // 28H
+#endif
 } TMR_TypeDef;
 
 typedef struct {

--- a/ch32fun/ch5xxhw.h
+++ b/ch32fun/ch5xxhw.h
@@ -241,6 +241,156 @@ typedef struct
 } PFIC_Type;
 #endif /* __ASSEMBLER__*/
 
+#ifdef CH570_CH572
+typedef struct {
+    __IO uint32_t CTRL;
+} CMP_TypeDef;
+#endif
+
+typedef struct {
+    __IO uint32_t INT_EN;       // 90
+    __IO uint32_t INT_MODE;     // 94
+    uint32_t RESERVED0;         // 98
+    __IO uint32_t INT_IF;       // 9C
+    __IO uint32_t PA_DIR;       // A0
+    __IO uint32_t PA_PIN;       // A4
+    __IO uint32_t PA_OUT;       // A8
+    __IO uint32_t PA_CLR;       // AC
+    __IO uint32_t PA_PU;        // B0
+    __IO uint32_t PA_PD_DRV;    // B4
+    __IO uint32_t PA_SET;       // B8
+#if defined(CH571_CH573) || defined(CH58x) || defined(CH59x)
+    uint32_t RESERVED1;         // BC
+    __IO uint32_t PB_DIR;       // C0
+    __IO uint32_t PB_PIN;       // C4
+    __IO uint32_t PB_OUT;       // C8
+    __IO uint32_t PB_CLR;       // CC
+    __IO uint32_t PB_PU;        // D0
+    __IO uint32_t PB_PD_DRV;    // D4
+    __IO uint32_t PB_SET;       // D8
+#endif
+} GPIO_TypeDef;
+
+#ifndef CH571_CH573
+typedef struct {
+    __IO uint16_t CTRL1;         // 0
+    uint16_t RESERVED0;          // 2
+    __IO uint16_t CTRL2;         // 4
+    uint16_t RESERVED1;          // 6
+    __IO uint16_t OADDR1;        // 8
+    uint16_t RESERVED2;          // A
+    __IO uint16_t OADDR2;        // C
+    uint16_t RESERVED3;          // E
+    __IO uint16_t DATAR;         // 10
+    uint16_t RESERVED4;          // 12
+    __IO uint16_t STAR1;         // 14
+    uint16_t RESERVED5;          // 16
+    __IO uint16_t STAR2;         // 18
+    uint16_t RESERVED6;          // 1A
+    __IO uint16_t CKCFGR;        // 1C
+    uint16_t RESERVED7;          // 1E
+    __IO uint16_t RTR;           // 20
+} I2C_TypeDef;
+#endif
+
+#ifdef CH570_CH572
+typedef struct {
+    __IO uint16_t CTRL;          // 0
+    __IO uint8_t INT_EN;         // 2
+    __IO uint8_t INT_FLAG;       // 3
+    __IO uint16_t SCAN_NUMB;     // 4
+} KeyScan_TypeDef;
+#endif
+
+typedef struct {
+    __IO uint8_t OUT_EN;         // 0
+    __IO uint8_t OUT_POLAR;      // 1
+    __IO uint8_t CONFIG;         // 2
+#ifdef CH570_CH572
+    __IO uint8_t DMA_CTRL;       // 3
+    __IO uint8_t PWM1_DATA;      // 4
+    __IO uint8_t PWM2_DATA;      // 5
+    __IO uint8_t PWM3_DATA;      // 6
+    uint8_t RESERVED0[5];        // 7
+    __IO uint8_t INT_EN;         // C
+    __IO uint8_t INT_FLAG;       // D
+    uint16_t RESERVED1;          // E
+    __IO uint8_t PWM4_DATA;      // 10
+    __IO uint8_t PWM5_DATA;      // 11
+    uint16_t RESERVED2;          // 12
+    __IO uint16_t CYC_VALUE;     // 14
+    __IO uint16_t CYC1_VALUE;    // 16
+    __IO uint16_t CLOCK_DIV;     // 18
+    uint16_t RESERVED3;          // 1A
+    __IO uint32_t DMA_NOW;       // 1C
+    __IO uint32_t DMA_BEG;       // 20
+    __IO uint32_t DMA_END;       // 24
+#else
+    __IO uint8_t CLOCK_DIV;      // 3
+    __IO uint8_t PWM4_DATA;      // 4
+    __IO uint8_t PWM5_DATA;      // 5
+    __IO uint8_t PWM6_DATA;      // 6
+    __IO uint8_t PWM7_DATA;      // 7
+    __IO uint8_t PWM8_DATA;      // 8
+    __IO uint8_t PWM9_DATA;      // 9
+    __IO uint8_t PWM10_DATA;     // A
+    __IO uint8_t PWM11_DATA;     // B
+    __IO uint8_t INT_CTRL;       // C
+#if defined(CH584_CH585) || defined(CH591_CH592)
+    uint8_t RESERVED0[3];        // D
+    __IO uint32_t REG_DATA8;     // 10
+    __IO uint32_t REG_CYCLE;     // 14
+#endif
+#endif
+} PWM_TypeDef;
+
+typedef struct {
+    __IO uint8_t CTRL_MOD;         // 0
+    __IO uint8_t CTRL_CFG;         // 1
+    __IO uint8_t INTER_EN;         // 2
+    __IO uint8_t CLKDIV_SLAVEPRE;  // 3
+    __IO uint8_t BUFFER;           // 4
+    __IO uint8_t RUN_FLAG;         // 5
+    __IO uint8_t INT_FLAG;         // 6
+    __IO uint8_t FIFO_COUNT;       // 7
+#ifdef CH570_CH572
+    __IO uint8_t INT_TYPE;         // 8
+    __IO uint8_t INTER1_EN;        // 9
+    __IO uint8_t INTER1_FLAG;      // A
+#else
+    uint8_t RESERVED0[3];          // 8
+#endif
+    __IO uint16_t TOTAL_CNT;       // C
+    uint16_t RESERVED1;            // E
+    __IO uint8_t FIFO;             // 10
+    uint8_t RESERVED2[2];          // 11
+    __IO uint8_t COUNT1;           // 13
+    __IO uint16_t DMA_NOW;         // 14
+    uint16_t RESERVED3;            // 16
+    __IO uint16_t DMA_BEG;         // 18
+    uint16_t RESERVED4;            // 1A
+    __IO uint16_t DMA_END;         // 1C
+} SPI_TypeDef;
+
+typedef struct {
+    __IO uint8_t CTRL_MOD;       // 0
+    __IO uint8_t CTRL_DMA;       // 1
+    __IO uint8_t INTER_EN;       // 2
+    uint8_t RESERVED0;           // 3
+    __IO uint8_t PWM_MOD;        // 4
+    uint8_t RESERVED1;           // 5
+    __IO uint8_t INT_FLAG;       // 6
+    __IO uint8_t FIFO_COUNT;     // 7
+    __IO uint32_t COUNT;         // 8
+    __IO uint32_t CNT_END;       // C
+    __IO uint32_t FIFO;          // 10
+    __IO uint16_t DMA_NOW;       // 14
+    uint16_t RESERVED2;          // 16
+    __IO uint16_t DMA_BEG;       // 18
+    uint16_t RESERVED3;          // 1A
+    __IO uint16_t DMA_END;       // 1C
+} TMR_TypeDef;
+
 typedef struct {
     __IO uint8_t MCR;
     __IO uint8_t IER;
@@ -257,7 +407,7 @@ typedef struct {
     __IO uint16_t DL;
     __IO uint8_t DIV;
     __IO uint8_t ADR;
-} UART_Typedef;
+} UART_TypeDef;
 
 
 #ifdef __ASSEMBLER__
@@ -1145,6 +1295,8 @@ typedef enum
 #define R32_ENC_REG_CEND    (*((vu32*)0x40002424))
 #define R32_ENC_REG_CCNT    (*((vu32*)0x40002428))
 #define BA_TMR              ((vu8*)0x40002400)        // point TMR base address
+
+#define TMR                 ((TMR_TypeDef*)BA_TMR)
 #else
 
 /* Timer0 register */
@@ -1234,6 +1386,11 @@ typedef enum
 #define BA_TMR1             ((vu8*)0x40002400)        // point TMR1 base address
 #define BA_TMR2             ((vu8*)0x40002800)        // point TMR2 base address
 #define BA_TMR3             ((vu8*)0x40002C00)        // point TMR3 base address
+
+#define TMR0                ((TMR_TypeDef*)BA_TMR0)
+#define TMR1                ((TMR_TypeDef*)BA_TMR1)
+#define TMR2                ((TMR_TypeDef*)BA_TMR2)
+#define TMR3                ((TMR_TypeDef*)BA_TMR3)
 #endif
 
 #define TMR_FIFO_SIZE       8                         // timer FIFO size (depth)
@@ -1431,11 +1588,11 @@ typedef enum
 #define UART_II_MODEM_CHG   0x00                      // RO, UART0 interrupt by modem status change
 #define UART_II_NO_INTER    0x01                      // RO, no UART interrupt is pending
 
-#define UART                ((UART_Typedef*)BA_UART)
-#define UART0                ((UART_Typedef*)BA_UART0)
-#define UART1                ((UART_Typedef*)BA_UART1)
-#define UART2                ((UART_Typedef*)BA_UART2)
-#define UART3                ((UART_Typedef*)BA_UART3)
+#define UART                ((UART_TypeDef*)BA_UART)
+#define UART0               ((UART_TypeDef*)BA_UART0)
+#define UART1               ((UART_TypeDef*)BA_UART1)
+#define UART2               ((UART_TypeDef*)BA_UART2)
+#define UART3               ((UART_TypeDef*)BA_UART3)
 
 /* SPI0 register */
 #define R32_SPI0_CONTROL    (*((vu32*)0x40004000))    // RW, SPI0 control
@@ -1537,6 +1694,9 @@ typedef enum
 #define SPI_DMA_BEG         0x18
 #define SPI_DMA_END         0x1C
 
+#define SPI0                ((SPI_TypeDef*)BA_SPI0)
+#define SPI1                ((SPI_TypeDef*)BA_SPI1)
+
 /* I2C register */
 #define R16_I2C_CTRL1       (*((vu16*)0x40004800))    // RW, I2C control 1
 #define R16_I2C_CTRL2       (*((vu16*)0x40004804))    // RW, I2C control 2
@@ -1611,6 +1771,10 @@ typedef enum
 #define  RB_I2C_F_S         0x8000                    // RW, I2C master mode selection: 0=standard mode, 1=fast mode
 #define I2C_RTR             32
 #define  RB_I2C_TRISE       0x003F                    // RW, Maximum rise time in Fm/Sm mode (Master mode)
+
+#ifndef CH571_CH573
+#define I2C                 ((I2C_TypeDef*)BA_I2C)
+#endif
 
 #ifdef CH57x
 /* PWM1/2/3/4/5/register */
@@ -1758,6 +1922,8 @@ typedef enum
 #define PWM10_DATA_HOLD     10
 #define PWM11_DATA_HOLD     11
 #endif
+
+#define PWMX                ((PWM_TypeDef*)BA_PWMX)
 
 #ifdef CH584_CH585
 /* LCD register */

--- a/ch32fun/ch5xxhw.h
+++ b/ch32fun/ch5xxhw.h
@@ -248,40 +248,44 @@ typedef struct {
 #endif
 
 typedef struct {
-    __IO uint32_t INT_EN;        // 0
 #if defined(CH570_CH572)
-    __IO uint16_t INT_MODE;      // 4H
-    __IO uint16_t INT_EDGE_TYPE; // 6H
+    __IO uint16_t PA_INT_EN;        // 0H
+    uint16_t RESERVED0;             // 2H
+    __IO uint16_t PA_INT_MODE;      // 4H
+    __IO uint16_t PA_INT_EDGE_TYPE; // 6H
+    uint32_t RESERVED1;             // 8H
+    __IO uint16_t PA_INT_IF;        // CH
+    uint16_t RESERVED2;             // EH
 #else
-    __IO uint32_t INT_MODE;      // 4H
-#endif
-#if defined(CH59x)
-    __IO uint32_t INT_EDGE_TYPE; // 8H
+    __IO uint16_t PA_INT_EN;        // 0H
+    __IO uint16_t PB_INT_EN;        // 2H
+    __IO uint16_t PA_INT_MODE;      // 4H
+    __IO uint16_t PB_INT_MODE;      // 6H
+#if defined(CH591_CH592)
+    __IO uint16_t PA_INT_EDGE_TYPE; // 8H
+    __IO uint16_t PB_INT_EDGE_TYPE; // AH
 #else
-    uint32_t RESERVED0;          // 8H
+    uint32_t RESERVED0;             // 8H
 #endif
-    __IO uint32_t INT_IF;        // CH
-    __IO uint32_t PA_DIR;        // 10H
-    __IO uint32_t PA_PIN;        // 14H
-    __IO uint32_t PA_OUT;        // 18H
-    __IO uint32_t PA_CLR;        // 1CH
-    __IO uint32_t PA_PU;         // 20H
-    __IO uint32_t PA_PD_DRV;     // 24H
-#if !defined(CH582_CH583) && !defined(CH571_CH573)
-    __IO uint32_t PA_SET;        // 28H
-#else
-    uint32_t RESERVED1;          // 28H
+    __IO uint16_t PA_INT_IF;        // CH
+    __IO uint16_t PB_INT_IF;        // EH
 #endif
-#if defined(CH571_CH573) || defined(CH58x) || defined(CH59x)
-    uint32_t RESERVED2;          // 2CH
-    __IO uint32_t PB_DIR;        // 30H
-    __IO uint32_t PB_PIN;        // 34H
-    __IO uint32_t PB_OUT;        // 38H
-    __IO uint32_t PB_CLR;        // 3CH
-    __IO uint32_t PB_PU;         // 40H
-    __IO uint32_t PB_PD_DRV;     // 44H
-#if !defined(CH582_CH583) && !defined(CH571_CH573)
-    __IO uint32_t PB_SET;        // 48H
+    __IO uint32_t PA_DIR;           // 10H
+    __IO uint32_t PA_PIN;           // 14H
+    __IO uint32_t PA_OUT;           // 18H
+    __IO uint32_t PA_CLR;           // 1CH
+    __IO uint32_t PA_PU;            // 20H
+    __IO uint32_t PA_PD_DRV;        // 24H
+    __IO uint32_t PA_SET;           // 28H
+#if defined(CH571_CH573) || defined(CH582_CH583) || defined(CH584_CH585) || defined(CH591_CH592)
+    uint32_t RESERVED1;             // 2CH
+    __IO uint32_t PB_DIR;           // 30H
+    __IO uint32_t PB_PIN;           // 34H
+    __IO uint32_t PB_OUT;           // 38H
+    __IO uint32_t PB_CLR;           // 3CH
+    __IO uint32_t PB_PU;            // 40H
+    __IO uint32_t PB_PD_DRV;        // 44H
+    __IO uint32_t PB_SET;           // 48H
 #endif
 } GPIO_TypeDef;
 

--- a/ch32fun/ch5xxhw.h
+++ b/ch32fun/ch5xxhw.h
@@ -956,10 +956,10 @@ typedef enum
 #define SAFE_ACCESS_SIG0    0x00                      // WO: safe accessing sign value for disable
 #define SYS_SAFE_ACCESS(a)  do { R8_SAFE_ACCESS_SIG = SAFE_ACCESS_SIG1; \
 								 R8_SAFE_ACCESS_SIG = SAFE_ACCESS_SIG2; \
-								 __ASM volatile ("nop\nnop"); \
+								 asm volatile ("nop\nnop"); \
 								 {a} \
 								 R8_SAFE_ACCESS_SIG = SAFE_ACCESS_SIG0; \
-								 __ASM volatile ("nop\nnop"); } while(0)
+								 asm volatile ("nop\nnop"); } while(0)
 
 #define R8_CHIP_ID          (*((vu8*)0x40001041))     // RF, chip ID register
 #define R8_SAFE_ACCESS_ID   (*((vu8*)0x40001042))     // RF, safe accessing ID register
@@ -2709,13 +2709,13 @@ RV_STATIC_INLINE void jump_isprom()
 #if (defined(CH570_CH572) || defined(CH584_CH585) || defined(CH591_CH592))
 	memset((void*)ISPROM_BSS_ADDRESS, 0, ISPROM_BSS_SIZE); // clear .bss
 
-	__ASM( "la gp, " ISPROM_IN_RAM_GLOBALPOINTER "\n"
+	asm( "la gp, " ISPROM_IN_RAM_GLOBALPOINTER "\n"
 		 ".option arch, +zicsr\n"
 		 "li t0, " ISPROM_IN_RAM_ENTRYPOINT "\n"
 		 "csrw mepc, t0\n" // __set_MEPC is not available here
 		 "mret\n");
 #elif defined(CH582_CH583)
-	__ASM( "la gp, " ISPROM_GLOBALPOINTER "\n"
+	asm( "la gp, " ISPROM_GLOBALPOINTER "\n"
 		 "j " ISPROM_ENTRYPOINT "\n");
 #endif
 }

--- a/examples_ch5xx/uart_send_receive/fun_uart_ch5xx.h
+++ b/examples_ch5xx/uart_send_receive/fun_uart_ch5xx.h
@@ -5,7 +5,7 @@
 
 #define FUNCONF_UART_PRINTF_BAUD 115200
 
-void uart_init_ch5xx(UART_Typedef *UARTx, int baudrate) {
+void uart_init_ch5xx(UART_TypeDef *UARTx, int baudrate) {
 	//# Configure GPIOs for CH582
 	if (UARTx == UART0) {
 		funPinMode(PB4, GPIO_CFGLR_IN_PU);		   // RX0 (PB4)
@@ -50,7 +50,7 @@ void uart_init_ch5xx(UART_Typedef *UARTx, int baudrate) {
 	UARTx->DIV = divider;
 }
 
-void uart_send_ch5xx(UART_Typedef *UARTx, u8 *buf, u16 len) {
+void uart_send_ch5xx(UART_TypeDef *UARTx, u8 *buf, u16 len) {
 	for (int i = 0; i < len; i++) {
 		while (!(UARTx->LSR & RB_LSR_TX_ALL_EMP));
 		UARTx->THR_RBR = buf[i];
@@ -58,7 +58,7 @@ void uart_send_ch5xx(UART_Typedef *UARTx, u8 *buf, u16 len) {
 }
 
 //! NOTE: if you are debugging with printf, note that it introduces a delay   
-u16 uart_receive_ch5xx( UART_Typedef *UARTx, u8 *buf, u16 max_len) {
+u16 uart_receive_ch5xx( UART_TypeDef *UARTx, u8 *buf, u16 max_len) {
 	u16 len = 0;
 	u32 start_time = SysTick->CNT;
 

--- a/examples_usb/USBFS/usbfs_cdc_uart/uart.c
+++ b/examples_usb/USBFS/usbfs_cdc_uart/uart.c
@@ -13,7 +13,7 @@ void uart_reset() {
 	// Manually clearing FIFO, because CH570 doesn't have reset UART function
 	for(int i = 0; i <= UART(cdc.uart->number)->RFC; i++)
 	{
-		UART(cdc.uart->number)->THR;
+		UART(cdc.uart->number)->THR_RBR;
 	}
 #endif
 #ifndef CH5xx
@@ -165,7 +165,7 @@ void uart_process_rx(CDC_config_t * ctx) {
 		
 		for (i = 0; i <= UART(ctx->uart->number)->RFC; i++) {
 			if ((pos + i) >= UART_RX_BUF_SIZE) pos -= UART_RX_BUF_SIZE;
-			uart_rx_buffer[pos+i] = UART(ctx->uart->number)->THR;
+			uart_rx_buffer[pos+i] = UART(ctx->uart->number)->THR_RBR;
 		}
 		
 		if ((ctx->rx_remain += i) > UART_RX_BUF_SIZE) {
@@ -271,7 +271,7 @@ void uart_process_tx(CDC_config_t * ctx) {
 	int local_pos = ctx->tx_pos;
 	// ctx->txing = 1;
 	while (ctx->tx_remain && UART(ctx->uart->number)->TFC != UART_FIFO_SIZE) {
-		UART(ctx->uart->number)->THR = uart_tx_buffer[local_pos++];
+		UART(ctx->uart->number)->THR_RBR = uart_tx_buffer[local_pos++];
 		if (ctx->tx_wrap_pos <= local_pos) {
 			local_pos = 0;
 			ctx->tx_wrap_pos = UART_TX_BUF_SIZE;

--- a/examples_usb/USBFS/usbfs_cdc_uart/uart.h
+++ b/examples_usb/USBFS/usbfs_cdc_uart/uart.h
@@ -5,23 +5,6 @@
 #include "ch32fun.h"
 
 #ifdef CH5xx
-typedef struct {
-	volatile uint8_t MCR;
-	volatile uint8_t IER;
-	volatile uint8_t FCR;
-	volatile uint8_t LCR;
-	volatile uint8_t IIR;
-	volatile uint8_t LSR;
-	uint16_t reserved_1;
-	volatile uint8_t THR;
-	uint8_t reserved_2;
-	volatile uint8_t RFC;
-	volatile uint8_t TFC;
-	volatile uint16_t DL;
-	volatile uint8_t DIV;
-	volatile uint8_t ADR;
-} UART_TypeDef;
-
 #define USART_WordLength_5b 0x00
 #define USART_WordLength_6b 0x01
 #define USART_WordLength_7b 0x02


### PR DESCRIPTION
This PR adds missing peripheral register structure definitions for CH5xx (GPIO, SPI, PWM, I2C, TMR, etc.). 
These definitions bring CH5xx in line with other SoCs (e.g. CH32Vxxx) and make it easier to write low-level drivers, for example in Zephyr, which maintains a fork of this project as a WCH HAL (https://github.com/zephyrproject-rtos/hal_wch).

Additionally, `asm` usages have been replaced with `__ASM` to match the conventions used in ch32fun.h and ensure consistency across the codebase.