### PR TITLE
Fixed typos in sx12xx examples

### DIFF
--- a/examples/spi_lora_sx126x/README.md
+++ b/examples/spi_lora_sx126x/README.md
@@ -56,7 +56,7 @@ connections. I had issues with dupont jumper wires.
 ## PARAMETERS:
 
 Main parameters:
-SF - Spreading Factor (larger FS (eg FS11) can travel further but take more air time)
+SF - Spreading Factor (larger SF (eg SF11) can travel further but take more air time)
 BW - Bandwidth (Higher BW allows higher data rate at the expense of reduced sensitivity)
 CR - Coding Rate (better correction and range at cost of data rate and air time)
 
@@ -65,8 +65,8 @@ Note:
 - SX126X supports SF (5-11), power range -9 dBm to +22 dBm
 - SX127X supports SF (6-12), power range -4 dBm to +20 dBm
 - LLCC68 uses SX126X loRa
-- FS6 on SX126X is not backward compatible with SF6 on SX127X.
-- larger FS (eg FS11) can travel further but take more air time
+- SF6 on SX126X is not backward compatible with SF6 on SX127X.
+- larger SF (eg SF11) can travel further but take more air time
   
 ## TODO:
 

--- a/examples/spi_lora_sx126x/fun_sx126x.h
+++ b/examples/spi_lora_sx126x/fun_sx126x.h
@@ -180,11 +180,11 @@ void fun_sx126x_setModulation(u8 sf, u8 bw, u8 cr, u8 lowDataRateOptimization) {
 	// Higher BW allows higher data rate at the expense of reduced sensitivity	
 	// Higher CR (Coding Rate) allows higher data rate at the expense of reduced sensitivity
 	// CR 0x01 = 4/5, CR 0x02 = 4/6, CR 0x03 = 4/7, CR 0x04 = 4/8
-	// lowDataRateOptimization can be used for low data rates (high FS for low BW) and payloads
+	// lowDataRateOptimization can be used for low data rates (high SF for low BW) and payloads
 	// which last longer time on air in order to allow the receiver to get better LoRa signal
 
 	// ref: `Time On Air`
-	// ToA = 2^FS * Nsymbol / BW(kHz)
+	// ToA = 2^SF * Nsymbol / BW(kHz)
 
 	// SF5 and SF6 works for SX1262 and LLCC68 but NOT SX1276
 	// valid spreading factor is between 5 and 12

--- a/examples/spi_lora_sx127x/README.md
+++ b/examples/spi_lora_sx127x/README.md
@@ -54,7 +54,7 @@ connections. I had issues with dupont jumper wires.
 ## PARAMETERS:
 
 Main parameters:
-SF - Spreading Factor (larger FS (eg FS11) can travel further but take more air time)
+SF - Spreading Factor (larger SF (eg SF11) can travel further but take more air time)
 BW - Bandwidth (Higher BW allows higher data rate at the expense of reduced sensitivity)
 CR - Coding Rate (better correction and range at cost of data rate and air time)
 
@@ -63,8 +63,8 @@ Note:
 - SX126X supports SF (5-11), power range -9 dBm to +22 dBm
 - SX127X supports SF (6-12), power range -4 dBm to +20 dBm
 - LLCC68 uses SX126X loRa
-- FS6 on SX126X is not backward compatible with SF6 on SX127X.
-- larger FS (eg FS11) can travel further but take more air time
+- SF6 on SX126X is not backward compatible with SF6 on SX127X.
+- larger SF (eg SF11) can travel further but take more air time
   
 ## TODO:
 


### PR DESCRIPTION
Fixed typos inside the sx126x and sx127x examples.