### PR TITLE
Support 192k ram split

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -2863,7 +2863,9 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 	flash_ctlr &= CR_OPTER_Reset;
 	flash_ctlr |= CR_OPTPG_Set;
 	if( MCF.WriteWord( dev, (intptr_t)&FLASH->CTLR, flash_ctlr ) ) goto flashoperr;
-	if( MCF.WriteWord( dev, (intptr_t)&OB->RDPR, RDP_Key ) ) goto flashoperr;
+	uint16_t rdpr_bytes = (uint16_t)RDP_Key;
+	rdpr_bytes |= (uint16_t)((uint16_t)~rdpr_bytes) << 8;
+	if( MCF.WriteHalfWord( dev, (intptr_t)&OB->RDPR, rdpr_bytes ) ) goto flashoperr;
 	if( MCF.WaitForFlash(dev) ) goto flashoperr;
 
 	if( MCF.WriteWord( dev, (intptr_t)&FLASH->OBKEYR, FLASH_KEY1 ) ) goto flashoperr;

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -2732,6 +2732,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			|| chip == 0x305C0508
 			|| chip == 0x30700508 
 			|| chip == 0x30710508 
+			|| chip == 0x30720508
 			|| chip == 0x30730508
 			|| chip == 0x30740508
 			|| chip == 0x3170B508
@@ -2749,6 +2750,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			|| chip == 0x305C0508
 			|| chip == 0x30700508 
 			|| chip == 0x30710508 
+			|| chip == 0x30720508
 			|| chip == 0x30730508
 			|| chip == 0x30740508
 			|| chip == 0x3170B508
@@ -2766,6 +2768,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			 || chip == 0x305C0508
 			 || chip == 0x30700508 
 			 || chip == 0x30710508 
+			 || chip == 0x30720508
 			 || chip == 0x30730508
 			 || chip == 0x30740508
 			 || chip == 0x3170B508
@@ -2783,6 +2786,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			 || chip == 0x305C0508
 			 || chip == 0x30700508 
 			 || chip == 0x30710508 
+			 || chip == 0x30720508
 			 || chip == 0x30730508
 			 || chip == 0x30740508
 			 || chip == 0x3170B508
@@ -2800,6 +2804,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			|| chip == 0x305C0508
 			|| chip == 0x30700508 
 			|| chip == 0x30710508 
+			|| chip == 0x30720508
 			|| chip == 0x30730508
 			|| chip == 0x30740508
 			|| chip == 0x3170B508
@@ -2865,6 +2870,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 	if( MCF.ReadHalfWord( dev, (intptr_t)&OB->USER, &option_bytes ) ) goto flashoperr;
 	printf("initial option_bytes = %04x\n", option_bytes);
 
+	// since WCH expand ram config bits, from 9:8, to 9:7. We expand option_bytes to 3 bit and shift for 5 bit instead of 6.
 
 	// Option byte b is stored as 16 bits (~b << 8)|b
 	// Mask off upper copy and clear split bits

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -2666,6 +2666,30 @@ flashoperr:
 
 static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 
+	// WCH expand ram config bits, from 9:8, to 9:7. And this caused split_code change in all cases.
+	// in older CH32FV2x_V3x Reference Manual V1.03
+	// SRAM_CODE_MODE is in [9:8], for large ram chip: CH32V303RC, CH32V303VC, CH32V307RC, CH32V307WC, CH32V307VC, CH32F203RC, CH32F203VC and CH32F207VC 
+	// 00: CODE-192KB + RAM-128KB
+	// 01: CODE-224KB + RAM-96KB
+	// 10: CODE-256KB + RAM-64KB
+	// 11: CODE-288KB + RAM-32KB 
+	// for small ram chip,CH32V20x_D8W, CH32V20x_D8 and CH32F20x_D8W
+	// 00: CODE-128KB + RAM-64KB
+	// 01: CODE-144KB + RAM-48KB
+	// 1x: CODE-160KB + RAM-32KB 
+	// but in newer CH32FV2x_V3x Reference Manual V2.4, the SRAM_CODE_MODE is in [9:7]
+	// for large ram chip: CCH32V303RC, CH32V303VC, CH32V307RC, CH32V307WC, CH32V307VC, CH32F203RC, CH32F203VC, CH32F207VC, CH32V317VC, CH32V317WC, CH32V317SC
+	// 00x: CODE-192KB + RAM-128KB 
+	// 01x: CODE-224KB + RAM-96KB 
+	// 10x: CODE-256KB + RAM-64KB 
+	// 110: CODE-128KB + RAM-192KB 
+	// 111: CODE-288KB + RAM-32KB
+	// for small ram chip: CH32V20x_D8W, CH32V20x_D8 and CH32F20x_D8W
+	// 00x: CODE-128KB + RAM-64KB 
+	// 01x: CODE-144KB + RAM-48KB 
+	// 1xx: CODE-160KB + RAM-32KB
+	// so most split_code shifted left by 1 bit and get bit 0 to be 1, except for FLASH_128_RAM_192 and FLASH_288_RAM_32.
+
 	uint8_t split_code = 0;
 	uint16_t option_bytes = 0;
 	uint32_t flash_ctlr = 0;

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -406,7 +406,9 @@ keep_going:
 					split = FLASH_256_RAM_64;
 				} else if (flash_size == 288 && sram_size == 32) {
 					split = FLASH_288_RAM_32;
-				}else if (flash_size == 128 && sram_size == 64) {
+				} else if (flash_size == 128 && sram_size == 192) {
+					split = FLASH_128_RAM_192;
+				} else if (flash_size == 128 && sram_size == 64) {
 					split = FLASH_128_RAM_64;
 				} else if (flash_size == 144 && sram_size == 48) {
 					split = FLASH_144_RAM_48;
@@ -2688,6 +2690,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 	* CH32V305FBP6: 0x305205x8
 	* CH32V305RBT6: 0x305005x8
 	* CH32V305GBU6: 0x305B05x8
+	* CH32V305CCT6: 0x305C05x8
 	* CH32V307WCU6: 0x307305x8
 	* CH32V307FBP6: 0x307205x8
 	* CH32V307RCT6: 0x307105x8
@@ -2700,14 +2703,16 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 	switch (split)
 	{
 		case FLASH_192_RAM_128:
-			if (chip == 0x30700508 
-			 || chip == 0x30710508 
-			 || chip == 0x30730508
-			 || chip == 0x30300504
-			 || chip == 0x30310504
-			 || chip == 0x30720508
-			 || chip == 0x30740508) {
-				split_code = 0;
+		   if (chip == 0x30300504
+			|| chip == 0x30310504
+			|| chip == 0x305C0508
+			|| chip == 0x30700508 
+			|| chip == 0x30710508 
+			|| chip == 0x30730508
+			|| chip == 0x30740508
+			|| chip == 0x3170B508
+			|| chip == 0x3173B508) {
+				split_code = 1;
 			} else {
 				fprintf( stderr, "Error, 192k/128k split not supported for chip 0x%08x\n", chip);
 				exit( -110 );
@@ -2715,14 +2720,16 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			break;
 		
 		case FLASH_224_RAM_96:
-			if (chip == 0x30700508 
-			 || chip == 0x30710508 
-			 || chip == 0x30730508
-			 || chip == 0x30300504
-			 || chip == 0x30310504
-			 || chip == 0x30720508
-			 || chip == 0x30740508) {
-				split_code = 1;
+		   if (chip == 0x30300504
+			|| chip == 0x30310504
+			|| chip == 0x305C0508
+			|| chip == 0x30700508 
+			|| chip == 0x30710508 
+			|| chip == 0x30730508
+			|| chip == 0x30740508
+			|| chip == 0x3170B508
+			|| chip == 0x3173B508) {
+				split_code = 3;
 			} else {
 				fprintf( stderr, "Error, 224k/96k split not supported for chip 0x%08x\n", chip);
 				exit( -110 );
@@ -2730,25 +2737,50 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			break;
 		
 		case FLASH_256_RAM_64:
-			if (chip == 0x30700508 
+			if (chip == 0x30300504
+			 || chip == 0x30310504
+			 || chip == 0x305C0508
+			 || chip == 0x30700508 
 			 || chip == 0x30710508 
 			 || chip == 0x30730508
-			 || chip == 0x30300504
-			 || chip == 0x30310504) {
-				split_code = 2;
+			 || chip == 0x30740508
+			 || chip == 0x3170B508
+			 || chip == 0x3173B508) {
+				split_code = 5;
 			} else {
 				fprintf( stderr, "Error, 256k/64k split not supported for chip 0x%08x\n", chip);
 				exit( -110 );
 			}
 			break;
-
-		case FLASH_288_RAM_32:
-			if (chip == 0x30700508 
+		
+		case FLASH_128_RAM_192:
+			if (chip == 0x30300504
+			 || chip == 0x30310504
+			 || chip == 0x305C0508
+			 || chip == 0x30700508 
 			 || chip == 0x30710508 
 			 || chip == 0x30730508
-			 || chip == 0x30300504
-			 || chip == 0x30310504) {
-				split_code = 3;
+			 || chip == 0x30740508
+			 || chip == 0x3170B508
+			 || chip == 0x3173B508) {
+				split_code = 6;
+			} else {
+				fprintf( stderr, "Error, 128k/192k split not supported for chip 0x%08x\n", chip);
+				exit( -110 );
+			}
+			break;
+
+		case FLASH_288_RAM_32:
+		   if (chip == 0x30300504
+			|| chip == 0x30310504
+			|| chip == 0x305C0508
+			|| chip == 0x30700508 
+			|| chip == 0x30710508 
+			|| chip == 0x30730508
+			|| chip == 0x30740508
+			|| chip == 0x3170B508
+			|| chip == 0x3173B508) {
+				split_code = 7;
 			} else {
 				fprintf( stderr, "Error, 288k/32k split not supported for chip 0x%08x\n", chip);
 				exit( -110 );
@@ -2761,7 +2793,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			 || chip == 0x2081050c
 			 || chip == 0x2082050c
 			 || chip == 0x2083050c) {
-				split_code = 0;
+				split_code = 1;
 			} else {
 				fprintf( stderr, "Error, 128k/64k split not supported for chip 0x%08x\n", chip);
 				exit( -110 );
@@ -2774,7 +2806,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			 || chip == 0x2081050c
 			 || chip == 0x2082050c
 			 || chip == 0x2083050c) {
-				split_code = 1;
+				split_code = 3;
 			} else {
 				fprintf( stderr, "Error, 144k/48k split not supported for chip 0x%08x\n", chip);
 				exit( -110 );
@@ -2787,7 +2819,7 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 			 || chip == 0x2081050c
 			 || chip == 0x2082050c
 			 || chip == 0x2083050c) {
-				split_code = 2;
+				split_code = 5;
 			} else {
 				fprintf( stderr, "Error, 160k/32k split not supported for chip 0x%08x\n", chip);
 				exit( -110 );
@@ -2812,9 +2844,9 @@ static int DefaultSetSplit(void * dev, enum RAMSplit split) {
 
 	// Option byte b is stored as 16 bits (~b << 8)|b
 	// Mask off upper copy and clear split bits
-	option_bytes &= 0x003F;
-	// Set split code at [7:6]
-	option_bytes |= split_code << 6;
+	option_bytes &= 0x001F;
+	// Set split code at [7:5]
+	option_bytes |= split_code << 5;
 	// Add inverted copy back as high byte
 	option_bytes |= (~option_bytes) << 8;
 

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -145,10 +145,11 @@ enum RiscVChip {
 
 enum RAMSplit {
 	// For supported V30x and some V20x devices
-	FLASH_192_RAM_128 = 0x00,
-	FLASH_224_RAM_96  = 0x01,
-	FLASH_256_RAM_64  = 0x02,
-	FLASH_288_RAM_32  = 0x03,
+	FLASH_192_RAM_128 = 0x01,
+	FLASH_224_RAM_96  = 0x02,
+	FLASH_256_RAM_64  = 0x04,
+	FLASH_128_RAM_192 = 0x06,
+	FLASH_288_RAM_32  = 0x07,
 
 	// For some V20x devices
 	FLASH_128_RAM_64  = 0x10,


### PR DESCRIPTION
The new version of reference manual seems use 3 bits instead of 2 bits for Ram split.

<img width="2464" height="1466" alt="Screenshot 2026-06-03 at 2 38 37 AM" src="https://github.com/user-attachments/assets/c469da87-dc8b-4ce0-93dc-28d612fee2fb" />

So the split_code is changed to 3 bits.

Also fixed the bug that the chip became Read Protected after ram split, by restore RDPR properly.
