### PR TITLE
Add support for sha1sum back into Makefile for non-Windows os

### DIFF
--- a/minichlink/Makefile
+++ b/minichlink/Makefile
@@ -10,11 +10,15 @@ H_S:=cmdserver.h funconfig.h hidapi.h libusb.h microgdbstub.h minichlink.h seria
 
 CFLAGS_WINDOWS:=-Os -s -Wall -D_WIN32_WINNT=0x0600 -I. -Wall -DCH32V003 -DMINICHLINK
 LDFLAGS_WINDOWS:=-L. -lpthread -lusb-1.0 -lsetupapi -lws2_32
-VERSION:=$(shell shasum $(C_S) $(H_S) Makefile | shasum | head -c 40)
 ifeq ($(OS),Windows_NT)
 	TOOLS:=minichlink.exe
+	SHASUM:=$(shell where shasum)
 else
 	OS_NAME := $(shell uname -s | tr A-Z a-z)
+	SHASUM:=$(@shell which shasum)
+	ifeq (, $(SHASUM))
+		SHASUM:=$(shell which sha1sum)
+ 	endif
 	ifeq ($(OS_NAME),linux)
 		LDFLAGS:=-lpthread -lusb-1.0 -ludev
 	endif
@@ -48,6 +52,7 @@ else
 		LDFLAGS := -lpthread $(LIBHIDAPI_LIBS) $(LIBUSB_LIBS)
 	endif
 endif
+VERSION:=$(shell $(SHASUM) $(C_S) $(H_S) Makefile | $(SHASUM) | head -c 40)
 
 all : $(TOOLS)
 
@@ -78,4 +83,4 @@ clean :
 
 hash :
 	echo $(VERSION) > version
-	shasum $(C_S) $(H_S) Makefile >> version
+	$(SHASUM) $(C_S) $(H_S) Makefile >> version


### PR DESCRIPTION
In a recent change, the minichlink Makefil changed to useing shasum to generate the file checksums, but Fedora doesn't include that by default--it's unintentionally provided on other Linux OSes through a Perl package.  

Make the script look for shasum or sha1sum on non-Windows platforms and to use that if found.

Changed Windows to use the 'where' command to look for shasum instead of the POSIX 'which' command.