### PR TITLE
minichlink: add CH32M030 flashing support (+ fix WCH-LinkE device UAF)

### DIFF
--- a/minichlink/chips.c
+++ b/minichlink/chips.c
@@ -356,7 +356,7 @@ const struct RiscVChip_s ch32m030 = {
 	.model_id = 0x0300,
 	.ram_base = 0x20000000,
 	.ram_size = 12*1024,
-	.sector_size = 256,
+	.sector_size = 128,
 	.flash_offset = 0x08000000,
 	.flash_size = 64*1024,
 	.bootloader_offset = 0,
@@ -364,7 +364,7 @@ const struct RiscVChip_s ch32m030 = {
 	.options_offset = 0x1FFFF300,
 	.options_size = 128,
 	.interface_speed = 0x01,
-	.protocol = PROTOCOL_UNSUPPORTED,
+	.protocol = PROTOCOL_DEFAULT,
 };
 
 const struct RiscVChip_s ch564 = {

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -2298,6 +2298,21 @@ int DefaultWriteBinaryBlob( void * dev, uint32_t address_to_write, uint32_t blob
 					// On the v2xx, v3xx, you also need to make sure FLASH->STATR & 2 is not set.  This is only an issue when running locally.
 
 					rsofar += 4;
+
+				// CH32M030 fast programming, per RM v1.2 §19.4.5 step 7: write
+				// 8 bytes (two 4-byte words) to the page-mapped address, THEN set
+				// FLASH_CTLR.BUFLOAD to commit them into the 128-byte page buffer;
+				// repeat 16 times to fill the page. So BUFLOAD pulses every SECOND
+				// word (j odd), not every word. An earlier port pulsed it every
+				// word (copying the X035 "in spite of the datasheet" path); on M030
+				// that silently drops isolated words during the write — verified by
+				// flash readback showing zeroed 4-byte holes (e.g. offset 0x0C, the
+				// HardFault vector, and 0x24), which reset-loops the CPU on any fault.
+				if( is_flash && iss->target_chip_type == CHIP_CH32M030 && (j & 1) )
+				{
+					MCF.WriteWord( dev, (intptr_t)&FLASH->CTLR, CR_PAGE_PG | CR_BUF_LOAD );
+					if( MCF.WaitForFlash ) MCF.WaitForFlash( dev );
+				}
 				}
 
 				if( is_flash )
@@ -2379,6 +2394,17 @@ int DefaultWriteBinaryBlob( void * dev, uint32_t address_to_write, uint32_t blob
 							return ret;
 						}
 						// On the v2xx, v3xx, you also need to make sure FLASH->STATR & 2 is not set.  This is only an issue when running locally.
+
+						// CH32M030: same RM v1.2 §19.4.5 step 7 rule as the full-sector
+						// path above — pulse BUFLOAD every second word to commit the
+						// 128-byte page buffer. This read-modify-write path handles any
+						// non-128-byte-aligned tail page; without the pulse that final
+						// page commits empty and reads back 0xFF.
+						if( is_flash && iss->target_chip_type == CHIP_CH32M030 && (j & 1) )
+						{
+							MCF.WriteWord( dev, (intptr_t)&FLASH->CTLR, CR_PAGE_PG | CR_BUF_LOAD );
+							if( MCF.WaitForFlash ) MCF.WaitForFlash( dev );
+						}
 					}
 
 					if( iss->target_chip_type == CHIP_CH32V20x || iss->target_chip_type == CHIP_CH32V30x || iss->target_chip_type == CHIP_CH32H41x )

--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -195,6 +195,15 @@ static inline libusb_device_handle * wch_link_base_setup( int inhibit_startup, c
 		fprintf( stderr, "\n" );
 	}
 
+	// libusb_free_device_list() with unref_devices=1 drops the last reference on
+	// every device in the list -- including the candidate(s) we still need to open
+	// below. Take a ref on each survivor first, otherwise libusb_open() operates on
+	// a freed device and fails (e.g. -4 on the libusb-win32 backend). The refs are
+	// balanced after the open (found path) or released implicitly at exit() (the
+	// IAP/ARM recovery paths).
+	if( found )                   libusb_ref_device( found );
+	if( found_arm_programmer )    libusb_ref_device( found_arm_programmer );
+	if( found_programmer_in_iap ) libusb_ref_device( found_programmer_in_iap );
 	libusb_free_device_list( list, 1 );
 
 	if( !found )
@@ -247,6 +256,11 @@ static inline libusb_device_handle * wch_link_base_setup( int inhibit_startup, c
 
 	libusb_device_handle * devh;
 	status = libusb_open( found, &devh );
+	// Balance the refs taken before libusb_free_device_list(). On success devh
+	// holds its own reference to `found`; the ARM/IAP candidates are unused here.
+	libusb_unref_device( found );
+	if( found_arm_programmer )    libusb_unref_device( found_arm_programmer );
+	if( found_programmer_in_iap ) libusb_unref_device( found_programmer_in_iap );
 	if( status )
 	{
 		fprintf( stderr, "Error: couldn't open wch link device (libusb_open() = %d)\n", status );


### PR DESCRIPTION
## Summary

Makes minichlink program the **CH32M030** and fixes a WCH-LinkE
use-after-free that otherwise blocks the LinkE on some libusb backends.
With this PR, a fresh minichlink built from `master` flashes an M030 over the
WCH-LinkE. Verified end-to-end on Windows (2 Hz blink on a CH32M030G8R7).

Three commits, smallest/most-general first:

### 1. Fix WCH-LinkE use-after-free after `libusb_free_device_list`

`wch_link_base_setup()` calls `libusb_free_device_list(list, 1)` — which
unreferences every device in the list — *before* opening the selected programmer.
`found` / `found_arm_programmer` / `found_programmer_in_iap` point at entries in
that list, so the later `libusb_open()` operates on a freed device.

Depending on the libusb backend this fails or survives by luck:
- On the Windows **libusb-win32** driver it returns `libusb_open() = -4`
  (`LIBUSB_ERROR_ACCESS`) and the LinkE can't be opened for **any** chip.
- On other backends the freed memory may still be intact, masking the bug.

Regression from the WCH-LinkE serial-number selection change (multiple-wchlinke),
- On other backends the freed memory may still be intact, masking the bug.

Regression from the WCH-LinkE serial-number selection change (multiple-wchlinke),
which moved the list free ahead of the open. Fix: take a reference on each
candidate device before the free and release it after the open (on success the
device handle holds its own reference; the IAP/ARM recovery paths `exit()`).

### 2. Enable CH32M030 flashing

Upstream already carries a `CHIP_CH32M030` enum and a `chips.c` stub marked
`PROTOCOL_UNSUPPORTED` with a 256-byte sector. The M030 page/sector is 128 bytes
(RM v1.2 §19) and it programs fine over the default protocol — flip it on.

### 3. BUFLOAD every 2 words on CH32M030 (RM v1.2 §19.4.5)

Per RM v1.2 §19.4.5 step 7, M030 fast programming writes 8 bytes (two words) then
sets `FLASH_CTLR.BUFLOAD` to commit them into the 128-byte page buffer — i.e. every
*second* word, not every word. Pulsing every word (the X035 path) silently drops
isolated words during the write; flash readback showed zeroed 4-byte holes (incl.
the HardFault vector at 0x0C), which reset-loops the CPU on any fault. Fixed in both
the full-sector and partial/tail-page write paths.

## Testing

- Windows 11, WCH-LinkE (LinkE v2.18, RISC-V mode), **libusb-win32** driver (Zadig).
- Before commit 1: `libusb_open() = -4` on every invocation (all chips).
- After: LinkE opens; `minichlink -w blink.bin flash` writes the image, flash
  readback matches the `.bin` byte-for-byte, and the M030 blinks at 2 Hz cold.

## Companion

Framework support for the chip is in the companion PR **"Add CH32M030 support
(framework + blink example)"**
Companion framework PR: #920