### PR TITLE
Fix bug in I2C pin remapping instructions in README

### DIFF
--- a/examples/i2c_slave/README.md
+++ b/examples/i2c_slave/README.md
@@ -34,19 +34,21 @@ Remapping examples:
 // 2 bits [bit 22 and bit 1] of AFIO_PCFR1 register are what control I2C1 pin remapping on ch32v003
 // [high bit, low bit]
 // [I2C1REMAP1, I2C1_RM]
+//
+// Important: always set/clear both bits in a single read-modify-write operation.
+// Two separate writes (one per bit) risk the second read returning stale data on some
+// CH32V003 silicon batches, silently routing I2C to the wrong pins with no other
+// indication of failure.
 
-// [0, 0]				default mapping (SCL on pin PC2, SDA on pin PC1)
-// (note: you don't need to do this, since it's the defualt:)
-AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;	  // set high bit = 0  (I2C1REMAP1)
-AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_REMAP;            // set low bit = 0   (I2C1_RM)
+// [0, 0]                     default mapping (SCL on pin PC2, SDA on pin PC1)
+// (note: you don't need to do this, since it's the default, unless you changed the mappings elsewhere)
+AFIO->PCFR1 &= ~(AFIO_PCFR1_I2C1_HIGH_BIT_REMAP | AFIO_PCFR1_I2C1_REMAP);  // high bit = 0 (I2C1REMAP1), low bit = 0 (I2C1_RM)
 
-// [0, 1]:			Remapping option #1 (SCL on pin PD1, SDA on pin PD0)
-AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;   // set high bit = 0  (I2C1REMAP1)
-AFIO->PCFR1 |= AFIO_PCFR1_I2C1_REMAP;             // set low bit = 1   (I2C1_RM)
+// [0, 1]:                    Remapping option #1 (SCL on pin PD1, SDA on pin PD0)
+AFIO->PCFR1 = (AFIO->PCFR1 & ~AFIO_PCFR1_I2C1_HIGH_BIT_REMAP) | AFIO_PCFR1_I2C1_REMAP;  // high bit = 0 (I2C1REMAP1), low bit = 1 (I2C1_RM)
 
-// [1, X]:			Remapping option #2 (SCL on pin PC5, SDA on pin PC6)
-AFIO->PCFR1 |= AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;    // set high bit = 1  (I2C1REMAP1)
-AFIO->PCFR1 |= AFIO_PCFR1_I2C1_REMAP;             // set low bit [ignored / don't care]    (I2C1_RM)
+// [1, X]:                    Remapping option #2 (SCL on pin PC5, SDA on pin PC6)
+AFIO->PCFR1 |= AFIO_PCFR1_I2C1_HIGH_BIT_REMAP | AFIO_PCFR1_I2C1_REMAP;  // high bit = 1 (I2C1REMAP1), low bit [ignored / don't care] (I2C1_RM)
 ```
 
 ## Initialization


### PR DESCRIPTION
Updated comments for clarity and corrected code for I2C pin remapping.

The original code occasionally failed to remap the 2x I2C pins and which failed i2c communications on ~10% of a batch of 100 boards with CH32V003F4U6 that I just received. both bits have to be set simultaneously, or it seems the remap can fail to take effect.

It must be some kind of manufacturing-batch-specific undefined behavior in certain ch32's, because each chip either consistently worked or consistently failed. it doesn't (it's not like it's flaky after each boot)

I wanted to submit this for initial review. I'm currently verifying this fix on my failed boards, and if everything is good, will give a thumbs up.

I wrote this example originally and got burned in production by my own example code :) What a life