### PR TITLE
Use serial number to choose WCH-LinkE when multiple ones plugged

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -46,10 +46,11 @@ void * MiniCHLinkInitAsDLL( struct MiniChlinkFunctions ** MCFO, const init_hints
 	fprintf(stderr, "minichlink version - %s\n", version);
 #endif
 	const char * specpgm = init_hints->specific_programmer;
+	const char * le_serial = init_hints->wch_linke_serial ? init_hints->wch_linke_serial : "";
 	if( specpgm )
 	{
 		if( strcmp( specpgm, "linke" ) == 0 )
-			dev = TryInit_WCHLinkE();
+			dev = TryInit_WCHLinkE(le_serial);
 		else if( strcmp( specpgm, "isp" ) == 0 )
 			dev = TryInit_WCHISP();
 		else if( !strcmp( specpgm, "esp32s2chfun" ) || !strcmp( specpgm, "funprog" ) )
@@ -67,7 +68,7 @@ void * MiniCHLinkInitAsDLL( struct MiniChlinkFunctions ** MCFO, const init_hints
 		{
 			fprintf( stderr, "Found MCU in bootloader mode\n" );
 		}
-		else if( (dev = TryInit_WCHLinkE()) )
+		else if( (dev = TryInit_WCHLinkE(le_serial)) )
 		{
 			fprintf( stderr, "Found WCH Link\n" );
 		}
@@ -153,6 +154,19 @@ int main( int argc, char ** argv )
 			if( i < argc )
 				hints.specific_programmer = argv[i];
 		}
+		else if( strncmp( v, "-l", 2 ) == 0 )
+		{
+			i++;
+			if( i < argc )
+				hints.wch_linke_serial = argv[i];
+		}
+	}
+
+	if( !hints.wch_linke_serial )
+	{
+		const char * env_serial = getenv( "MINICHLINK_LINKE_SERIAL" );
+		if( env_serial && env_serial[0] )
+			hints.wch_linke_serial = env_serial;
 	}
 
 #if !defined(WINDOWS) && !defined(WIN32) && !defined(_WIN32) && !defined(__APPLE__)
@@ -275,12 +289,13 @@ keep_going:
 				break;
 			case 'C': // For specifying programmer
 			case 'c':
+			case 'l': // WCH-LinkE USB serial (parsed previously)
 				// COM port or programmer argument already parsed previously
 				// we still need to skip the next argument
 				iarg+=1;
 				if( iarg >= argc )
 				{
-					fprintf( stderr, "-c/C argument required 2 arguments\n" );
+					fprintf( stderr, "-c/C/-l argument required 2 arguments\n" );
 					goto unimplemented;
 				}
 				break;
@@ -1052,7 +1067,8 @@ help:
 	fprintf( stderr, " -f Disable 5V\n" );
 	fprintf( stderr, " -k Skip programmer initialization\n" );
 	fprintf( stderr, " -c [serial port for Ardulink, try /dev/ttyACM0 or COM11 etc] or [VID+PID of USB for b003boot, try 0x1209b003]\n" );
-	fprintf( stderr, " -C [specified programmer, eg. b003boot, ardulink, esp32s2chfun, funprog, isp]\n" );
+	fprintf( stderr, " -C [specified programmer, eg. b003boot, ardulink, esp32s2chfun, funprog, isp, linke]\n" );
+	fprintf( stderr, " -l [WCH-LinkE USB serial; omit for default device selection]\n" );
 	fprintf( stderr, " -u Clear all code flash - by power off (also can unbrick)\n" );
 	fprintf( stderr, " -a Reboot into Halt\n" );
 	fprintf( stderr, " -A Go into Halt without reboot\n" );

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -46,11 +46,10 @@ void * MiniCHLinkInitAsDLL( struct MiniChlinkFunctions ** MCFO, const init_hints
 	fprintf(stderr, "minichlink version - %s\n", version);
 #endif
 	const char * specpgm = init_hints->specific_programmer;
-	const char * le_serial = init_hints->wch_linke_serial ? init_hints->wch_linke_serial : "";
 	if( specpgm )
 	{
 		if( strcmp( specpgm, "linke" ) == 0 )
-			dev = TryInit_WCHLinkE(le_serial);
+			dev = TryInit_WCHLinkE(init_hints);
 		else if( strcmp( specpgm, "isp" ) == 0 )
 			dev = TryInit_WCHISP();
 		else if( !strcmp( specpgm, "esp32s2chfun" ) || !strcmp( specpgm, "funprog" ) )
@@ -68,7 +67,7 @@ void * MiniCHLinkInitAsDLL( struct MiniChlinkFunctions ** MCFO, const init_hints
 		{
 			fprintf( stderr, "Found MCU in bootloader mode\n" );
 		}
-		else if( (dev = TryInit_WCHLinkE(le_serial)) )
+		else if( (dev = TryInit_WCHLinkE(init_hints)) )
 		{
 			fprintf( stderr, "Found WCH Link\n" );
 		}
@@ -158,15 +157,17 @@ int main( int argc, char ** argv )
 		{
 			i++;
 			if( i < argc )
-				hints.wch_linke_serial = argv[i];
+				hints.programmer_serial_number = argv[i];
 		}
 	}
 
-	if( !hints.wch_linke_serial )
+	if( !hints.programmer_serial_number )
 	{
-		const char * env_serial = getenv( "MINICHLINK_LINKE_SERIAL" );
+		const char * env_serial = getenv( "MINICHLINK_programmer_serial_number" );
+		if( !env_serial || !env_serial[0] )
+			env_serial = getenv( "MINICHLINK_LINKE_SERIAL" );
 		if( env_serial && env_serial[0] )
-			hints.wch_linke_serial = env_serial;
+			hints.programmer_serial_number = env_serial;
 	}
 
 #if !defined(WINDOWS) && !defined(WIN32) && !defined(_WIN32) && !defined(__APPLE__)
@@ -289,7 +290,7 @@ keep_going:
 				break;
 			case 'C': // For specifying programmer
 			case 'c':
-			case 'l': // WCH-LinkE USB serial (parsed previously)
+			case 'l': // programmer USB serial (parsed previously)
 				// COM port or programmer argument already parsed previously
 				// we still need to skip the next argument
 				iarg+=1;
@@ -1068,7 +1069,7 @@ help:
 	fprintf( stderr, " -k Skip programmer initialization\n" );
 	fprintf( stderr, " -c [serial port for Ardulink, try /dev/ttyACM0 or COM11 etc] or [VID+PID of USB for b003boot, try 0x1209b003]\n" );
 	fprintf( stderr, " -C [specified programmer, eg. b003boot, ardulink, esp32s2chfun, funprog, isp, linke]\n" );
-	fprintf( stderr, " -l [WCH-LinkE USB serial; omit for default device selection]\n" );
+	fprintf( stderr, " -l [programmer USB serial; omit for default device selection]\n" );
 	fprintf( stderr, " -u Clear all code flash - by power off (also can unbrick)\n" );
 	fprintf( stderr, " -a Reboot into Halt\n" );
 	fprintf( stderr, " -A Go into Halt without reboot\n" );

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -263,13 +263,14 @@ struct InternalState
 typedef struct {
 	const char * serial_port;
 	const char * specific_programmer;
+	const char * wch_linke_serial; /* NULL or "" = any WCH-LinkE */
 } init_hints_t;
 
 void * MiniCHLinkInitAsDLL(struct MiniChlinkFunctions ** MCFO, const init_hints_t* init_hints) DLLDECORATE;
 extern struct MiniChlinkFunctions MCF;
 
 // Returns 'dev' on success, else 0.
-void * TryInit_WCHLinkE(void);
+void * TryInit_WCHLinkE(const char * wch_linke_serial);
 void * TryInit_WCHISP(void);
 void * TryInit_ESP32S2CHFUN(uint32_t id);
 void * TryInit_NHCLink042(void);

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -263,14 +263,14 @@ struct InternalState
 typedef struct {
 	const char * serial_port;
 	const char * specific_programmer;
-	const char * wch_linke_serial; /* NULL or "" = any WCH-LinkE */
+	const char * programmer_serial_number; /* NULL or "" = no USB serial filter */
 } init_hints_t;
 
 void * MiniCHLinkInitAsDLL(struct MiniChlinkFunctions ** MCFO, const init_hints_t* init_hints) DLLDECORATE;
 extern struct MiniChlinkFunctions MCF;
 
 // Returns 'dev' on success, else 0.
-void * TryInit_WCHLinkE(const char * wch_linke_serial);
+void * TryInit_WCHLinkE(const init_hints_t * hints);
 void * TryInit_WCHISP(void);
 void * TryInit_ESP32S2CHFUN(uint32_t id);
 void * TryInit_NHCLink042(void);

--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -106,9 +106,9 @@ static void wch_link_multicommands( libusb_device_handle * devh, int nrcommands,
 	va_end( argp );
 }
 
-#define WCH_LINKE_SERIAL_MAX 256
+#define USB_SERIAL_MAX 256
 
-static int wch_linke_read_serial( libusb_device *device, char *buf, size_t buflen )
+static int get_usb_serialnumber( libusb_device *device, char *buf, size_t buflen )
 {
 	struct libusb_device_descriptor desc;
 	if( libusb_get_device_descriptor( device, &desc ) != 0 || desc.iSerialNumber == 0 )
@@ -125,8 +125,8 @@ static int wch_linke_device_matches_serial( libusb_device *device, const char *w
 {
 	if( !want_serial || !want_serial[0] )
 		return 1;
-	char buf[WCH_LINKE_SERIAL_MAX];
-	if( wch_linke_read_serial( device, buf, sizeof( buf ) ) != 0 )
+	char buf[USB_SERIAL_MAX];
+	if( get_usb_serialnumber( device, buf, sizeof( buf ) ) != 0 )
 		return 0;
 	return strcmp( buf, want_serial ) == 0;
 }
@@ -178,8 +178,8 @@ static inline libusb_device_handle * wch_link_base_setup( int inhibit_startup, c
 			struct libusb_device_descriptor desc;
 			if( libusb_get_device_descriptor(device,&desc) != 0 ) continue;
 			if( desc.idVendor != 0x1a86 || desc.idProduct != 0x8010 ) continue;
-			char buf[WCH_LINKE_SERIAL_MAX];
-			if( wch_linke_read_serial( device, buf, sizeof( buf ) ) == 0 )
+			char buf[USB_SERIAL_MAX];
+			if( get_usb_serialnumber( device, buf, sizeof( buf ) ) == 0 )
 				fprintf( stderr, " (available: '%s')", buf );
 		}
 		fprintf( stderr, "\n" );

--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -161,10 +161,12 @@ static inline libusb_device_handle * wch_link_base_setup( int inhibit_startup, c
 				found = device;
 		}
 		if( r == 0 && desc.idVendor == 0x1a86 && desc.idProduct == 0x8012) {
+			saw_linke = 1;
 			if( usb_device_matches_serial( device, want_serial ) )
 				found_arm_programmer = device;
 		}
 		if( r == 0 && desc.idVendor == 0x4348 && desc.idProduct == 0x55e0) {
+			saw_linke = 1;
 			if( usb_device_matches_serial( device, want_serial ) )
 				found_programmer_in_iap = device;
 		}
@@ -176,11 +178,19 @@ static inline libusb_device_handle * wch_link_base_setup( int inhibit_startup, c
 		for (i = 0; i < cnt; i++) {
 			libusb_device *device = list[i];
 			struct libusb_device_descriptor desc;
+			const char * mode_label;
 			if( libusb_get_device_descriptor(device,&desc) != 0 ) continue;
-			if( desc.idVendor != 0x1a86 || desc.idProduct != 0x8010 ) continue;
+			if( desc.idVendor == 0x1a86 && desc.idProduct == 0x8010 )
+				mode_label = "RISC-V";
+			else if( desc.idVendor == 0x1a86 && desc.idProduct == 0x8012 )
+				mode_label = "ARM";
+			else if( desc.idVendor == 0x4348 && desc.idProduct == 0x55e0 )
+				mode_label = "IAP";
+			else
+				continue;
 			char buf[USB_SERIAL_MAX];
 			if( get_usb_serialnumber( device, buf, sizeof( buf ) ) == 0 )
-				fprintf( stderr, " (available: '%s')", buf );
+				fprintf( stderr, " (available %s: '%s')", mode_label, buf );
 		}
 		fprintf( stderr, "\n" );
 	}

--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -106,7 +106,32 @@ static void wch_link_multicommands( libusb_device_handle * devh, int nrcommands,
 	va_end( argp );
 }
 
-static inline libusb_device_handle * wch_link_base_setup( int inhibit_startup )
+#define WCH_LINKE_SERIAL_MAX 256
+
+static int wch_linke_read_serial( libusb_device *device, char *buf, size_t buflen )
+{
+	struct libusb_device_descriptor desc;
+	if( libusb_get_device_descriptor( device, &desc ) != 0 || desc.iSerialNumber == 0 )
+		return -1;
+	libusb_device_handle *handle;
+	if( libusb_open( device, &handle ) != 0 )
+		return -1;
+	int r = libusb_get_string_descriptor_ascii( handle, desc.iSerialNumber, (unsigned char *)buf, buflen );
+	libusb_close( handle );
+	return ( r >= 0 ) ? 0 : -1;
+}
+
+static int wch_linke_device_matches_serial( libusb_device *device, const char *want_serial )
+{
+	if( !want_serial || !want_serial[0] )
+		return 1;
+	char buf[WCH_LINKE_SERIAL_MAX];
+	if( wch_linke_read_serial( device, buf, sizeof( buf ) ) != 0 )
+		return 0;
+	return strcmp( buf, want_serial ) == 0;
+}
+
+static inline libusb_device_handle * wch_link_base_setup( int inhibit_startup, const char * want_serial )
 {
 	libusb_context * ctx = 0;
 	int status;
@@ -123,15 +148,44 @@ static inline libusb_device_handle * wch_link_base_setup( int inhibit_startup )
 	libusb_device *found = NULL;
 	libusb_device * found_arm_programmer = NULL;
 	libusb_device * found_programmer_in_iap = NULL;
+	int saw_linke = 0;
+	const int filter_serial = ( want_serial && want_serial[0] );
 
 	for (i = 0; i < cnt; i++) {
 		libusb_device *device = list[i];
 		struct libusb_device_descriptor desc;
 		int r = libusb_get_device_descriptor(device,&desc);
-		if( r == 0 && desc.idVendor == 0x1a86 && desc.idProduct == 0x8010 ) { found = device; }
-		if( r == 0 && desc.idVendor == 0x1a86 && desc.idProduct == 0x8012) { found_arm_programmer = device; }
-		if( r == 0 && desc.idVendor == 0x4348 && desc.idProduct == 0x55e0) { found_programmer_in_iap = device; }
+		if( r == 0 && desc.idVendor == 0x1a86 && desc.idProduct == 0x8010 ) {
+			saw_linke = 1;
+			if( wch_linke_device_matches_serial( device, want_serial ) )
+				found = device;
+		}
+		if( r == 0 && desc.idVendor == 0x1a86 && desc.idProduct == 0x8012) {
+			if( wch_linke_device_matches_serial( device, want_serial ) )
+				found_arm_programmer = device;
+		}
+		if( r == 0 && desc.idVendor == 0x4348 && desc.idProduct == 0x55e0) {
+			if( wch_linke_device_matches_serial( device, want_serial ) )
+				found_programmer_in_iap = device;
+		}
 	}
+
+	if( filter_serial && !found && saw_linke )
+	{
+		fprintf( stderr, "No WCH-LinkE with serial '%s' found.", want_serial );
+		for (i = 0; i < cnt; i++) {
+			libusb_device *device = list[i];
+			struct libusb_device_descriptor desc;
+			if( libusb_get_device_descriptor(device,&desc) != 0 ) continue;
+			if( desc.idVendor != 0x1a86 || desc.idProduct != 0x8010 ) continue;
+			char buf[WCH_LINKE_SERIAL_MAX];
+			if( wch_linke_read_serial( device, buf, sizeof( buf ) ) == 0 )
+				fprintf( stderr, " (available: '%s')", buf );
+		}
+		fprintf( stderr, "\n" );
+	}
+
+	libusb_free_device_list( list, 1 );
 
 	if( !found )
 	{
@@ -626,10 +680,10 @@ static int LEExit( void * d )
 	return 0;
 }
 
-void * TryInit_WCHLinkE()
+void * TryInit_WCHLinkE(const char * wch_linke_serial)
 {
 	libusb_device_handle * wch_linke_devh;
-	wch_linke_devh = wch_link_base_setup(0);
+	wch_linke_devh = wch_link_base_setup(0, wch_linke_serial);
 	if( !wch_linke_devh ) return 0;
 
 	struct LinkEProgrammerStruct * ret = malloc( sizeof( struct LinkEProgrammerStruct ) );

--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -12,12 +12,14 @@
 #include "chips.h"
 
 #define FORCE_EXTERNAL_CHIP_DETECTION 1
+#define USB_SERIAL_MAX 256
 
 struct LinkEProgrammerStruct
 {
 	void * internal;
 	libusb_device_handle * devh;
 	int lasthaltmode; // For non-003 chips
+	char programmer_serial_number[USB_SERIAL_MAX]; /* "" if unfiltered */
 };
 #if !FORCE_EXTERNAL_CHIP_DETECTION
 static int checkChip(enum RiscVChip chip) {
@@ -106,8 +108,6 @@ static void wch_link_multicommands( libusb_device_handle * devh, int nrcommands,
 	va_end( argp );
 }
 
-#define USB_SERIAL_MAX 256
-
 static int get_usb_serialnumber( libusb_device *device, char *buf, size_t buflen )
 {
 	struct libusb_device_descriptor desc;
@@ -121,7 +121,7 @@ static int get_usb_serialnumber( libusb_device *device, char *buf, size_t buflen
 	return ( r >= 0 ) ? 0 : -1;
 }
 
-static int wch_linke_device_matches_serial( libusb_device *device, const char *want_serial )
+static int usb_device_matches_serial( libusb_device *device, const char *want_serial )
 {
 	if( !want_serial || !want_serial[0] )
 		return 1;
@@ -157,22 +157,22 @@ static inline libusb_device_handle * wch_link_base_setup( int inhibit_startup, c
 		int r = libusb_get_device_descriptor(device,&desc);
 		if( r == 0 && desc.idVendor == 0x1a86 && desc.idProduct == 0x8010 ) {
 			saw_linke = 1;
-			if( wch_linke_device_matches_serial( device, want_serial ) )
+			if( usb_device_matches_serial( device, want_serial ) )
 				found = device;
 		}
 		if( r == 0 && desc.idVendor == 0x1a86 && desc.idProduct == 0x8012) {
-			if( wch_linke_device_matches_serial( device, want_serial ) )
+			if( usb_device_matches_serial( device, want_serial ) )
 				found_arm_programmer = device;
 		}
 		if( r == 0 && desc.idVendor == 0x4348 && desc.idProduct == 0x55e0) {
-			if( wch_linke_device_matches_serial( device, want_serial ) )
+			if( usb_device_matches_serial( device, want_serial ) )
 				found_programmer_in_iap = device;
 		}
 	}
 
 	if( filter_serial && !found && saw_linke )
 	{
-		fprintf( stderr, "No WCH-LinkE with serial '%s' found.", want_serial );
+		fprintf( stderr, "No matching WCH-LinkE (serial '%s') found.", want_serial );
 		for (i = 0; i < cnt; i++) {
 			libusb_device *device = list[i];
 			struct libusb_device_descriptor desc;
@@ -680,16 +680,21 @@ static int LEExit( void * d )
 	return 0;
 }
 
-void * TryInit_WCHLinkE(const char * wch_linke_serial)
+void * TryInit_WCHLinkE(const init_hints_t * hints)
 {
+	const char * want_serial = "";
+	if( hints && hints->programmer_serial_number && hints->programmer_serial_number[0] )
+		want_serial = hints->programmer_serial_number;
+
 	libusb_device_handle * wch_linke_devh;
-	wch_linke_devh = wch_link_base_setup(0, wch_linke_serial);
+	wch_linke_devh = wch_link_base_setup(0, want_serial);
 	if( !wch_linke_devh ) return 0;
 
 	struct LinkEProgrammerStruct * ret = malloc( sizeof( struct LinkEProgrammerStruct ) );
 	memset( ret, 0, sizeof( *ret ) );
 	ret->devh = wch_linke_devh;
 	ret->lasthaltmode = 0;
+	strncpy( ret->programmer_serial_number, want_serial, sizeof( ret->programmer_serial_number ) - 1 );
 
 	MCF.ReadReg32 = LEReadReg32;
 	MCF.WriteReg32 = LEWriteReg32;


### PR DESCRIPTION
This commit added -l argument to pass in a serial number. If serial number is passed, the pgm-wch-linke.c will use the WCH-LinkE with matching serial number. Rather than last one wins.
