### PR TITLE
Add vector-free-table example and cleanup ISR setup code.

### DIFF
--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -1072,6 +1072,8 @@ void handle_reset( void ) __attribute__((section(".text.handle_reset")));
 #if FUNCONF_ISR_IN_RAM
 	void Init()         __attribute__((naked)) __attribute((section(".init"))) __attribute((weak,alias("InitDefault"))) __attribute((naked));
 	void InitDefault()  __attribute__((naked)) __attribute((section(".init"))) __attribute((naked));
+
+#if !defined(FUNCONF_TINYVECTOR) || !FUNCONF_TINYVECTOR
 	void InitDefault( void )
 	{
 		asm volatile( "\n\
@@ -1081,6 +1083,9 @@ void handle_reset( void ) __attribute__((section(".text.handle_reset")));
 			j handle_reset\n\
 		.option   pop;\n" );
 	}
+#else
+	void InitDefault()   __attribute__((naked)) __attribute((section(".init"))) __attribute((weak,alias("handle_reset")));
+#endif
 
 	void InterruptVector()         __attribute__((naked)) __attribute((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("InterruptVectorDefault"))) __attribute((naked));
 	void InterruptVectorDefault()  __attribute__((naked)) __attribute((section(VECTOR_HANDLER_SECTION))) __attribute((naked));
@@ -1091,6 +1096,7 @@ void handle_reset( void ) __attribute__((section(".text.handle_reset")));
 #else
 	void InterruptVector()         __attribute__((naked)) __attribute((section(".init"))) __attribute((weak,alias("InterruptVectorDefault"))) __attribute((naked));
 	void InterruptVectorDefault()  __attribute__((naked)) __attribute((section(".init"))) __attribute((naked));
+
 	void InterruptVectorDefault( void )
 	{
 		#if !defined(FUNCONF_TINYVECTOR) || !FUNCONF_TINYVECTOR
@@ -1132,18 +1138,19 @@ void handle_reset( void )
 	// Setup the interrupt vector, processor status and INTSYSCR.
 
 #if FUNCONF_ENABLE_HPE	// Enabled nested and hardware (HPE) stack, since it's really good on the x035.
-"	li t0, 0x1888\n\
-	csrs mstatus, t0\n"
-"	li t0, 0x0b\n\
-	csrw 0x804, t0\n"
+"	li a3, 0x1888\n\
+	csrs mstatus, a3\n"
+"	li a3, 0x0b\n\
+	csrw 0x804, a3\n"
 #else
 "	li a0, 0x1880\n\
 	csrw mstatus, a0\n"
 #endif
-"	li a3, 0x3\n\
-	la a0, InterruptVector\n\
-	or a0, a0, a3\n\
-	csrw mtvec, a0\n" 
+#if !defined(FUNCONF_TINYVECTOR) || !FUNCONF_TINYVECTOR
+"	la a3, InterruptVector\n\
+	ori a3, a3, 3\n\
+	csrw mtvec, a3\n"
+#endif
 	: : : "a0", "a3", "memory");
 
 	// Careful: Use registers to prevent overwriting of self-data.
@@ -1221,8 +1228,8 @@ void handle_reset( void )
 	la a1, _highcode_vma_start\n\
 	la a2, _highcode_vma_end\n\
 	bgeu a1, a2, 2f\n\
-1:	lw t0, (a0)\n\
-	sw t0, (a1)\n\
+1:	lw a3, (a0)\n\
+	sw a3, (a1)\n\
 	addi a0, a0, 4\n\
 	addi a1, a1, 4\n\
 	bltu a1, a2, 1b\n\
@@ -1233,8 +1240,8 @@ void handle_reset( void )
 	la a1, _data_vma\n\
 	la a2, _edata\n\
 	beq a1, a2, 2f\n\
-1:	lw t0, 0(a0)\n\
-	sw t0, 0(a1)\n\
+1:	lw a3, 0(a0)\n\
+	sw a3, 0(a1)\n\
 	addi a0, a0, 4\n\
 	addi a1, a1, 4\n\
 	bltu a1, a2, 1b\n\
@@ -1251,26 +1258,32 @@ void handle_reset( void )
 
 	// Setup the interrupt vector, processor status and INTSYSCR.
 	asm volatile(
-"	li t0, 0x1f\n\
-	csrw 0xbc0, t0\n"
+"	li a3, 0x1f\n\
+	csrw 0xbc0, a3\n"
 
 #if defined(CH32V30x) && !defined( DISABLED_FLOAT )
-"	li t0, 0x7888\n\
-	csrs mstatus, t0\n"
+"	li a3, 0x7888\n\
+	csrs mstatus, a3\n"
 #else
-"	li t0, 0x1888\n\
-	csrs mstatus, t0\n"
+"	li a3, 0x1888\n\
+	csrs mstatus, a3\n"
 #endif
 
 #if FUNCONF_ENABLE_HPE	// Enabled nested and hardware (HPE) stack, since it's really good on the x035.
-"	li t0, 0x0b\n\
-	csrw 0x804, t0\n"
+"	li a3, 0x0b\n\
+	csrw 0x804, a3\n"
 #endif
-"	la t0, InterruptVector\n\
-	ori t0, t0, 3\n\
-	csrw mtvec, t0\n"
-	: : [InterruptVector]"r"(InterruptVector) : "t0", "memory"
+	: : : "a3", "memory"
 	);
+
+#if !defined(FUNCONF_TINYVECTOR) || !FUNCONF_TINYVECTOR
+	asm volatile(
+"	la a3, InterruptVector\n\
+	ori a3, a3, 3\n\
+	csrw mtvec, a3\n"
+	: : [InterruptVector]"r"(InterruptVector) : "a3", "memory"
+	);
+#endif
 
 #if defined( FUNCONF_SYSTICK_USE_HCLK ) && FUNCONF_SYSTICK_USE_HCLK && !defined(CH32V10x)
 	SysTick->CTLR = 5;
@@ -1338,8 +1351,8 @@ void handle_reset( void )
 	la a1, _itcm_vma_start\n\
 	la a2, _itcm_vma_end\n\
 	bgeu a1, a2, 2f\n\
-1:	lw t0, (a0)\n\
-	sw t0, (a1)\n\
+1:	lw a3, (a0)\n\
+	sw a3, (a1)\n\
 	addi a0, a0, 4\n\
 	addi a1, a1, 4\n\
 	bltu a1, a2, 1b\n\
@@ -1349,8 +1362,8 @@ void handle_reset( void )
 	la a1, _dtcm_vma_start\n\
 	la a2, _dtcm_vma_end\n\
 	bgeu a1, a2, 2f\n\
-1:	lw t0, (a0)\n\
-	sw t0, (a1)\n\
+1:	lw a3, (a0)\n\
+	sw a3, (a1)\n\
 	addi a0, a0, 4\n\
 	addi a1, a1, 4\n\
 	bltu a1, a2, 1b\n\
@@ -1360,8 +1373,8 @@ void handle_reset( void )
 	la a1, _data_vma\n\
 	la a2, _edata\n\
 	beq a1, a2, 2f\n\
-1:	lw t0, 0(a0)\n\
-	sw t0, 0(a1)\n\
+1:	lw a3, 0(a0)\n\
+	sw a3, 0(a1)\n\
 	addi a0, a0, 4\n\
 	addi a1, a1, 4\n\
 	bltu a1, a2, 1b\n\
@@ -1379,39 +1392,46 @@ void handle_reset( void )
 	// Setup the interrupt vector, processor status and INTSYSCR.
 	asm volatile(
 "	bnez a7, 5f\n\
-	la t0, 0x12370303\n\
-	csrw 0xbc0, t0\n\
+	la a3, 0x12370303\n\
+	csrw 0xbc0, a3\n\
 	j 3f\n\
-5:	la t0, 0x12378400\n\
-	csrw 0xbc0, t0\n\
+5:	la a3, 0x12378400\n\
+	csrw 0xbc0, a3\n\
 3:\n"
 
 #if !defined( DISABLED_FLOAT )
-"	li t0, 0x7888\n\
-	csrs mstatus, t0\n"
+"	li a3, 0x7888\n\
+	csrs mstatus, a3\n"
 #else
-"	li t0, 0x1888\n\
-	csrs mstatus, t0\n"
+"	li a3, 0x1888\n\
+	csrs mstatus, a3\n"
 #endif
 
 #if FUNCONF_ENABLE_HPE
 "	bnez a7, 5f\n\
-	li t0, 0x01\n\
-	csrw 0xBC1, t0\n\
-	li t0, 0x0b\n\
-	csrw 0x804, t0\n\
+	li a3, 0x01\n\
+	csrw 0xBC1, a3\n\
+	li a3, 0x0b\n\
+	csrw 0x804, a3\n\
 	j 3f\n\
-5:	li t0, 0x07\n\
-	csrw 0xBC1, t0\n\
-	li t0, 0x0b\n\
-	csrw 0x804, t0\n\
+5:	li a3, 0x07\n\
+	csrw 0xBC1, a3\n\
+	li a3, 0x0b\n\
+	csrw 0x804, a3\n\
 3:\n"
 #endif
-"	la t0, InterruptVector\n\
-	ori t0, t0, 3\n\
-	csrw mtvec, t0\n"
-	: : [InterruptVector]"r"(InterruptVector) : "t0", "memory"
+	: : : "a3", "memory"
 	);
+
+
+#if !defined(FUNCONF_TINYVECTOR) || !FUNCONF_TINYVECTOR
+	asm volatile(
+"	la a3, InterruptVector\n\
+	ori a3, a3, 3\n\
+	csrw mtvec, a3\n"
+	: : [InterruptVector]"r"(InterruptVector) : "a3", "memory"
+	);
+#endif
 
 #if defined( FUNCONF_SYSTICK_USE_HCLK ) && FUNCONF_SYSTICK_USE_HCLK
 	SysTick->CTLR = 5;

--- a/ch32fun/ch32fun.h
+++ b/ch32fun/ch32fun.h
@@ -144,6 +144,10 @@
 	#define FUNCONF_ENABLE_HPE 0
 #endif
 
+#ifndef FUNCONF_TINYVECTOR
+	#define FUNCONF_TINYVECTOR 0
+#endif
+
 #if FUNCONF_ENABLE_HPE == 1
 	#define INTERRUPT_DECORATOR  __attribute__((interrupt("WCH-Interrupt-fast")))
 #else
@@ -1024,7 +1028,13 @@ void funAnalogInit( void );
 // Be sure to call funAnalogInit first.
 int funAnalogRead( int nAnalogNumber );
 
-void handle_reset()            __attribute__((naked)) __attribute((section(".text.handle_reset"))) __attribute__((used));
+#if FUNCONF_CUSTOM_MTVEC
+	void handle_reset( void ) __attribute__((naked))  __attribute__((section(".init"))) __attribute__((used));
+#else
+	void handle_reset( void ) __attribute__((naked))  __attribute__((section(".text.handle_reset"))) __attribute__((used));
+#endif
+
+
 void DefaultIRQHandler( void ) __attribute__((section(VECTOR_HANDLER_SECTION))) __attribute__((naked)) __attribute__((used));
 // used to clear the CSS flag in case of clock fail switch
 #if defined(FUNCONF_USE_CLK_SEC) && FUNCONF_USE_CLK_SEC

--- a/examples/vector_free_table_irq/Makefile
+++ b/examples/vector_free_table_irq/Makefile
@@ -1,0 +1,11 @@
+all : flash
+
+TARGET:=vector_free_table_irq
+
+TARGET_MCU?=CH32V003
+include ../../ch32fun/ch32fun.mk
+
+flash : cv_flash
+clean : cv_clean
+
+

--- a/examples/vector_free_table_irq/funconfig.h
+++ b/examples/vector_free_table_irq/funconfig.h
@@ -1,0 +1,13 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+// Optional: Use HPE, or WCH's "fast interrupt" mode. 
+// there are a lot of trade offs, only use it if you
+// know what you are doing.
+//#define FUNCONF_ENABLE_HPE   1
+
+// Disable normal vector tables.
+#define FUNCONF_TINYVECTOR   1
+
+#endif
+

--- a/examples/vector_free_table_irq/vector_free_table_irq.c
+++ b/examples/vector_free_table_irq/vector_free_table_irq.c
@@ -1,10 +1,21 @@
 #include "ch32fun.h"
 #include <stdio.h>
 
-#define TEST_VTF 1
+#define TEST_VTF 0
+
+//#define ISR_SECTION_ATTR __attribute__((section(".srodata")))
+#define ISR_SECTION_ATTR __attribute__((section(".text")))
+
+
+#if TEST_VTF
+#define ISR_ALIGNMENT
+#else
+// Alignment only needed on direct MTVEC writing, not VFT.
+#define ISR_ALIGNMENT __attribute__((aligned(1024)))
+#endif
 
 // Inherits the right "interrupt" flags for HPE/normal interrupts.
-void EXTI7_0_IRQHandler( void ) INTERRUPT_DECORATOR __attribute__((section(".srodata")));
+void EXTI7_0_IRQHandler( void ) INTERRUPT_DECORATOR ISR_ALIGNMENT ISR_SECTION_ATTR;
 
 void EXTI7_0_IRQHandler( void ) 
 {
@@ -50,6 +61,9 @@ int main()
 	PFIC->VTFIDR[0] = EXTI7_0_IRQn;
 #else
 	__set_MTVEC( (uint32_t)&EXTI7_0_IRQHandler );
+	// MTVEC on the 003/006, etc. is as follows:
+	//  bit 0: unified or tabled.  I.e. ADDRESS = address&0xfffffffc, otherwise ADDRESS = (address&0xfffffffc) + ISR*4
+	//  bit 1: indirect or direct, if 1, requires instruction at ADDRESS, i.e. jmp, so PC = *ADDRESS.  Otherwise set PC = ADDRESS
 #endif
 #endif
 

--- a/examples/vector_free_table_irq/vector_free_table_irq.c
+++ b/examples/vector_free_table_irq/vector_free_table_irq.c
@@ -1,0 +1,66 @@
+#include "ch32fun.h"
+#include <stdio.h>
+
+#define TEST_VTF 1
+
+// Inherits the right "interrupt" flags for HPE/normal interrupts.
+void EXTI7_0_IRQHandler( void ) INTERRUPT_DECORATOR __attribute__((section(".srodata")));
+
+void EXTI7_0_IRQHandler( void ) 
+{
+	// Flash just a little blip.
+	funDigitalWrite( PD3, FUN_HIGH );
+	funDigitalWrite( PD3, FUN_LOW );
+
+	// Acknowledge the interrupt
+	EXTI->INTFR = EXTI_Line3;
+
+#if FUNCONF_ENABLE_HPE
+	// The HPE target doesn't know how to function-prologue.
+	asm volatile( "mret" );
+#endif
+}
+
+int ramloop() __attribute__((noinline))  __attribute__((section(".srodata")));
+int ramloop()
+{
+	while(1)
+	{
+		funDigitalWrite( PD3, FUN_HIGH );
+		funDigitalWrite( PD3, FUN_LOW );
+		ADD_N_NOPS(5);
+		DelaySysTick(10);
+	}
+
+}
+
+int main()
+{
+	SystemInit();
+	// Enable GPIOs
+	RCC->APB2PCENR = RCC_APB2Periph_GPIOD | RCC_APB2Periph_GPIOC | RCC_APB2Periph_AFIO;
+
+	funPinMode( PD3, GPIO_CFGLR_OUT_10Mhz_PP );
+	funDigitalWrite( PD3, FUN_HIGH );
+
+	// If you set FUNCONF_CUSTOM_MTVEC, make MTVEC point to the function that handles all IRQs.
+#if FUNCONF_TINYVECTOR
+#if TEST_VTF
+	PFIC->VTFADDR[0] = 1|(uint32_t)&EXTI7_0_IRQHandler;
+	PFIC->VTFIDR[0] = EXTI7_0_IRQn;
+#else
+	__set_MTVEC( (uint32_t)&EXTI7_0_IRQHandler );
+#endif
+#endif
+
+	// Configure the IO as an interrupt.
+	AFIO->EXTICR = AFIO_EXTICR_EXTI3_PD;
+	EXTI->INTENR = EXTI_INTENR_MR3; // Enable EXT3
+	EXTI->FTENR = EXTI_FTENR_TR3;  // Falling edge trigger
+
+	// enable interrupt
+	NVIC_EnableIRQ( EXTI7_0_IRQn );
+
+	ramloop();
+}
+


### PR DESCRIPTION
1. Add a vector free table example. 
2. Fixup startup assembly.

I tried avoiding t0, to keep the startup registers more consistent, and fix the clobber lists.

This example takes latency from ~558ns in example to 416ns, so, 7 cycles.

NEED TO make sure this doesn't break ch32fun on ch32v305, ch32x035, ch570.