### PR TITLE
Add support to build on FreeBSD

### DIFF
--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -92,8 +92,10 @@ void __libc_init_array(void)
 #include <stdint.h>
 #include <ch32fun.h>
 
+#if defined(__FreeBSD__)
 #ifdef putchar
 #undef putchar
+#endif
 #endif
 
 #if defined(CH32H41x)

--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -92,6 +92,10 @@ void __libc_init_array(void)
 #include <stdint.h>
 #include <ch32fun.h>
 
+#ifdef putchar
+#undef putchar
+#endif
+
 #if defined(CH32H41x)
 volatile v5f_main v5f_start_function = NULL;
 static int start_v5f(void)

--- a/ch32fun/ch32fun.mk
+++ b/ch32fun/ch32fun.mk
@@ -12,6 +12,10 @@ PREFIX_DEFAULT:=riscv64-elf
 
 ifneq ($(shell $(WHICH) riscv64-unknown-elf-gcc 2>$(NULLDEV)),)
 	PREFIX_DEFAULT:=riscv64-unknown-elf
+else ifneq ($(shell $(WHICH) riscv64-none-elf-gcc 2>$(NULLDEV)),)
+	PREFIX_DEFAULT:=riscv64-none-elf
+else ifneq ($(shell $(WHICH) riscv32-unknown-elf-gcc 2>$(NULLDEV)),)
+	PREFIX_DEFAULT:=riscv32-unknown-elf
 else ifneq ($(shell $(WHICH) riscv-none-elf-gcc 2>$(NULLDEV)),)
 	PREFIX_DEFAULT:=riscv-none-elf
 else ifneq ($(shell $(WHICH) riscv64-linux-gnu-gcc 2>$(NULLDEV)),)

--- a/minichlink/Makefile
+++ b/minichlink/Makefile
@@ -51,6 +51,17 @@ else
 		INCS := $(LIBHIDAPI_INCS) $(LIBUSB_INCS)
 		LDFLAGS := -lpthread $(LIBHIDAPI_LIBS) $(LIBUSB_LIBS)
 	endif
+	ifeq ($(OS_NAME),freebsd)
+		# use ports/comms/hidapi
+		LIBHIDAPI_INCS := $(shell pkg-config --cflags hidapi)
+		LIBHIDAPI_LIBS := $(shell pkg-config --libs hidapi)
+		# use system libusb1
+		LIBUSB_INCS := $(shell pkg-config --cflags libusb-1.0)
+		LIBUSB_LIBS := $(shell pkg-config --libs libusb-1.0)
+
+		INCS := $(LIBHIDAPI_INCS) $(LIBUSB_INCS)
+		LDFLAGS := -liconv -lpthread $(LIBHIDAPI_LIBS) $(LIBUSB_LIBS)
+	endif
 endif
 VERSION:=$(shell $(SHASUM) $(C_S) $(H_S) Makefile | $(SHASUM) | head -c 40)
 

--- a/minichlink/cmdserver.h
+++ b/minichlink/cmdserver.h
@@ -30,7 +30,7 @@ int WSAAPI WSAPoll(struct pollfd * fdArray, ULONG fds, INT timeout );
 
 #ifdef __linux__
 #include <linux/in.h>
-#elif defined(__APPLE__)
+#elif defined(__APPLE__)||defined(__FreeBSD__)
 #include <netinet/in.h>
 #endif
 

--- a/minichlink/hidapi.c
+++ b/minichlink/hidapi.c
@@ -4768,10 +4768,11 @@ HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 	return last_global_error_str;
 }
 
-#elif defined( __NetBSD__ )
+#elif defined( __NetBSD__ )||defined( __FreeBSD__ )
 // Use library version from pkgsrc/comms/libhidapi
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <hidapi.h>
 
 #else

--- a/minichlink/microgdbstub.h
+++ b/minichlink/microgdbstub.h
@@ -92,6 +92,8 @@ int WSAAPI WSAPoll(struct pollfd * fdArray, ULONG	   fds, INT		 timeout );
 
 #ifdef __linux__
 #include <linux/in.h>
+#elif defined(__FreeBSD__)
+#include <netinet/in.h>
 #endif
 
 char gdbbuffer[65536];


### PR DESCRIPTION
Add riscv64-none-elf and riscv32-unknown-elf in ch32fun.mk.

For minichlink on FreeBSD, use ports-provided hidapi, and system libusb via pkg-config, and include the external hidapi header.