### PR TITLE
Add CH32M030 support (framework + blink example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ch32fun contains:
 
 ## Other family support
 
-Currently, there is support for the ch32x035, ch32v002, ch32v004, ch32v005, ch32v006, ch32v007, ch32v103, ch32v203, ch32v208, ch32v303, ch32v305 and ch32v307. Recently support for ch570, ch572, ch571, ch573, ch581, ch582, ch583, ch584, ch585 and ch591, ch592 was added. Some obscure chips like ch32m030, ch641, ch643, ch645 should also work, test reports on those will be appreciated.
+Currently, there is support for the ch32x035, ch32m030, ch32v002, ch32v004, ch32v005, ch32v006, ch32v007, ch32v103, ch32v203, ch32v208, ch32v303, ch32v305 and ch32v307. Recently support for ch570, ch572, ch571, ch573, ch581, ch582, ch583, ch584, ch585 and ch591, ch592 was added. Some obscure chips like ch641, ch643, ch645 should also work, test reports on those will be appreciated.
 
 GDB is mostly tested on the 003, but works, to a limited degree on the other processors.
 

--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -1902,6 +1902,21 @@ void DelaySysTick( uint32_t n )
 #if defined(CH32V003) || defined(CH32V00x)
 	uint32_t targend = SysTick->CNT + n;
 	while( ((int32_t)( SysTick->CNT - targend )) < 0 );
+#elif defined(CH32M030)
+	// M030 SysTick is 32-bit compare-mode only: CTLR(0), SR(4), CNT(0x08, 32-bit),
+	// CMP(0x10, 32-bit); offsets 0x0C/0x14 are RESERVED. The struct's 64-bit CNT/CMP
+	// span those reserved words, and accessing them bus-faults the core -> trap ->
+	// reset loop (the cold-boot blink failure). Use the 32-bit *L fields only and
+	// mirror WCH's Delay (mrs debug.c): clear flag, load CMP, enable, poll SR.
+	// The configured SysTick counts at full HCLK here (measured: dividing by 8 a la
+	// WCH's debug.c gives 8x-too-fast delays / 16 Hz blink). n is already in HCLK
+	// ticks, so load it directly.
+	SysTick->SR &= ~1u;                       // clear count-match flag
+	SysTick->CMPL = (uint32_t)n;              // 32-bit compare target (offset 0x10), HCLK ticks
+	SysTick->CTLR |= (1u << 4);
+	SysTick->CTLR |= (1u << 5) | (1u << 0);   // enable counter
+	while( ( SysTick->SR & 1u ) == 0 ) {}     // wait for compare match
+	SysTick->CTLR &= ~1u;                      // stop counter
 #elif defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x) || defined(CH32L103) || defined(CH582_CH583) || defined(CH591_CH592) || defined(CH32H41x)
 	uint64_t targend = SysTick->CNT + n;
 	while( ((int64_t)( SysTick->CNT - targend )) < 0 );
@@ -1969,6 +1984,22 @@ void StartV5F(v5f_main function)
 
 void SystemInit( void )
 {
+#if defined(CH32M030)
+	/* CH32M030 clock bring-up: HSI 8 MHz -> fixed-x18 PLL = 144 MHz -> HPRE/2 -> 72 MHz.
+	   CRITICAL: the factory HSI calibration lives in RCC_CTLR[15:8]. The generic path
+	   below writes RCC->CTLR wholesale, wiping that trim, so HSI drifts and the PLL
+	   never locks -> SystemInit hangs forever. Use read-modify-write ONLY. This mirrors
+	   WCH's SetSysClockTo72_HSI (mrs_files/.../system_ch32m030.c) in ch32fun style. */
+	FLASH->ACTLR = FLASH_ACTLR_LATENCY_3;             // 3 wait states @ 72 MHz (RM 19.3.1)
+	RCC->CTLR  |= RCC_HSION;                           // ensure HSI on (carries HSICAL trim)
+	RCC->CFGR0 |= RCC_HPRE_DIV2;                       // HCLK = SYSCLK / 2 -> 72 MHz
+	RCC->CFGR0 &= ~RCC_PLLSRC;                         // PLL source = HSI (RM 3.4.2)
+	RCC->CTLR  |= RCC_PLLON;                           // enable PLL (RMW: HSICAL preserved)
+	while( (RCC->CTLR & RCC_PLLRDY) == 0 ) {}          // wait for PLL lock
+	RCC->CFGR0  = (RCC->CFGR0 & ~0x3u) | RCC_SW_PLL;   // SYSCLK source = PLL (SW[1:0])
+	while( (RCC->CFGR0 & 0xCu) != 0x8u ) {}            // wait until SWS[3:2] == PLL
+	return;                                            // generic path below is bypassed for M030
+#endif
 #if defined(CH32V30x) && defined(TARGET_MCU_MEMORY_SPLIT)
 	FLASH->OBR = TARGET_MCU_MEMORY_SPLIT<<8;
 #endif
@@ -1992,17 +2023,22 @@ void SystemInit( void )
 		#define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PPRE2_DIV1 | RCC_PPRE1_DIV1 | PLL_MULTIPLICATION
 	#elif defined(CH32H41x)
 		#define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PPRE2_DIV2 | RCC_PPRE2_DIV2 | RCC_FPRE_DIV4 | RCC_CFGR0_MCO_SYSCLK
+	#elif defined(CH32M030)
+        /* M030 has no PPRE1/PPRE2 (APB1 and APB2 run at HCLK) and a fixed-multiplier
+           PLL (no PLLMUL field) — see RM v1.2 §3.4.2 CFGR0. SYSCLK target 72 MHz
+           is selected internally by hardware once PLL is enabled. */
+        #define BASE_CFGR0 RCC_HPRE_DIV1
 	#else
 		#define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PPRE2_DIV1 | RCC_PPRE1_DIV2 | PLL_MULTIPLICATION
 	#endif
 #else
-	#if defined(CH32V003) || defined(CH32X03x) || defined(CH32V00x)
-		#define BASE_CFGR0 RCC_HPRE_DIV1     					  // HCLK = SYSCLK = APB1 And, no pll.
-	#elif defined(CH32H41x)
-		#define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PPRE2_DIV0 | RCC_PPRE2_DIV0 | RCC_CFGR0_MCO_SYSCLK
-	#else
-		#define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PPRE2_DIV1 | RCC_PPRE1_DIV1
-	#endif
+	#if defined(CH32V003) || defined(CH32X03x) || defined(CH32V00x) || defined(CH32M030)
+        #define BASE_CFGR0 RCC_HPRE_DIV1                          // HCLK = SYSCLK = APB1 And, no pll. (M030 has no PPRE1/PPRE2)
+    #elif defined(CH32H41x)
+        #define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PPRE2_DIV0 | RCC_PPRE2_DIV0 | RCC_CFGR0_MCO_SYSCLK
+    #else
+        #define BASE_CFGR0 RCC_HPRE_DIV1 | RCC_PPRE2_DIV1 | RCC_PPRE1_DIV1
+    #endif
 #endif
 
 // HSI always ON - needed for the Debug subsystem
@@ -2027,6 +2063,11 @@ void SystemInit( void )
 	#endif
 #elif defined(CH32X03x)
 	FLASH->ACTLR = FLASH_ACTLR_LATENCY_2;                   // +2 Cycle Latency (Recommended per TRM)
+#elif defined(CH32M030)
+	// Fallback only: the dedicated M030 block at the top of SystemInit() sets
+	// LATENCY_3 and returns early, so this is normally unreached. Keep it
+	// consistent (3 wait states @ 72 MHz, RM 19.3.1) in case that path changes.
+	FLASH->ACTLR = FLASH_ACTLR_LATENCY_3;
 #elif defined(CH32H41x)
 	FLASH->ACTLR |= FLASH_ACTLR_EHMOD;
 #endif

--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -907,6 +907,7 @@ void CAN1_SCE_IRQHandler( void )		__attribute__((section(VECTOR_HANDLER_SECTION)
 void EXTI9_5_IRQHandler( void )			__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM1_BRK_IRQHandler( void )		__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM1_UP_IRQHandler( void )			__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void TIM1_TRG_IRQHandler( void )		__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM1_TRG_COM_IRQHandler( void )	__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM1_CC_IRQHandler( void )			__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM2_IRQHandler( void )			__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -984,6 +985,10 @@ void PIOC_IRQHandler( void )			__attribute__((section(VECTOR_HANDLER_SECTION))) 
 void OPA_IRQHandler( void )				__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USBPD_IRQHandler( void )			__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void USBPD_WKUP_IRQHandler( void )		__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBPD0_IRQHandler( void )			__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBPD0_WKUP_IRQHandler( void )		__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBPD1_IRQHandler( void )			__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
+void USBPD1_WKUP_IRQHandler( void )		__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM2_CC_IRQHandler( void )			__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM2_TRG_IRQHandler( void )		__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
 void TIM2_BRK_IRQHandler( void )		__attribute__((section(VECTOR_HANDLER_SECTION))) __attribute((weak,alias("DefaultIRQHandler"))) __attribute__((used));
@@ -1122,7 +1127,7 @@ void handle_reset( void ) __attribute__((section(".text.handle_reset")));
 
 #if !FUNCONF_OVERRIDE_STARTUP
 
-#if defined( CH32V003 ) || defined( CH32X03x ) || defined(CH32V00x)
+#if defined( CH32V003 ) || defined( CH32X03x ) || defined(CH32V00x) || defined( CH32M030 )
 
 void handle_reset( void )
 {
@@ -1150,6 +1155,21 @@ void handle_reset( void )
 "	la a3, InterruptVector\n\
 	ori a3, a3, 3\n\
 	csrw mtvec, a3\n"
+#endif
+#if defined(CH32M030)
+	// QingKeV3B core CSRs at reset, matching WCH startup_ch32m030.S. Without
+	// corecfgr the core's fetch mode is wrong and it traps in early startup,
+	// never reaching main (SystemInit never runs -> clock stays at reset HSI).
+	// This variant of handle_reset never sets corecfgr/intsyscr otherwise.
+	//   corecfgr (0xBC0)=0x21  FETCH_MODE + MIE mapping/prefetch
+	//   intsyscr (0x804)=0x03  HWSTKEN + interrupt nesting enable
+	//   inestcr  (0xBC1)=0x01  nesting depth 1
+	"li a0, 0x21\n\
+	csrw 0xBC0, a0\n\
+	li a0, 0x03\n\
+	csrw 0x804, a0\n\
+	li a0, 0x01\n\
+	csrw 0xBC1, a0\n"
 #endif
 	: : : "a0", "a3", "memory");
 

--- a/ch32fun/ch32fun.h
+++ b/ch32fun/ch32fun.h
@@ -156,7 +156,11 @@
 
 
 #if !defined( FUNCONF_USE_CLK_SEC )
-	#define FUNCONF_USE_CLK_SEC  1// use clock security system by default
+	#if defined( CH32M030 )
+		#define FUNCONF_USE_CLK_SEC  0 // M030 has no Clock Security System (per RM v1.2 §3) — default off
+	#else
+		#define FUNCONF_USE_CLK_SEC  1 // use clock security system by default
+	#endif
 #endif
 
 #ifndef HSE_VALUE
@@ -172,6 +176,8 @@
 		#endif
 	#elif defined(CH32V30x)
 		#define HSE_VALUE				  (8000000)
+	#elif defined(CH32M030)
+		#define HSE_VALUE				  (8000000) // M030 supports 4-25 MHz HSE; 8 MHz is the typical default
 	#elif defined(CH57x) || defined(CH58x) || defined(CH59x)
 		#define HSE_VALUE				  (32000000)
 	#elif defined(CH32H41x)
@@ -191,6 +197,8 @@
 		#define HSI_VALUE					(8000000)
 	#elif defined(CH32V30x)
 		#define HSI_VALUE					(8000000)
+	#elif defined(CH32M030)
+		#define HSI_VALUE					(8000000) // Internal 8 MHz RC oscillator
 	#elif defined(CH32H41x)
 		#define HSI_VALUE					(25000000)
 	#endif
@@ -215,6 +223,8 @@
 			#define FUNCONF_PLL_MULTIPLIER 18	// Default: 8 * 18 = 144 MHz
 		#elif defined(CH32V30x)
 			#define FUNCONF_PLL_MULTIPLIER 18	// Default: 8 * 18 = 144 MHz
+		#elif defined(CH32M030)
+			#define FUNCONF_PLL_MULTIPLIER 9	// M030 HW PLL is fixed x18, then HPRE/2: effective x9 -> 8 * 9 = 72 MHz
 		#elif defined(CH32H41x)
 			#define FUNCONF_PLL_MULTIPLIER 16	// Default: 25 * 16 = 400 MHz
 		#else // CH32V003
@@ -416,6 +426,8 @@ typedef enum {RESET = 0, SET = !RESET} FlagStatus, ITStatus;
 	#include "ch32x03xhw.h"
 #elif defined( CH32X03x )
 	#include "ch32x03xhw.h"
+#elif defined( CH32M030 )
+	#include "ch32m030hw.h"
 #elif defined( CH32V10x )
 	#include "ch32v10xhw.h"
 #elif defined( CH32L103 )
@@ -967,7 +979,7 @@ RV_STATIC_INLINE void funPinMode(u32 pin, GPIOModeTypeDef mode)
 
 #define funDigitalWrite( pin, value ) do{ GpioOf( pin )->BSHR = 1<<((!(value))*16 + ((pin) & 0xf)); }while(0)
 
-#if defined(CH32X03x)
+#if defined(CH32X03x) || defined(CH32M030)
 #define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC ); }
 #define funPinMode( pin, mode ) { *((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3)) = ( (*((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3))) & (~(0xf<<(4*((pin)&0x7))))) | ((mode)<<(4*((pin)&0x7))); }
 #elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32L103)

--- a/ch32fun/ch32fun.ld
+++ b/ch32fun/ch32fun.ld
@@ -133,6 +133,14 @@ MEMORY
 	#else
 		#error "Unknown MCU package"
 	#endif
+#elif TARGET_MCU_LD == 12
+	/* CH32M030 - 64K Flash / 12K RAM, uniform across all packages */
+	#if MCU_PACKAGE == 1
+		FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 64K
+		RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 12K
+	#else
+		#error "Unknown MCU package"
+	#endif
 #else
 	#error "Unknown MCU target"
 #endif

--- a/ch32fun/ch32fun.mk
+++ b/ch32fun/ch32fun.mk
@@ -130,7 +130,25 @@ else ifeq ($(findstring CH32X03,$(TARGET_MCU)),CH32X03) # CH32X033, X035
 		MCU_PACKAGE:=1
 	endif
 
-	TARGET_MCU_LD:=4		
+	TARGET_MCU_LD:=4
+else ifeq ($(findstring CH32M030,$(TARGET_MCU)),CH32M030) # CH32M030
+	TARGET_MCU_PACKAGE?=CH32M030G8R7
+	CFLAGS_ARCH+=-march=rv32imc \
+		-mabi=ilp32 \
+		-DCH32M030=1
+
+	# MCU Flash/RAM split (M030 always 64K/12K regardless of package)
+	ifeq ($(findstring G8, $(TARGET_MCU_PACKAGE)), G8)
+		MCU_PACKAGE:=1
+	else ifeq ($(findstring F8, $(TARGET_MCU_PACKAGE)), F8)
+		MCU_PACKAGE:=1
+	else ifeq ($(findstring K8, $(TARGET_MCU_PACKAGE)), K8)
+		MCU_PACKAGE:=1
+	else ifeq ($(findstring C8, $(TARGET_MCU_PACKAGE)), C8)
+		MCU_PACKAGE:=1
+	endif
+
+	TARGET_MCU_LD:=12
 else ifeq ($(findstring CH32L103,$(TARGET_MCU)),CH32L103) # CH32L103
 	TARGET_MCU_PACKAGE?=CH32L103C8T6
 	CFLAGS_ARCH+=-march=rv32imac \

--- a/ch32fun/ch32m030hw.h
+++ b/ch32fun/ch32m030hw.h
@@ -1,0 +1,6172 @@
+#ifndef _CH32M030HW_H
+#define _CH32M030HW_H
+
+#include "ch32fun.h"
+
+#ifndef __ASSEMBLER__  // Things before this can be used in assembly.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Interrupt Number Definition, according to the selected device */
+/* Interrupt Number Definition for CH32M030, per RM section 5.3 Table 5-1 */
+typedef enum IRQn
+{
+    /******  RISC-V Processor Core Interrupts ******************************************/
+    NonMaskableInt_IRQn  = 2,   /* 2  Non-Maskable Interrupt                    */
+    EXC_IRQn             = 3,   /* 3  Exception Interrupt                       */
+    Ecall_M_Mode_IRQn    = 5,   /* 5  Machine-mode environment call             */
+    Ecall_U_Mode_IRQn    = 8,   /* 8  User-mode environment call                */
+    Break_Point_IRQn     = 9,   /* 9  Breakpoint                                */
+    SysTick_IRQn         = 12,  /* 12 System Timer Interrupt                    */
+    Software_IRQn        = 14,  /* 14 Software Interrupt                        */
+
+    /******  CH32M030 Peripheral Interrupts ********************************************/
+    WWDG_IRQn            = 16,  /* Window Watchdog Interrupt                    */
+    OPA_IRQn             = 17,  /* OPA global interrupt (moved from 48 on X035) */
+    FLASH_IRQn           = 18,  /* FLASH global Interrupt                       */
+    RCC_IRQn             = 19,  /* RCC global Interrupt                         */
+    EXTI7_0_IRQn         = 20,  /* External Line[7:0] Interrupts                */
+    AWU_IRQn             = 21,  /* AWU (Auto Wake-Up) global Interrupt          */
+    DMA1_Channel1_IRQn   = 22,  /* DMA1 Channel 1 global Interrupt              */
+    DMA1_Channel2_IRQn   = 23,  /* DMA1 Channel 2 global Interrupt              */
+    DMA1_Channel3_IRQn   = 24,  /* DMA1 Channel 3 global Interrupt              */
+    DMA1_Channel4_IRQn   = 25,  /* DMA1 Channel 4 global Interrupt              */
+    DMA1_Channel5_IRQn   = 26,  /* DMA1 Channel 5 global Interrupt              */
+    DMA1_Channel6_IRQn   = 27,  /* DMA1 Channel 6 global Interrupt              */
+    DMA1_Channel7_IRQn   = 28,  /* DMA1 Channel 7 global Interrupt              */
+    ADC_IRQn             = 29,  /* ADC global Interrupt                         */
+    I2C1_EV_IRQn         = 30,  /* I2C1 Event Interrupt                         */
+    I2C1_ER_IRQn         = 31,  /* I2C1 Error Interrupt                         */
+    UART1_IRQn           = 32,  /* UART1 global Interrupt (no synchronous mode) */
+    EXTI15_8_IRQn        = 33,  /* External Line[15:8] Interrupts               */
+    TIM1_BRK_IRQn        = 34,  /* TIM1 Break Interrupt                         */
+    TIM1_UP_IRQn         = 35,  /* TIM1 Update Interrupt                        */
+    TIM1_TRG_IRQn        = 36,  /* TIM1 Trigger Interrupt                       */
+    TIM1_CC_IRQn         = 37,  /* TIM1 Capture/Compare Interrupt               */
+    TIM2_IRQn            = 38,  /* TIM2 global Interrupt                        */
+    USBPD0_IRQn          = 39,  /* USB Power Delivery controller 0              */
+    USBPD0_WKUP_IRQn     = 40,  /* USBPD0 Wake-Up Interrupt                     */
+    USBPD1_IRQn          = 41,  /* USB Power Delivery controller 1              */
+    USBPD1_WKUP_IRQn     = 42,  /* USBPD1 Wake-Up Interrupt                     */
+    TIM3_IRQn            = 43,  /* TIM3 global Interrupt                        */
+    SPI1_IRQn            = 44,  /* SPI1 global Interrupt (moved from 33 on X035)*/
+    USBFS_IRQn           = 45,  /* USB Full-Speed global Interrupt              */
+    USBFS_WakeUp_IRQn    = 46,  /* USBFS Wake-Up Interrupt                      */
+} IRQn_Type;
+
+#define DEFAULT_INTERRUPT_VECTOR_CONTENTS "\n\
+	.align  2\n\
+	.option   push;\n\
+	.option   norvc;\n\
+	j handle_reset\n\
+	.word   0\n\
+	.word   NMI_Handler              /* 2:  NMI */                                       \n\
+	.word   HardFault_Handler        /* 3:  Hard Fault */                                \n\
+	.word   0\n\
+	.word   Ecall_M_Mode_Handler     /* 5:  M-mode ecall */                              \n\
+	.word   0\n\
+	.word   0\n\
+	.word   Ecall_U_Mode_Handler     /* 8:  U-mode ecall */                              \n\
+	.word   Break_Point_Handler      /* 9:  Breakpoint */                                \n\
+	.word   0\n\
+	.word   0\n\
+	.word   SysTick_Handler          /* 12: SysTick */                                   \n\
+	.word   0\n\
+	.word   SW_Handler               /* 14: Software interrupt */                        \n\
+	.word   0\n\
+	/* External Interrupts (slot 16 onward) */                                           \n\
+	.word   WWDG_IRQHandler          /* 16: Window Watchdog */                           \n\
+	.word   OPA_IRQHandler           /* 17: OPA (moved from 48 on X035) */               \n\
+	.word   FLASH_IRQHandler         /* 18: Flash */                                     \n\
+	.word   RCC_IRQHandler           /* 19: RCC */                                       \n\
+	.word   EXTI7_0_IRQHandler       /* 20: EXTI Line[7:0] */                            \n\
+	.word   AWU_IRQHandler           /* 21: AWU */                                       \n\
+	.word   DMA1_Channel1_IRQHandler /* 22: DMA1 Channel 1 */                            \n\
+	.word   DMA1_Channel2_IRQHandler /* 23: DMA1 Channel 2 */                            \n\
+	.word   DMA1_Channel3_IRQHandler /* 24: DMA1 Channel 3 */                            \n\
+	.word   DMA1_Channel4_IRQHandler /* 25: DMA1 Channel 4 */                            \n\
+	.word   DMA1_Channel5_IRQHandler /* 26: DMA1 Channel 5 */                            \n\
+	.word   DMA1_Channel6_IRQHandler /* 27: DMA1 Channel 6 */                            \n\
+	.word   DMA1_Channel7_IRQHandler /* 28: DMA1 Channel 7 */                            \n\
+	.word   ADC1_IRQHandler          /* 29: ADC */                                       \n\
+	.word   I2C1_EV_IRQHandler       /* 30: I2C1 Event */                                \n\
+	.word   I2C1_ER_IRQHandler       /* 31: I2C1 Error */                                \n\
+	.word   UART1_IRQHandler         /* 32: UART1 */                                     \n\
+	.word   EXTI15_8_IRQHandler      /* 33: EXTI Line[15:8] */                           \n\
+	.word   TIM1_BRK_IRQHandler      /* 34: TIM1 Break */                                \n\
+	.word   TIM1_UP_IRQHandler       /* 35: TIM1 Update */                               \n\
+	.word   TIM1_TRG_IRQHandler      /* 36: TIM1 Trigger */                              \n\
+	.word   TIM1_CC_IRQHandler       /* 37: TIM1 Capture/Compare */                      \n\
+	.word   TIM2_IRQHandler          /* 38: TIM2 */                                      \n\
+	.word   USBPD0_IRQHandler        /* 39: USBPD controller 0 */                        \n\
+	.word   USBPD0_WKUP_IRQHandler   /* 40: USBPD0 Wake-Up */                            \n\
+	.word   USBPD1_IRQHandler        /* 41: USBPD controller 1 */                        \n\
+	.word   USBPD1_WKUP_IRQHandler   /* 42: USBPD1 Wake-Up */                            \n\
+	.word   TIM3_IRQHandler          /* 43: TIM3 */                                      \n\
+	.word   SPI1_IRQHandler          /* 44: SPI1 (moved from 33 on X035) */              \n\
+	.word   USBFS_IRQHandler         /* 45: USBFS */                                     \n\
+	.word   USBFSWakeUp_IRQHandler   /* 46: USBFS Wake-Up */                             \n\
+	.option   pop;\n"
+    
+/* memory mapped structure for SysTick */
+typedef struct
+{
+  __IO uint32_t CTLR;
+  __IO uint32_t SR;
+  union
+  {
+     struct
+     {
+        __IO uint32_t CNTL;
+        __IO uint32_t CNTH;
+        __IO uint32_t CMPL;
+        __IO uint32_t CMPH;
+     };
+     struct
+     {
+        __IO uint64_t CNT;
+        __IO uint64_t CMP;
+     };
+  };
+} SysTick_Type;
+
+#define funSysTick32() (SysTick->CNTL)
+#define funSysTickHigh() (SysTick->CNTH)
+
+#endif /* __ASSEMBLER__*/
+
+#define HardFault_IRQn    EXC_IRQn
+
+	#define ADC1_2_IRQn       ADC_IRQn
+
+/* Standard Peripheral Library old definitions (maintained for legacy purpose) */
+#define HSI_Value             HSI_VALUE
+#define HSE_Value             HSE_VALUE
+#define HSEStartUp_TimeOut    HSE_STARTUP_TIMEOUT
+
+#ifndef __ASSEMBLER__
+/* Analog to Digital Converter */
+typedef struct
+{
+    __IO uint32_t STATR;
+    __IO uint32_t CTLR1;
+    __IO uint32_t CTLR2;
+    __IO uint32_t SAMPTR1;
+    __IO uint32_t SAMPTR2;
+    __IO uint32_t IOFR1;
+    __IO uint32_t IOFR2;
+    __IO uint32_t IOFR3;
+    __IO uint32_t IOFR4;
+    __IO uint32_t WDHTR;
+    __IO uint32_t WDLTR;
+    __IO uint32_t RSQR1;
+    __IO uint32_t RSQR2;
+    __IO uint32_t RSQR3;
+    __IO uint32_t ISQR;
+    __IO uint32_t IDATAR1;
+    __IO uint32_t IDATAR2;
+    __IO uint32_t IDATAR3;
+    __IO uint32_t IDATAR4;
+    __IO uint32_t RDATAR;
+    __IO uint32_t CTLR3;
+    __IO uint32_t WDTR1;
+    __IO uint32_t WDTR2;
+    __IO uint32_t WDTR3;
+} ADC_TypeDef;
+
+
+
+/* CRC Calculation Unit */
+typedef struct
+{
+	__IO uint32_t DATAR;
+	__IO uint8_t  IDATAR;
+	uint8_t       RESERVED0;
+	uint16_t      RESERVED1;
+	__IO uint32_t CTLR;
+} CRC_TypeDef;
+
+
+/* Debug MCU */
+typedef struct
+{
+    __IO uint32_t CFGR0;
+    __IO uint32_t CFGR1;
+} DBGMCU_TypeDef;
+
+/* DMA Controller */
+typedef struct
+{
+    __IO uint32_t CFGR;
+    __IO uint32_t CNTR;
+    __IO uint32_t PADDR;
+    __IO uint32_t MADDR;
+} DMA_Channel_TypeDef;
+
+typedef struct
+{
+    __IO uint32_t INTFR;
+    __IO uint32_t INTFCR;
+} DMA_TypeDef;
+
+/* External Interrupt/Event Controller */
+typedef struct
+{
+    __IO uint32_t INTENR;
+    __IO uint32_t EVENR;
+    __IO uint32_t RTENR;
+    __IO uint32_t FTENR;
+    __IO uint32_t SWIEVR;
+    __IO uint32_t INTFR;
+} EXTI_TypeDef;
+
+/* FLASH Registers */
+typedef struct
+{
+    __IO uint32_t ACTLR;
+    __IO uint32_t KEYR;
+    __IO uint32_t OBKEYR;
+    __IO uint32_t STATR;
+    __IO uint32_t CTLR;
+    __IO uint32_t ADDR;
+    __IO uint32_t RESERVED;
+    __IO uint32_t OBR;
+    __IO uint32_t WPR;
+    __IO uint32_t MODEKEYR;
+    __IO uint32_t BOOT_MODEKEYR;
+} FLASH_TypeDef;
+
+/* Option Bytes Registers */
+typedef struct
+{
+    __IO uint16_t RDPR;
+    __IO uint16_t USER;
+    __IO uint16_t Data0;
+    __IO uint16_t Data1;
+    __IO uint16_t WRPR0;
+    __IO uint16_t WRPR1;
+    __IO uint16_t WRPR2;
+    __IO uint16_t WRPR3;
+} OB_TypeDef;
+
+typedef struct
+{
+	__IO uint16_t CAP;
+	__IO uint16_t RES1;
+	__IO uint32_t RES2;
+	__IO uint32_t UID0;
+	__IO uint32_t UID1;
+	__IO uint32_t UID2;
+	__IO uint32_t RES3;
+} ESG_TypeDef;
+
+typedef struct
+{
+    union
+    {   
+        __I uint32_t CHIPID;
+        struct 
+        {
+            __I uint16_t REVID;
+	        __I uint16_t DEVID;
+        };
+    };
+} INFO_TypeDef;
+
+
+/* General Purpose I/O */
+typedef enum
+{
+	GPIO_CFGLR_IN_ANALOG = 0,
+	GPIO_CFGLR_IN_FLOAT = 4,
+	GPIO_CFGLR_IN_PUPD = 8,
+	GPIO_CFGLR_OUT_10Mhz_PP = 1,
+	GPIO_CFGLR_OUT_2Mhz_PP = 2,
+	GPIO_CFGLR_OUT_50Mhz_PP = 3,
+	GPIO_CFGLR_OUT_10Mhz_OD = 5,
+	GPIO_CFGLR_OUT_2Mhz_OD = 6,
+	GPIO_CFGLR_OUT_50Mhz_OD = 7,
+	GPIO_CFGLR_OUT_10Mhz_AF_PP = 9,
+	GPIO_CFGLR_OUT_2Mhz_AF_PP = 10,
+	GPIO_CFGLR_OUT_50Mhz_AF_PP = 11,
+	GPIO_CFGLR_OUT_10Mhz_AF_OD = 13,
+	GPIO_CFGLR_OUT_2Mhz_AF_OD = 14,
+	GPIO_CFGLR_OUT_50Mhz_AF_OD = 15,
+} GPIO_CFGLR_PIN_MODE_Typedef;
+
+typedef union {
+	uint32_t __FULL;
+	struct {
+		GPIO_CFGLR_PIN_MODE_Typedef PIN0 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN1 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN2 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN3 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN4 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN5 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN6 :4;
+		GPIO_CFGLR_PIN_MODE_Typedef PIN7 :4;
+	};
+} GPIO_CFGLR_t;
+typedef union {
+	uint32_t __FULL;
+	const struct {
+		uint32_t IDR0 :1;
+		uint32_t IDR1 :1;
+		uint32_t IDR2 :1;
+		uint32_t IDR3 :1;
+		uint32_t IDR4 :1;
+		uint32_t IDR5 :1;
+		uint32_t IDR6 :1;
+		uint32_t IDR7 :1;
+		uint32_t :24;
+	};
+} GPIO_INDR_t;
+typedef union {
+	uint32_t __FULL;
+	struct {
+		uint32_t ODR0 :1;
+		uint32_t ODR1 :1;
+		uint32_t ODR2 :1;
+		uint32_t ODR3 :1;
+		uint32_t ODR4 :1;
+		uint32_t ODR5 :1;
+		uint32_t ODR6 :1;
+		uint32_t ODR7 :1;
+		uint32_t :24;
+	};
+} GPIO_OUTDR_t;
+typedef union {
+	uint32_t __FULL;
+	struct {
+		uint32_t BS0 :1;
+		uint32_t BS1 :1;
+		uint32_t BS2 :1;
+		uint32_t BS3 :1;
+		uint32_t BS4 :1;
+		uint32_t BS5 :1;
+		uint32_t BS6 :1;
+		uint32_t BS7 :1;
+		uint32_t :8;
+		uint32_t BR0 :1;
+		uint32_t BR1 :1;
+		uint32_t BR2 :1;
+		uint32_t BR3 :1;
+		uint32_t BR4 :1;
+		uint32_t BR5 :1;
+		uint32_t BR6 :1;
+		uint32_t BR7 :1;
+		uint32_t :8;
+	};
+} GPIO_BSHR_t;
+typedef union {
+	uint32_t __FULL;
+	struct {
+		uint32_t BR0 :1;
+		uint32_t BR1 :1;
+		uint32_t BR2 :1;
+		uint32_t BR3 :1;
+		uint32_t BR4 :1;
+		uint32_t BR5 :1;
+		uint32_t BR6 :1;
+		uint32_t BR7 :1;
+		uint32_t :24;
+	};
+} GPIO_BCR_t;
+typedef union {
+	uint32_t __FULL;
+	struct {
+		uint32_t LCK0 :1;
+		uint32_t LCK1 :1;
+		uint32_t LCK2 :1;
+		uint32_t LCK3 :1;
+		uint32_t LCK4 :1;
+		uint32_t LCK5 :1;
+		uint32_t LCK6 :1;
+		uint32_t LCK7 :1;
+		uint32_t LCKK :1;
+		uint32_t :23;
+	};
+} GPIO_LCKR_t;
+typedef struct
+{
+	__IO uint32_t CFGLR;
+	__IO uint32_t CFGHR;
+	__I  uint32_t INDR;
+	__IO uint32_t OUTDR;
+	__IO uint32_t BSHR;
+	__IO uint32_t BCR;
+	__IO uint32_t LCKR;
+	__IO uint32_t CFGXR;
+	__IO uint32_t BSXR;
+} GPIO_TypeDef;
+
+#define DYN_GPIO_READ(gpio, field) ((GPIO_##field##_t) { .__FULL = gpio->field })
+#define DYN_GPIO_WRITE(gpio, field, ...) gpio->field = ((const GPIO_##field##_t) __VA_ARGS__).__FULL
+#define DYN_GPIO_MOD(gpio, field, reg, val) {GPIO_##field##_t tmp; tmp.__FULL = gpio->field; tmp.reg = val; gpio->field = tmp.__FULL;}
+
+/* Alternate Function I/O */
+typedef struct
+{
+    uint32_t RESERVED0;
+    __IO uint32_t PCFR1;
+    __IO uint32_t EXTICR1;
+    __IO uint32_t EXTICR2;
+    uint32_t RESERVED1;
+    uint32_t RESERVED2;
+    __IO uint32_t CTLR;
+} AFIO_TypeDef;
+
+/* Inter Integrated Circuit Interface */
+typedef struct
+{
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED1;
+    __IO uint16_t OADDR1;
+    uint16_t      RESERVED2;
+    __IO uint16_t OADDR2;
+    uint16_t      RESERVED3;
+    __IO uint16_t DATAR;
+    uint16_t      RESERVED4;
+    __IO uint16_t STAR1;
+    uint16_t      RESERVED5;
+    __IO uint16_t STAR2;
+    uint16_t      RESERVED6;
+    __IO uint16_t CKCFGR;
+    uint16_t      RESERVED7;
+} I2C_TypeDef;
+
+/* Independent WatchDog */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t PSCR;
+    __IO uint32_t RLDR;
+    __IO uint32_t STATR;
+} IWDG_TypeDef;
+
+/* Power Control */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t CSR;
+} PWR_TypeDef;
+
+/* Reset and Clock Control */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t CFGR0;
+    __IO uint32_t INTR;
+    __IO uint32_t APB2PRSTR;
+    __IO uint32_t APB1PRSTR;
+    __IO uint32_t AHBPCENR;
+    __IO uint32_t APB2PCENR;
+    __IO uint32_t APB1PCENR;
+    __IO uint32_t RESERVED1;
+    __IO uint32_t RSTSCKR;
+    __IO uint32_t AHBRSTR;
+} RCC_TypeDef;
+
+
+
+/* Serial Peripheral Interface */
+typedef struct
+{
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED1;
+    __IO uint16_t STATR;
+    uint16_t      RESERVED2;
+    __IO uint16_t DATAR;
+    uint16_t      RESERVED3;
+    __IO uint16_t CRCR;
+    uint16_t      RESERVED4;
+    __IO uint16_t RCRCR;
+    uint16_t      RESERVED5;
+    __IO uint16_t TCRCR;
+    uint16_t      RESERVED6;
+    uint32_t      RESERVED7;
+    uint32_t      RESERVED8;
+    __IO uint16_t HSCR;
+    uint16_t      RESERVED9;
+} SPI_TypeDef;
+
+/* TIM */
+typedef struct
+{
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED0;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED1;
+    __IO uint16_t SMCFGR;
+    uint16_t      RESERVED2;
+    __IO uint16_t DMAINTENR;
+    uint16_t      RESERVED3;
+    __IO uint16_t INTFR;
+    uint16_t      RESERVED4;
+    __IO uint16_t SWEVGR;
+    uint16_t      RESERVED5;
+    __IO uint16_t CHCTLR1;
+    uint16_t      RESERVED6;
+    __IO uint16_t CHCTLR2;
+    uint16_t      RESERVED7;
+    __IO uint16_t CCER;
+    uint16_t      RESERVED8;
+    __IO uint16_t CNT;
+    uint16_t      RESERVED9;
+    __IO uint16_t PSC;
+    uint16_t      RESERVED10;
+    __IO uint16_t ATRLR;
+    uint16_t      RESERVED11;
+    __IO uint16_t RPTCR;
+    uint16_t      RESERVED12;
+    __IO uint32_t CH1CVR;
+    __IO uint32_t CH2CVR;
+    __IO uint32_t CH3CVR;
+    __IO uint32_t CH4CVR;
+    __IO uint16_t BDTR;
+    uint16_t      RESERVED13;
+    __IO uint16_t DMACFGR;
+    uint16_t      RESERVED14;
+    __IO uint16_t DMAADR;
+    uint16_t      RESERVED15;
+    __IO uint16_t SPEC;
+    uint16_t      RESERVED16;
+} TIM_TypeDef;
+
+/* Universal Synchronous Asynchronous Receiver Transmitter */
+typedef struct
+{
+    __IO uint16_t STATR;
+    uint16_t      RESERVED0;
+    __IO uint16_t DATAR;
+    uint16_t      RESERVED1;
+    __IO uint16_t BRR;
+    uint16_t      RESERVED2;
+    __IO uint16_t CTLR1;
+    uint16_t      RESERVED3;
+    __IO uint16_t CTLR2;
+    uint16_t      RESERVED4;
+    __IO uint16_t CTLR3;
+    uint16_t      RESERVED5;
+    __IO uint16_t GPR;
+    uint16_t      RESERVED6;
+} USART_TypeDef;
+
+/* Window WatchDog */
+typedef struct
+{
+    __IO uint32_t CTLR;
+    __IO uint32_t CFGR;
+    __IO uint32_t STATR;
+} WWDG_TypeDef;
+
+/* Enhanced Registers */
+typedef struct
+{
+    __IO uint32_t EXTEN_CTR;
+} EXTEN_TypeDef;
+
+/* The reference manual for the ch32v2xx/v3xx reference this as "CTR" field in the "EXTEND" register so adding an alias here. */
+typedef struct
+{
+    __IO uint32_t CTR;
+} EXTEND_TypeDef;
+
+
+
+
+/* Touch Sensor, Mirrors Analog to Digital Converter */
+typedef struct
+{
+	__IO uint32_t RESERVED0[3];
+	__IO uint32_t CHARGE1;
+	__IO uint32_t CHARGE2;
+	__IO uint32_t RESERVED1[10];
+	__IO uint32_t CHGOFFSET;
+	__IO uint32_t RESERVED2[3];
+	__IO uint32_t DR_ACT_DCG;
+} TKEY_TypeDef;
+
+/* Op amp / comparator */
+typedef struct
+{
+	__IO uint16_t CFGR1;
+	__IO uint16_t CFGR2;
+	__IO uint32_t CTLR1;
+	__IO uint32_t CTLR2;
+	__IO uint32_t OPA_KEY;
+	__IO uint32_t CMP_KEY;
+	__IO uint32_t POLL_KEY;
+} OPACMP_TypeDef;
+
+/* USB Full Speed Device Mode */
+typedef struct
+{
+	__IO uint8_t BASE_CTRL;
+	__IO uint8_t UDEV_CTRL; // or host ctlr
+	__IO uint8_t INT_EN;
+	__IO uint8_t DEV_ADDR;
+	__IO uint8_t RESERVED0;
+	__IO uint8_t MIS_ST;
+	__IO uint8_t INT_FG;
+	__IO uint8_t INT_ST;
+	__IO uint16_t RX_LEN;
+	__IO uint16_t RESERVED1;
+	__IO uint8_t UEP4_1_MOD;
+	__IO uint8_t UEP2_3_MOD; // Also HOST_EP_MOD
+	__IO uint8_t UEP567_MOD;
+	__IO uint8_t RESERVED2;
+
+	__IO uint32_t UEP0_DMA;
+	__IO uint32_t UEP1_DMA;
+	__IO uint32_t UEP2_DMA; // Also HOST_RX_DMA
+	__IO uint32_t UEP3_DMA; // Also HOST_TX_DMA
+
+	//__IO uint32_t UEP0_CTRL;
+	__IO uint16_t UEP0_TX_LEN;
+	__IO uint16_t UEP0_CTRL_H;
+
+	//__IO uint32_t UEP1_CTRL;
+	__IO uint16_t UEP1_TX_LEN;
+	__IO uint16_t UEP1_CTRL_H; // Also HOST_SETUP
+
+	//__IO uint32_t UEP2_CTRL;
+	__IO uint16_t UEP2_TX_LEN; // Also HOST_PID
+	__IO uint16_t UEP2_CTRL_H; // Also HOST_RX_CTL
+
+	//__IO uint32_t UEP3_CTRL;
+	__IO uint16_t UEP3_TX_LEN; // Also HOST_TX_LEN
+	__IO uint16_t UEP3_CTRL_H; // Also HOST_TX_CTL
+
+	//__IO uint32_t UEP4_CTRL;
+	__IO uint16_t UEP4_TX_LEN;
+	__IO uint16_t UEP4_CTRL_H;
+
+	__IO uint32_t RESERVED3[8];
+
+	__IO uint32_t UEP5_DMA;
+	__IO uint32_t UEP6_DMA;
+	__IO uint32_t UEP7_DMA;
+
+	__IO uint32_t RESERVED4;
+
+	//__IO uint32_t UEP5_CTRL;
+	__IO uint16_t UEP5_TX_LEN;
+	__IO uint16_t UEP5_CTRL_H;
+
+	//__IO uint32_t UEP6_CTRL;
+	__IO uint16_t UEP6_TX_LEN;
+	__IO uint16_t UEP6_CTRL_H;
+
+	//__IO uint32_t UEP7_CTRL;
+	__IO uint16_t UEP7_TX_LEN;
+	__IO uint16_t UEP7_CTRL_H;
+
+	__IO uint32_t UEPX_MOD;
+} USBFS_TypeDef;
+
+
+
+
+
+#define USBFSD_UEP_MOD_BASE         0x4002340C
+#define USBFSD_UEP_DMA_BASE         0x40023410
+#define USBFSD_UEP_LEN_BASE         0x40023420
+#define USBFSD_UEP_CTL_BASE         0x40023422
+#define USBFSD_UEP_RX_EN            0x08
+#define USBFSD_UEP_TX_EN            0x04
+#define USBFSD_UEP_BUF_MOD          0x01
+#define USBFSD_UEP_MOD( N )         (*((volatile uint8_t *)( USBFSD_UEP_MOD_BASE + N )))
+#define USBFSD_UEP_TX_CTRL( N )     (*((volatile uint8_t *)( USBFSD_UEP_CTL_BASE + N * 0x04 )))
+#define USBFSD_UEP_RX_CTRL( N )     (*((volatile uint8_t *)( USBFSD_UEP_CTL_BASE + N * 0x04 )))
+#define USBFSD_UEP_DMA( N )         (*((volatile uint32_t *)( USBFSD_UEP_DMA_BASE + N * 0x04 )))
+#define USBFSD_UEP_BUF( N )         ((uint8_t *)(*((volatile uint32_t *)( USBFSD_UEP_DMA_BASE + N * 0x04 ))) + 0x20000000)
+#define USBFSD_UEP_TLEN( N )        (*((volatile uint16_t *)( USBFSD_UEP_LEN_BASE + N * 0x04 )))
+
+/* R8_UEPn_TX_CTRL */
+#define USBFS_UEP_T_AUTO_TOG        (1<<4)      // enable automatic toggle after successful transfer completion on endpoint 1/2/3: 0=manual toggle, 1=automatic toggle
+#define USBFS_UEP_T_TOG             (1<<6)      // prepared data toggle flag of USB endpoint X transmittal (IN): 0=DATA0, 1=DATA1
+#define USBFS_UEP_T_RES_MASK        (3<<0)      // bit mask of handshake response type for USB endpoint X transmittal (IN)
+#define USBFS_UEP_T_RES_ACK         (0<<1)
+#define USBFS_UEP_T_RES_NONE        (1<<0)
+#define USBFS_UEP_T_RES_NAK         (1<<1)
+#define USBFS_UEP_T_RES_STALL       (3<<0)
+// bUEP_T_RES1 & bUEP_T_RES0: handshake response type for USB endpoint X transmittal (IN)
+//   00: DATA0 or DATA1 then expecting ACK (ready)
+//   01: DATA0 or DATA1 then expecting no response, time out from host, for non-zero endpoint isochronous transactions
+//   10: NAK (busy)
+//   11: STALL (error)
+// host aux setup
+
+/* R8_UEPn_RX_CTRL, n=0-7 */
+#define USBFS_UEP_R_AUTO_TOG        (1<<4)      // enable automatic toggle after successful transfer completion on endpoint 1/2/3: 0=manual toggle, 1=automatic toggle
+#define USBFS_UEP_R_TOG             (1<<7)      // expected data toggle flag of USB endpoint X receiving (OUT): 0=DATA0, 1=DATA1
+#define USBFS_UEP_R_RES_MASK        (3<<2)      // bit mask of handshake response type for USB endpoint X receiving (OUT)
+#define USBFS_UEP_R_RES_ACK         (0<<3)
+#define USBFS_UEP_R_RES_NONE        (1<<2)
+#define USBFS_UEP_R_RES_NAK         (1<<3)
+#define USBFS_UEP_R_RES_STALL       (3<<2)
+
+
+#define EP1_T_EN					(1<<6)
+#define EP2_T_EN					(1<<2)
+#define EP3_T_EN					(1<<6)
+#define EP4_T_EN					(1<<2)
+#define EP1_R_EN					(1<<7)
+#define EP2_R_EN					(1<<3)
+#define EP3_R_EN					(1<<7)
+#define EP4_R_EN					(1<<3)
+
+
+/* R8_USB_CTRL */
+#define USBFS_UC_HOST_MODE          0x80
+#define USBFS_UC_LOW_SPEED          0x40
+#define USBFS_UC_DEV_PU_EN          0x20
+#define USBFS_UC_SYS_CTRL_MASK      0x30
+#define USBFS_UC_SYS_CTRL0          0x00
+#define USBFS_UC_SYS_CTRL1          0x10
+#define USBFS_UC_SYS_CTRL2          0x20
+#define USBFS_UC_SYS_CTRL3          0x30
+#define USBFS_UC_INT_BUSY           0x08
+#define USBFS_UC_RESET_SIE          0x04
+#define USBFS_UC_CLR_ALL            0x02
+#define USBFS_UC_DMA_EN             0x01
+
+/* R8_USB_INT_EN */
+#define USBFS_UIE_DEV_SOF           0x80
+#define USBFS_UIE_DEV_NAK           0x40
+#define USBFS_UIE_FIFO_OV           0x10
+#define USBFS_UIE_HST_SOF           0x08
+#define USBFS_UIE_SUSPEND           0x04
+#define USBFS_UIE_TRANSFER          0x02
+#define USBFS_UIE_DETECT            0x01
+#define USBFS_UIE_BUS_RST           0x01
+
+/* R8_USB_DEV_AD */
+#define USBFS_UDA_GP_BIT            0x80
+#define USBFS_USB_ADDR_MASK         0x7F
+
+/* R8_USB_MIS_ST */
+#define USBFS_UMS_SOF_PRES          0x80
+#define USBFS_UMS_SOF_ACT           0x40
+#define USBFS_UMS_SIE_FREE          0x20
+#define USBFS_UMS_R_FIFO_RDY        0x10
+#define USBFS_UMS_BUS_RESET         0x08
+#define USBFS_UMS_SUSPEND           0x04
+#define USBFS_UMS_DM_LEVEL          0x02
+#define USBFS_UMS_DEV_ATTACH        0x01
+
+
+
+
+#define USBFS_UDA_GP_BIT            0x80
+#define USBFS_USB_ADDR_MASK         0x7F
+
+#define DEF_USBD_UEP0_SIZE		   64	 /* usb hs/fs device end-point 0 size */
+#define UEP_SIZE 64
+
+#define DEF_UEP_IN                  0x80
+#define DEF_UEP_OUT                 0x00
+#define DEF_UEP_BUSY                0x01
+#define DEF_UEP_FREE                0x00
+
+#define DEF_UEP0 0
+#define DEF_UEP1 1
+#define DEF_UEP2 2
+#define DEF_UEP3 3
+#define DEF_UEP4 4
+#define DEF_UEP5 5
+#define DEF_UEP6 6
+#define DEF_UEP7 7
+#define UNUM_EP 8
+
+
+
+/* USB Host Mode */
+
+typedef struct
+{
+	__IO uint8_t RESERVED0;
+	__IO uint8_t HOST_CTRL;
+	__IO uint8_t RESERVED1;
+	__IO uint8_t RESERVED2;
+	__IO uint8_t RESERVED3;
+	__IO uint8_t RESERVED4;
+	__IO uint8_t RESERVED5;
+	__IO uint8_t RESERVED6;
+	__IO uint16_t RESERVED7;
+	__IO uint16_t RESERVED8;
+	__IO uint8_t RESERVED9;
+	__IO uint8_t HOST_EP_MOD;
+	__IO uint8_t RESERVED10;
+	__IO uint8_t RESERVED11;
+
+	__IO uint32_t RESERVED12;
+	__IO uint32_t RESERVED13;
+	__IO uint32_t HOST_RX_DMA;
+	__IO uint32_t HOST_TX_DMA;
+
+	__IO uint16_t RESERVED14;
+	__IO uint16_t RESERVED15;
+	__IO uint16_t RESERVED16;
+
+	__IO uint16_t HOST_SETUP;
+	__IO uint16_t HOST_EP_PID;
+	__IO uint16_t HOST_RX_CTL;
+	__IO uint16_t HOST_TX_LEN;
+	__IO uint16_t HOST_TX_CTL;
+
+	__IO uint16_t RESERVED20;
+	__IO uint16_t RESERVED21;
+
+	__IO uint32_t RESERVED22[8];
+
+	__IO uint32_t RESERVED23;
+	__IO uint32_t RESERVED24;
+	__IO uint32_t RESERVED25;
+
+	__IO uint32_t RESERVED26;
+
+	__IO uint16_t RESERVED27;
+	__IO uint16_t RESERVED28;
+
+	__IO uint16_t RESERVED29;
+	__IO uint16_t RESERVED30;
+
+	__IO uint16_t RESERVED31;
+	__IO uint16_t RESERVED32;
+
+	__IO uint32_t RESERVED33;
+} USBDH_TypeDef;
+
+
+/* USB Power Delivery */
+typedef struct
+{
+	__IO uint32_t CONFIG;
+	__IO uint32_t CONTROL;
+	__IO uint32_t STATUS;
+	__IO uint32_t PORT;
+	__IO uint32_t DMA;
+} USBPD_TypeDef;
+
+
+/* USB Power Delivery */
+typedef struct
+{
+	__IO uint16_t CONFIG;
+	__IO uint16_t BMC_CLK_CNT;
+
+	__IO uint8_t CONTROL;
+	__IO uint8_t TX_SEL;
+	__IO uint16_t BMC_TX_SZ;
+
+	__IO uint8_t DATA_BUF;
+	__IO uint8_t STATUS;
+	__IO uint16_t BMC_BYTE_CNT;
+
+	__IO uint16_t PORT_CC1;
+	__IO uint16_t PORT_CC2;
+
+	__IO uint32_t DMA;
+} USBPD_DETAILED_TypeDef;
+
+
+
+
+/* memory mapped structure for Program Fast Interrupt Controller (PFIC) */
+typedef struct{
+    __I  uint32_t ISR[8];
+    __I  uint32_t IPR[8];
+    __IO uint32_t ITHRESDR;
+    __IO uint32_t RESERVED;
+    __IO uint32_t CFGR;
+    __I  uint32_t GISR;
+    __IO uint8_t VTFIDR[4];
+    uint8_t RESERVED0[12];
+    __IO uint32_t VTFADDR[4];
+    uint8_t RESERVED1[0x90];
+    __O  uint32_t IENR[8];
+    uint8_t RESERVED2[0x60];
+    __O  uint32_t IRER[8];
+    uint8_t RESERVED3[0x60];
+    __O  uint32_t IPSR[8];
+    uint8_t RESERVED4[0x60];
+    __O  uint32_t IPRR[8];
+    uint8_t RESERVED5[0x60];
+    __IO uint32_t IACTR[8];
+    uint8_t RESERVED6[0xE0];
+    __IO uint8_t IPRIOR[256];
+    uint8_t RESERVED7[0x810];
+    __IO uint32_t SCTLR;
+}PFIC_Type;
+
+#endif // !__ASSEMBLER__
+
+/* Peripheral memory map */
+#ifdef __ASSEMBLER__
+#define FLASH_BASE                              (0x08000000) /* FLASH base address in the alias region */
+#define SRAM_BASE                               (0x20000000) /* SRAM base address in the alias region */
+#define PERIPH_BASE                             (0x40000000) /* Peripheral base address in the alias region */
+#define CORE_PERIPH_BASE                        (0xE0000000) /* System peripherals base address in the alias region */
+#else
+#define FLASH_BASE                              ((uint32_t)0x08000000) /* FLASH base address in the alias region */
+#define SRAM_BASE                               ((uint32_t)0x20000000) /* SRAM base address in the alias region */
+#define PERIPH_BASE                             ((uint32_t)0x40000000) /* Peripheral base address in the alias region */
+#define CORE_PERIPH_BASE                        ((uint32_t)0xE0000000) /* System peripherals base address in the alias region */
+#endif
+
+
+#define APB1PERIPH_BASE                         (PERIPH_BASE)
+#define APB2PERIPH_BASE                         (PERIPH_BASE + 0x10000)
+#define AHBPERIPH_BASE                          (PERIPH_BASE + 0x20000)
+
+/* APB1 peripherals (CH32M030 RM v1.2 §1.2) */
+#define TIM2_BASE                               (APB1PERIPH_BASE + 0x0000)
+#define TIM3_BASE                               (APB1PERIPH_BASE + 0x0400)
+#define WWDG_BASE                               (APB1PERIPH_BASE + 0x2C00)
+/* M030 has no IWDG, no USART2/3/4 — removed vs. X035 */
+#define I2C1_BASE                               (APB1PERIPH_BASE + 0x5400)
+#define PWR_BASE                                (APB1PERIPH_BASE + 0x7000)
+/* AWU on M030 is folded into PWR (R32_PWR_AWUCSR @ 0x40007008,
+   R32_PWR_AWUWR @ 0x4000700C) — no standalone AWU peripheral */
+
+/* APB2 peripherals (CH32M030 RM v1.2 §1.2) */
+#define AFIO_BASE                               (APB2PERIPH_BASE + 0x0000)
+#define EXTI_BASE                               (APB2PERIPH_BASE + 0x0400)
+#define GPIOA_BASE                              (APB2PERIPH_BASE + 0x0800)
+#define GPIOB_BASE                              (APB2PERIPH_BASE + 0x0C00)
+#define GPIOC_BASE                              (APB2PERIPH_BASE + 0x1000) /* PC0-PC5 only, CFGLR only (no CFGHR) */
+/* M030 has no GPIOD — removed vs. X035 */
+#define ADC1_BASE                               (APB2PERIPH_BASE + 0x2400)
+#define TIM1_BASE                               (APB2PERIPH_BASE + 0x2C00)
+#define SPI1_BASE                               (APB2PERIPH_BASE + 0x3000)
+#define USART1_BASE                             (APB2PERIPH_BASE + 0x3800) /* WCH names this UART1 on M030 (no sync mode) */
+#define UART1_BASE                              USART1_BASE                /* Alias matching M030 RM naming */
+
+/* AHB peripherals (CH32M030 RM v1.2 §1.2) */
+#define DMA1_BASE                               (AHBPERIPH_BASE + 0x0000)
+#define DMA1_Channel1_BASE                      (AHBPERIPH_BASE + 0x0008)
+#define DMA1_Channel2_BASE                      (AHBPERIPH_BASE + 0x001C)
+#define DMA1_Channel3_BASE                      (AHBPERIPH_BASE + 0x0030)
+#define DMA1_Channel4_BASE                      (AHBPERIPH_BASE + 0x0044)
+#define DMA1_Channel5_BASE                      (AHBPERIPH_BASE + 0x0058)
+#define DMA1_Channel6_BASE                      (AHBPERIPH_BASE + 0x006C)
+#define DMA1_Channel7_BASE                      (AHBPERIPH_BASE + 0x0080)
+/* M030 DMA has 7 channels only — Channel 8 removed vs. X035 */
+#define RCC_BASE                                (AHBPERIPH_BASE + 0x1000)
+
+#define FLASH_R_BASE                            (AHBPERIPH_BASE + 0x2000) /* Flash registers base address */
+
+#define USBFS_BASE                              (AHBPERIPH_BASE + 0x3400) /* §16 */
+#define EXTEN_BASE                              (AHBPERIPH_BASE + 0x3800) /* §20 */
+#define USBPD0_BASE                             (AHBPERIPH_BASE + 0x4000) /* §15 — controller 0 */
+#define USBPD1_BASE                             (AHBPERIPH_BASE + 0x4400) /* §15 — controller 1 */
+#define OPA_BASE                                (AHBPERIPH_BASE + 0x4800) /* §17 — QII/ISP/CMP block; struct rewrite TBD */
+/* M030 has no standalone AWU and no PIOC — removed vs. X035 */
+
+
+#define OB_BASE                                 ((uint32_t)0x1FFFF800)    /* Flash Option Bytes base address */
+#define ESIG_BASE                               ((uint32_t)0x1FFFF7E0)
+#define INFO_BASE                               ((uint32_t)0x1FFFF704)
+
+#define PFIC_BASE    (CORE_PERIPH_BASE + 0xE000)
+#define SysTick_BASE    (CORE_PERIPH_BASE + 0xF000)
+
+
+
+
+/* Peripheral declaration */
+#define TIM2                                    ((TIM_TypeDef *)TIM2_BASE)
+#define TIM3                                    ((TIM_TypeDef *)TIM3_BASE)
+#define WWDG                                    ((WWDG_TypeDef *)WWDG_BASE)
+/* IWDG, USART2/3/4 removed — not present on M030 */
+#define I2C1                                    ((I2C_TypeDef *)I2C1_BASE)
+#define PWR                                     ((PWR_TypeDef *)PWR_BASE)
+
+#define AFIO                                    ((AFIO_TypeDef *)AFIO_BASE)
+#define EXTI                                    ((EXTI_TypeDef *)EXTI_BASE)
+#define GPIOA                                   ((GPIO_TypeDef *)GPIOA_BASE)
+#define GPIOB                                   ((GPIO_TypeDef *)GPIOB_BASE)
+#define GPIOC                                   ((GPIO_TypeDef *)GPIOC_BASE)
+/* GPIOD removed — not present on M030 */
+#define ADC1                                    ((ADC_TypeDef *)ADC1_BASE)
+#define TKey                                    ((TKEY_TypeDef *)ADC1_BASE)
+#define OPA                                     ((OPACMP_TypeDef *)OPA_BASE)        /* Struct layout rewrite pending */
+#define USBFS                                   ((USBFS_TypeDef *)USBFS_BASE)
+#define USBPD0WORD                              ((USBPD_TypeDef *)USBPD0_BASE)
+#define USBPD0                                  ((USBPD_DETAILED_TypeDef *)USBPD0_BASE)
+#define USBPD1WORD                              ((USBPD_TypeDef *)USBPD1_BASE)
+#define USBPD1                                  ((USBPD_DETAILED_TypeDef *)USBPD1_BASE)
+#define USBDH                                   ((USBDH_TypeDef *)USBFS_BASE)
+
+#define TIM1                                    ((TIM_TypeDef *)TIM1_BASE)
+#define SPI1                                    ((SPI_TypeDef *)SPI1_BASE)
+#define USART1                                  ((USART_TypeDef *)USART1_BASE)
+#define UART1                                   USART1                              /* Alias matching M030 RM naming */
+
+#define DMA1                                    ((DMA_TypeDef *)DMA1_BASE)
+#define DMA1_Channel1                           ((DMA_Channel_TypeDef *)DMA1_Channel1_BASE)
+#define DMA1_Channel2                           ((DMA_Channel_TypeDef *)DMA1_Channel2_BASE)
+#define DMA1_Channel3                           ((DMA_Channel_TypeDef *)DMA1_Channel3_BASE)
+#define DMA1_Channel4                           ((DMA_Channel_TypeDef *)DMA1_Channel4_BASE)
+#define DMA1_Channel5                           ((DMA_Channel_TypeDef *)DMA1_Channel5_BASE)
+#define DMA1_Channel6                           ((DMA_Channel_TypeDef *)DMA1_Channel6_BASE)
+#define DMA1_Channel7                           ((DMA_Channel_TypeDef *)DMA1_Channel7_BASE)
+/* DMA1_Channel8 removed — M030 has 7 channels */
+#define RCC                                     ((RCC_TypeDef *)RCC_BASE)
+#define FLASH                                   ((FLASH_TypeDef *)FLASH_R_BASE)
+#define OB                                      ((OB_TypeDef *)OB_BASE)
+#define ESIG                                    ((ESG_TypeDef *)ESIG_BASE)
+// Mentioned in ch32v30x_dbgmcu.c, may not work on all processors.
+#define INFO                                    ((INFO_TypeDef *)INFO_BASE) 
+#define EXTEN                                   ((EXTEN_TypeDef *)EXTEN_BASE)
+#define EXTEND                                  ((EXTEND_TypeDef *)EXTEN_BASE)  // Alias to EXTEN
+
+
+
+
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                        Analog to Digital Converter                         */
+/******************************************************************************/
+
+/********************  Bit definition for ADC_STATR register  ********************/
+#define ADC_AWD                                 ((uint8_t)0x01) /* Analog watchdog flag */
+#define ADC_EOC                                 ((uint8_t)0x02) /* End of conversion */
+#define ADC_JEOC                                ((uint8_t)0x04) /* Injected channel end of conversion */
+#define ADC_JSTRT                               ((uint8_t)0x08) /* Injected channel Start flag */
+#define ADC_STRT                                ((uint8_t)0x10) /* Regular channel Start flag */
+
+/*******************  Bit definition for ADC_CTLR1 register  ********************/
+#define ADC_AWDCH                               ((uint32_t)0x0000001F) /* AWDCH[4:0] bits (Analog watchdog channel select bits) */
+#define ADC_AWDCH_0                             ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_AWDCH_1                             ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_AWDCH_2                             ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_AWDCH_3                             ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_AWDCH_4                             ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_EOCIE                               ((uint32_t)0x00000020) /* Interrupt enable for EOC */
+#define ADC_AWDIE                               ((uint32_t)0x00000040) /* Analog Watchdog interrupt enable */
+#define ADC_JEOCIE                              ((uint32_t)0x00000080) /* Interrupt enable for injected channels */
+#define ADC_SCAN                                ((uint32_t)0x00000100) /* Scan mode */
+#define ADC_AWDSGL                              ((uint32_t)0x00000200) /* Enable the watchdog on a single channel in scan mode */
+#define ADC_JAUTO                               ((uint32_t)0x00000400) /* Automatic injected group conversion */
+#define ADC_DISCEN                              ((uint32_t)0x00000800) /* Discontinuous mode on regular channels */
+#define ADC_JDISCEN                             ((uint32_t)0x00001000) /* Discontinuous mode on injected channels */
+
+#define ADC_DISCNUM                             ((uint32_t)0x0000E000) /* DISCNUM[2:0] bits (Discontinuous mode channel count) */
+#define ADC_DISCNUM_0                           ((uint32_t)0x00002000) /* Bit 0 */
+#define ADC_DISCNUM_1                           ((uint32_t)0x00004000) /* Bit 1 */
+#define ADC_DISCNUM_2                           ((uint32_t)0x00008000) /* Bit 2 */
+
+#define ADC_DUALMOD                             ((uint32_t)0x000F0000) /* DUALMOD[3:0] bits (Dual mode selection) */
+#define ADC_DUALMOD_0                           ((uint32_t)0x00010000) /* Bit 0 */
+#define ADC_DUALMOD_1                           ((uint32_t)0x00020000) /* Bit 1 */
+#define ADC_DUALMOD_2                           ((uint32_t)0x00040000) /* Bit 2 */
+#define ADC_DUALMOD_3                           ((uint32_t)0x00080000) /* Bit 3 */
+
+#define ADC_JAWDEN                              ((uint32_t)0x00400000) /* Analog watchdog enable on injected channels */
+#define ADC_AWDEN                               ((uint32_t)0x00800000) /* Analog watchdog enable on regular channels */
+#define ADC_TKENABLE                            ((uint32_t)0x01000000) /* TKEN mode enable */
+
+/*******************  Bit definition for ADC_CTLR2 register  ********************/
+#define ADC_ADON                                ((uint32_t)0x00000001) /* A/D Converter ON / OFF */
+#define ADC_CONT                                ((uint32_t)0x00000002) /* Continuous Conversion */
+#define ADC_CAL                                 ((uint32_t)0x00000004) /* A/D Calibration */
+#define ADC_RSTCAL                              ((uint32_t)0x00000008) /* Reset Calibration */
+#define ADC_DMA                                 ((uint32_t)0x00000100) /* Direct Memory access mode */
+#define ADC_ALIGN                               ((uint32_t)0x00000800) /* Data Alignment */
+
+#define ADC_JEXTSEL                             ((uint32_t)0x00007000) /* JEXTSEL[2:0] bits (External event select for injected group) */
+#define ADC_JEXTSEL_0                           ((uint32_t)0x00001000) /* Bit 0 */
+#define ADC_JEXTSEL_1                           ((uint32_t)0x00002000) /* Bit 1 */
+#define ADC_JEXTSEL_2                           ((uint32_t)0x00004000) /* Bit 2 */
+
+#define ADC_JEXTTRIG                            ((uint32_t)0x00008000) /* External Trigger Conversion mode for injected channels */
+
+#define ADC_EXTSEL                              ((uint32_t)0x000E0000) /* EXTSEL[2:0] bits (External Event Select for regular group) */
+#define ADC_EXTSEL_0                            ((uint32_t)0x00020000) /* Bit 0 */
+#define ADC_EXTSEL_1                            ((uint32_t)0x00040000) /* Bit 1 */
+#define ADC_EXTSEL_2                            ((uint32_t)0x00080000) /* Bit 2 */
+
+#define ADC_EXTTRIG                             ((uint32_t)0x00100000) /* External Trigger Conversion mode for regular channels */
+#define ADC_JSWSTART                            ((uint32_t)0x00200000) /* Start Conversion of injected channels */
+#define ADC_SWSTART                             ((uint32_t)0x00400000) /* Start Conversion of regular channels */
+#define ADC_TSVREFE                             ((uint32_t)0x00800000) /* Temperature Sensor and VREFINT Enable */
+
+/******************  Bit definition for ADC_SAMPTR1 register  *******************/
+#define ADC_SMP10                               ((uint32_t)0x00000007) /* SMP10[2:0] bits (Channel 10 Sample time selection) */
+#define ADC_SMP10_0                             ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SMP10_1                             ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SMP10_2                             ((uint32_t)0x00000004) /* Bit 2 */
+
+#define ADC_SMP11                               ((uint32_t)0x00000038) /* SMP11[2:0] bits (Channel 11 Sample time selection) */
+#define ADC_SMP11_0                             ((uint32_t)0x00000008) /* Bit 0 */
+#define ADC_SMP11_1                             ((uint32_t)0x00000010) /* Bit 1 */
+#define ADC_SMP11_2                             ((uint32_t)0x00000020) /* Bit 2 */
+
+#define ADC_SMP12                               ((uint32_t)0x000001C0) /* SMP12[2:0] bits (Channel 12 Sample time selection) */
+#define ADC_SMP12_0                             ((uint32_t)0x00000040) /* Bit 0 */
+#define ADC_SMP12_1                             ((uint32_t)0x00000080) /* Bit 1 */
+#define ADC_SMP12_2                             ((uint32_t)0x00000100) /* Bit 2 */
+
+#define ADC_SMP13                               ((uint32_t)0x00000E00) /* SMP13[2:0] bits (Channel 13 Sample time selection) */
+#define ADC_SMP13_0                             ((uint32_t)0x00000200) /* Bit 0 */
+#define ADC_SMP13_1                             ((uint32_t)0x00000400) /* Bit 1 */
+#define ADC_SMP13_2                             ((uint32_t)0x00000800) /* Bit 2 */
+
+#define ADC_SMP14                               ((uint32_t)0x00007000) /* SMP14[2:0] bits (Channel 14 Sample time selection) */
+#define ADC_SMP14_0                             ((uint32_t)0x00001000) /* Bit 0 */
+#define ADC_SMP14_1                             ((uint32_t)0x00002000) /* Bit 1 */
+#define ADC_SMP14_2                             ((uint32_t)0x00004000) /* Bit 2 */
+
+#define ADC_SMP15                               ((uint32_t)0x00038000) /* SMP15[2:0] bits (Channel 15 Sample time selection) */
+#define ADC_SMP15_0                             ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SMP15_1                             ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SMP15_2                             ((uint32_t)0x00020000) /* Bit 2 */
+
+#define ADC_SMP16                               ((uint32_t)0x001C0000) /* SMP16[2:0] bits (Channel 16 Sample time selection) */
+#define ADC_SMP16_0                             ((uint32_t)0x00040000) /* Bit 0 */
+#define ADC_SMP16_1                             ((uint32_t)0x00080000) /* Bit 1 */
+#define ADC_SMP16_2                             ((uint32_t)0x00100000) /* Bit 2 */
+
+#define ADC_SMP17                               ((uint32_t)0x00E00000) /* SMP17[2:0] bits (Channel 17 Sample time selection) */
+#define ADC_SMP17_0                             ((uint32_t)0x00200000) /* Bit 0 */
+#define ADC_SMP17_1                             ((uint32_t)0x00400000) /* Bit 1 */
+#define ADC_SMP17_2                             ((uint32_t)0x00800000) /* Bit 2 */
+
+/******************  Bit definition for ADC_SAMPTR2 register  *******************/
+#define ADC_SMP0                                ((uint32_t)0x00000007) /* SMP0[2:0] bits (Channel 0 Sample time selection) */
+#define ADC_SMP0_0                              ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SMP0_1                              ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SMP0_2                              ((uint32_t)0x00000004) /* Bit 2 */
+
+#define ADC_SMP1                                ((uint32_t)0x00000038) /* SMP1[2:0] bits (Channel 1 Sample time selection) */
+#define ADC_SMP1_0                              ((uint32_t)0x00000008) /* Bit 0 */
+#define ADC_SMP1_1                              ((uint32_t)0x00000010) /* Bit 1 */
+#define ADC_SMP1_2                              ((uint32_t)0x00000020) /* Bit 2 */
+
+#define ADC_SMP2                                ((uint32_t)0x000001C0) /* SMP2[2:0] bits (Channel 2 Sample time selection) */
+#define ADC_SMP2_0                              ((uint32_t)0x00000040) /* Bit 0 */
+#define ADC_SMP2_1                              ((uint32_t)0x00000080) /* Bit 1 */
+#define ADC_SMP2_2                              ((uint32_t)0x00000100) /* Bit 2 */
+
+#define ADC_SMP3                                ((uint32_t)0x00000E00) /* SMP3[2:0] bits (Channel 3 Sample time selection) */
+#define ADC_SMP3_0                              ((uint32_t)0x00000200) /* Bit 0 */
+#define ADC_SMP3_1                              ((uint32_t)0x00000400) /* Bit 1 */
+#define ADC_SMP3_2                              ((uint32_t)0x00000800) /* Bit 2 */
+
+#define ADC_SMP4                                ((uint32_t)0x00007000) /* SMP4[2:0] bits (Channel 4 Sample time selection) */
+#define ADC_SMP4_0                              ((uint32_t)0x00001000) /* Bit 0 */
+#define ADC_SMP4_1                              ((uint32_t)0x00002000) /* Bit 1 */
+#define ADC_SMP4_2                              ((uint32_t)0x00004000) /* Bit 2 */
+
+#define ADC_SMP5                                ((uint32_t)0x00038000) /* SMP5[2:0] bits (Channel 5 Sample time selection) */
+#define ADC_SMP5_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SMP5_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SMP5_2                              ((uint32_t)0x00020000) /* Bit 2 */
+
+#define ADC_SMP6                                ((uint32_t)0x001C0000) /* SMP6[2:0] bits (Channel 6 Sample time selection) */
+#define ADC_SMP6_0                              ((uint32_t)0x00040000) /* Bit 0 */
+#define ADC_SMP6_1                              ((uint32_t)0x00080000) /* Bit 1 */
+#define ADC_SMP6_2                              ((uint32_t)0x00100000) /* Bit 2 */
+
+#define ADC_SMP7                                ((uint32_t)0x00E00000) /* SMP7[2:0] bits (Channel 7 Sample time selection) */
+#define ADC_SMP7_0                              ((uint32_t)0x00200000) /* Bit 0 */
+#define ADC_SMP7_1                              ((uint32_t)0x00400000) /* Bit 1 */
+#define ADC_SMP7_2                              ((uint32_t)0x00800000) /* Bit 2 */
+
+#define ADC_SMP8                                ((uint32_t)0x07000000) /* SMP8[2:0] bits (Channel 8 Sample time selection) */
+#define ADC_SMP8_0                              ((uint32_t)0x01000000) /* Bit 0 */
+#define ADC_SMP8_1                              ((uint32_t)0x02000000) /* Bit 1 */
+#define ADC_SMP8_2                              ((uint32_t)0x04000000) /* Bit 2 */
+
+#define ADC_SMP9                                ((uint32_t)0x38000000) /* SMP9[2:0] bits (Channel 9 Sample time selection) */
+#define ADC_SMP9_0                              ((uint32_t)0x08000000) /* Bit 0 */
+#define ADC_SMP9_1                              ((uint32_t)0x10000000) /* Bit 1 */
+#define ADC_SMP9_2                              ((uint32_t)0x20000000) /* Bit 2 */
+
+/******************  Bit definition for ADC_IOFR1 register  *******************/
+#define ADC_JOFFSET1                            ((uint16_t)0x0FFF) /* Data offset for injected channel 1 */
+
+/******************  Bit definition for ADC_IOFR2 register  *******************/
+#define ADC_JOFFSET2                            ((uint16_t)0x0FFF) /* Data offset for injected channel 2 */
+
+/******************  Bit definition for ADC_IOFR3 register  *******************/
+#define ADC_JOFFSET3                            ((uint16_t)0x0FFF) /* Data offset for injected channel 3 */
+
+/******************  Bit definition for ADC_IOFR4 register  *******************/
+#define ADC_JOFFSET4                            ((uint16_t)0x0FFF) /* Data offset for injected channel 4 */
+
+/*******************  Bit definition for ADC_WDHTR register  ********************/
+#define ADC_HT                                  ((uint16_t)0x0FFF) /* Analog watchdog high threshold */
+
+/*******************  Bit definition for ADC_WDLTR register  ********************/
+#define ADC_LT                                  ((uint16_t)0x0FFF) /* Analog watchdog low threshold */
+
+/*******************  Bit definition for ADC_RSQR1 register  *******************/
+#define ADC_SQ13                                ((uint32_t)0x0000001F) /* SQ13[4:0] bits (13th conversion in regular sequence) */
+#define ADC_SQ13_0                              ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SQ13_1                              ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SQ13_2                              ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_SQ13_3                              ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_SQ13_4                              ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_SQ14                                ((uint32_t)0x000003E0) /* SQ14[4:0] bits (14th conversion in regular sequence) */
+#define ADC_SQ14_0                              ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_SQ14_1                              ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_SQ14_2                              ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_SQ14_3                              ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_SQ14_4                              ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_SQ15                                ((uint32_t)0x00007C00) /* SQ15[4:0] bits (15th conversion in regular sequence) */
+#define ADC_SQ15_0                              ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_SQ15_1                              ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_SQ15_2                              ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_SQ15_3                              ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_SQ15_4                              ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_SQ16                                ((uint32_t)0x000F8000) /* SQ16[4:0] bits (16th conversion in regular sequence) */
+#define ADC_SQ16_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SQ16_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SQ16_2                              ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_SQ16_3                              ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_SQ16_4                              ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_L                                   ((uint32_t)0x00F00000) /* L[3:0] bits (Regular channel sequence length) */
+#define ADC_L_0                                 ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_L_1                                 ((uint32_t)0x00200000) /* Bit 1 */
+#define ADC_L_2                                 ((uint32_t)0x00400000) /* Bit 2 */
+#define ADC_L_3                                 ((uint32_t)0x00800000) /* Bit 3 */
+
+/*******************  Bit definition for ADC_RSQR2 register  *******************/
+#define ADC_SQ7                                 ((uint32_t)0x0000001F) /* SQ7[4:0] bits (7th conversion in regular sequence) */
+#define ADC_SQ7_0                               ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SQ7_1                               ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SQ7_2                               ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_SQ7_3                               ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_SQ7_4                               ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_SQ8                                 ((uint32_t)0x000003E0) /* SQ8[4:0] bits (8th conversion in regular sequence) */
+#define ADC_SQ8_0                               ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_SQ8_1                               ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_SQ8_2                               ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_SQ8_3                               ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_SQ8_4                               ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_SQ9                                 ((uint32_t)0x00007C00) /* SQ9[4:0] bits (9th conversion in regular sequence) */
+#define ADC_SQ9_0                               ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_SQ9_1                               ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_SQ9_2                               ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_SQ9_3                               ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_SQ9_4                               ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_SQ10                                ((uint32_t)0x000F8000) /* SQ10[4:0] bits (10th conversion in regular sequence) */
+#define ADC_SQ10_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SQ10_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SQ10_2                              ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_SQ10_3                              ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_SQ10_4                              ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_SQ11                                ((uint32_t)0x01F00000) /* SQ11[4:0] bits (11th conversion in regular sequence) */
+#define ADC_SQ11_0                              ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_SQ11_1                              ((uint32_t)0x00200000) /* Bit 1 */
+#define ADC_SQ11_2                              ((uint32_t)0x00400000) /* Bit 2 */
+#define ADC_SQ11_3                              ((uint32_t)0x00800000) /* Bit 3 */
+#define ADC_SQ11_4                              ((uint32_t)0x01000000) /* Bit 4 */
+
+#define ADC_SQ12                                ((uint32_t)0x3E000000) /* SQ12[4:0] bits (12th conversion in regular sequence) */
+#define ADC_SQ12_0                              ((uint32_t)0x02000000) /* Bit 0 */
+#define ADC_SQ12_1                              ((uint32_t)0x04000000) /* Bit 1 */
+#define ADC_SQ12_2                              ((uint32_t)0x08000000) /* Bit 2 */
+#define ADC_SQ12_3                              ((uint32_t)0x10000000) /* Bit 3 */
+#define ADC_SQ12_4                              ((uint32_t)0x20000000) /* Bit 4 */
+
+/*******************  Bit definition for ADC_RSQR3 register  *******************/
+#define ADC_SQ1                                 ((uint32_t)0x0000001F) /* SQ1[4:0] bits (1st conversion in regular sequence) */
+#define ADC_SQ1_0                               ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_SQ1_1                               ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_SQ1_2                               ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_SQ1_3                               ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_SQ1_4                               ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_SQ2                                 ((uint32_t)0x000003E0) /* SQ2[4:0] bits (2nd conversion in regular sequence) */
+#define ADC_SQ2_0                               ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_SQ2_1                               ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_SQ2_2                               ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_SQ2_3                               ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_SQ2_4                               ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_SQ3                                 ((uint32_t)0x00007C00) /* SQ3[4:0] bits (3rd conversion in regular sequence) */
+#define ADC_SQ3_0                               ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_SQ3_1                               ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_SQ3_2                               ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_SQ3_3                               ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_SQ3_4                               ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_SQ4                                 ((uint32_t)0x000F8000) /* SQ4[4:0] bits (4th conversion in regular sequence) */
+#define ADC_SQ4_0                               ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_SQ4_1                               ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_SQ4_2                               ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_SQ4_3                               ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_SQ4_4                               ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_SQ5                                 ((uint32_t)0x01F00000) /* SQ5[4:0] bits (5th conversion in regular sequence) */
+#define ADC_SQ5_0                               ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_SQ5_1                               ((uint32_t)0x00200000) /* Bit 1 */
+#define ADC_SQ5_2                               ((uint32_t)0x00400000) /* Bit 2 */
+#define ADC_SQ5_3                               ((uint32_t)0x00800000) /* Bit 3 */
+#define ADC_SQ5_4                               ((uint32_t)0x01000000) /* Bit 4 */
+
+#define ADC_SQ6                                 ((uint32_t)0x3E000000) /* SQ6[4:0] bits (6th conversion in regular sequence) */
+#define ADC_SQ6_0                               ((uint32_t)0x02000000) /* Bit 0 */
+#define ADC_SQ6_1                               ((uint32_t)0x04000000) /* Bit 1 */
+#define ADC_SQ6_2                               ((uint32_t)0x08000000) /* Bit 2 */
+#define ADC_SQ6_3                               ((uint32_t)0x10000000) /* Bit 3 */
+#define ADC_SQ6_4                               ((uint32_t)0x20000000) /* Bit 4 */
+
+/*******************  Bit definition for ADC_ISQR register  *******************/
+#define ADC_JSQ1                                ((uint32_t)0x0000001F) /* JSQ1[4:0] bits (1st conversion in injected sequence) */
+#define ADC_JSQ1_0                              ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_JSQ1_1                              ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_JSQ1_2                              ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_JSQ1_3                              ((uint32_t)0x00000008) /* Bit 3 */
+#define ADC_JSQ1_4                              ((uint32_t)0x00000010) /* Bit 4 */
+
+#define ADC_JSQ2                                ((uint32_t)0x000003E0) /* JSQ2[4:0] bits (2nd conversion in injected sequence) */
+#define ADC_JSQ2_0                              ((uint32_t)0x00000020) /* Bit 0 */
+#define ADC_JSQ2_1                              ((uint32_t)0x00000040) /* Bit 1 */
+#define ADC_JSQ2_2                              ((uint32_t)0x00000080) /* Bit 2 */
+#define ADC_JSQ2_3                              ((uint32_t)0x00000100) /* Bit 3 */
+#define ADC_JSQ2_4                              ((uint32_t)0x00000200) /* Bit 4 */
+
+#define ADC_JSQ3                                ((uint32_t)0x00007C00) /* JSQ3[4:0] bits (3rd conversion in injected sequence) */
+#define ADC_JSQ3_0                              ((uint32_t)0x00000400) /* Bit 0 */
+#define ADC_JSQ3_1                              ((uint32_t)0x00000800) /* Bit 1 */
+#define ADC_JSQ3_2                              ((uint32_t)0x00001000) /* Bit 2 */
+#define ADC_JSQ3_3                              ((uint32_t)0x00002000) /* Bit 3 */
+#define ADC_JSQ3_4                              ((uint32_t)0x00004000) /* Bit 4 */
+
+#define ADC_JSQ4                                ((uint32_t)0x000F8000) /* JSQ4[4:0] bits (4th conversion in injected sequence) */
+#define ADC_JSQ4_0                              ((uint32_t)0x00008000) /* Bit 0 */
+#define ADC_JSQ4_1                              ((uint32_t)0x00010000) /* Bit 1 */
+#define ADC_JSQ4_2                              ((uint32_t)0x00020000) /* Bit 2 */
+#define ADC_JSQ4_3                              ((uint32_t)0x00040000) /* Bit 3 */
+#define ADC_JSQ4_4                              ((uint32_t)0x00080000) /* Bit 4 */
+
+#define ADC_JL                                  ((uint32_t)0x00300000) /* JL[1:0] bits (Injected Sequence length) */
+#define ADC_JL_0                                ((uint32_t)0x00100000) /* Bit 0 */
+#define ADC_JL_1                                ((uint32_t)0x00200000) /* Bit 1 */
+
+/*******************  Bit definition for ADC_IDATAR1 register  *******************/
+#define ADC_IDATAR1_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/*******************  Bit definition for ADC_IDATAR2 register  *******************/
+#define ADC_IDATAR2_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/*******************  Bit definition for ADC_IDATAR3 register  *******************/
+#define ADC_IDATAR3_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/*******************  Bit definition for ADC_IDATAR4 register  *******************/
+#define ADC_IDATAR4_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+
+/********************  Bit definition for ADC_RDATAR register  ********************/
+#define ADC_RDATAR_DATA                         ((uint32_t)0x0000FFFF) /* Regular data */
+#define ADC_RDATAR_ADC2DATA                     ((uint32_t)0xFFFF0000) /* ADC2 data */
+
+
+/********************  Bit definition for ADC_CTLR3 register  ********************/
+#define ADC_CTLR3_CLK_DIV                       ((uint32_t)0x0000000F) /* CLK_DIVL[3:0] bits */
+#define ADC_CTLR3_CLK_DIV_0                     ((uint32_t)0x00000001) /* Bit 0 */
+#define ADC_CTLR3_CLK_DIV_1                     ((uint32_t)0x00000002) /* Bit 1 */
+#define ADC_CTLR3_CLK_DIV_2                     ((uint32_t)0x00000004) /* Bit 2 */
+#define ADC_CTLR3_CLK_DIV_3                     ((uint32_t)0x00000008) /* Bit 3 */
+
+#define ADC_CTLR3_AWD_SCAN                      ((uint32_t)0x00000200) /* Analog watchdog Scan enable */
+#define ADC_CTLR3_AWD0_RST_EN                   ((uint32_t)0x00001000) /* Watchdog0 Reset Enable */
+#define ADC_CTLR3_AWD1_RST_EN                   ((uint32_t)0x00002000) /* Watchdog1 Reset Enable */
+#define ADC_CTLR3_AWD2_RST_EN                   ((uint32_t)0x00004000) /* Watchdog2 Reset Enable */
+#define ADC_CTLR3_AWD3_RST_EN                   ((uint32_t)0x00008000) /* Watchdog3 Reset Enable */
+
+/********************  Bit definition for ADC_WDTR1 register  ********************/
+#define ADC_WDTR1_LTR1                          ((uint32_t)0x00000FFF) /* Analog watchdog1 low threshold */
+#define ADC_WDTR1_HTR1                          ((uint32_t)0x0FFF0000) /* Analog watchdog1 high threshold */
+
+/********************  Bit definition for ADC_WDTR2 register  ********************/
+#define ADC_WDTR2_LTR2                          ((uint32_t)0x00000FFF) /* Analog watchdog2 low threshold */
+#define ADC_WDTR2_HTR2                          ((uint32_t)0x0FFF0000) /* Analog watchdog2 high threshold */
+
+/********************  Bit definition for ADC_WDTR3 register  ********************/
+#define ADC_WDTR3_LTR3                          ((uint32_t)0x00000FFF) /* Analog watchdog3 low threshold */
+#define ADC_WDTR3_HTR3                          ((uint32_t)0x0FFF0000) /* Analog watchdog3 high threshold */
+
+/******************************************************************************/
+/*                             DMA Controller                                 */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_INTFR register  ********************/
+#define DMA_GIF1                                ((uint32_t)0x00000001) /* Channel 1 Global interrupt flag */
+#define DMA_TCIF1                               ((uint32_t)0x00000002) /* Channel 1 Transfer Complete flag */
+#define DMA_HTIF1                               ((uint32_t)0x00000004) /* Channel 1 Half Transfer flag */
+#define DMA_TEIF1                               ((uint32_t)0x00000008) /* Channel 1 Transfer Error flag */
+#define DMA_GIF2                                ((uint32_t)0x00000010) /* Channel 2 Global interrupt flag */
+#define DMA_TCIF2                               ((uint32_t)0x00000020) /* Channel 2 Transfer Complete flag */
+#define DMA_HTIF2                               ((uint32_t)0x00000040) /* Channel 2 Half Transfer flag */
+#define DMA_TEIF2                               ((uint32_t)0x00000080) /* Channel 2 Transfer Error flag */
+#define DMA_GIF3                                ((uint32_t)0x00000100) /* Channel 3 Global interrupt flag */
+#define DMA_TCIF3                               ((uint32_t)0x00000200) /* Channel 3 Transfer Complete flag */
+#define DMA_HTIF3                               ((uint32_t)0x00000400) /* Channel 3 Half Transfer flag */
+#define DMA_TEIF3                               ((uint32_t)0x00000800) /* Channel 3 Transfer Error flag */
+#define DMA_GIF4                                ((uint32_t)0x00001000) /* Channel 4 Global interrupt flag */
+#define DMA_TCIF4                               ((uint32_t)0x00002000) /* Channel 4 Transfer Complete flag */
+#define DMA_HTIF4                               ((uint32_t)0x00004000) /* Channel 4 Half Transfer flag */
+#define DMA_TEIF4                               ((uint32_t)0x00008000) /* Channel 4 Transfer Error flag */
+#define DMA_GIF5                                ((uint32_t)0x00010000) /* Channel 5 Global interrupt flag */
+#define DMA_TCIF5                               ((uint32_t)0x00020000) /* Channel 5 Transfer Complete flag */
+#define DMA_HTIF5                               ((uint32_t)0x00040000) /* Channel 5 Half Transfer flag */
+#define DMA_TEIF5                               ((uint32_t)0x00080000) /* Channel 5 Transfer Error flag */
+#define DMA_GIF6                                ((uint32_t)0x00100000) /* Channel 6 Global interrupt flag */
+#define DMA_TCIF6                               ((uint32_t)0x00200000) /* Channel 6 Transfer Complete flag */
+#define DMA_HTIF6                               ((uint32_t)0x00400000) /* Channel 6 Half Transfer flag */
+#define DMA_TEIF6                               ((uint32_t)0x00800000) /* Channel 6 Transfer Error flag */
+#define DMA_GIF7                                ((uint32_t)0x01000000) /* Channel 7 Global interrupt flag */
+#define DMA_TCIF7                               ((uint32_t)0x02000000) /* Channel 7 Transfer Complete flag */
+#define DMA_HTIF7                               ((uint32_t)0x04000000) /* Channel 7 Half Transfer flag */
+#define DMA_TEIF7                               ((uint32_t)0x08000000) /* Channel 7 Transfer Error flag */
+#define DMA_GIF8                                ((uint32_t)0x10000000) /* Channel 8 Global interrupt flag */
+#define DMA_TCIF8                               ((uint32_t)0x20000000) /* Channel 8 Transfer Complete flag */
+#define DMA_HTIF8                               ((uint32_t)0x40000000) /* Channel 8 Half Transfer flag */
+#define DMA_TEIF8                               ((uint32_t)0x80000000) /* Channel 8 Transfer Error flag */
+
+/*******************  Bit definition for DMA_INTFCR register  *******************/
+#define DMA_CGIF1                               ((uint32_t)0x00000001) /* Channel 1 Global interrupt clear */
+#define DMA_CTCIF1                              ((uint32_t)0x00000002) /* Channel 1 Transfer Complete clear */
+#define DMA_CHTIF1                              ((uint32_t)0x00000004) /* Channel 1 Half Transfer clear */
+#define DMA_CTEIF1                              ((uint32_t)0x00000008) /* Channel 1 Transfer Error clear */
+#define DMA_CGIF2                               ((uint32_t)0x00000010) /* Channel 2 Global interrupt clear */
+#define DMA_CTCIF2                              ((uint32_t)0x00000020) /* Channel 2 Transfer Complete clear */
+#define DMA_CHTIF2                              ((uint32_t)0x00000040) /* Channel 2 Half Transfer clear */
+#define DMA_CTEIF2                              ((uint32_t)0x00000080) /* Channel 2 Transfer Error clear */
+#define DMA_CGIF3                               ((uint32_t)0x00000100) /* Channel 3 Global interrupt clear */
+#define DMA_CTCIF3                              ((uint32_t)0x00000200) /* Channel 3 Transfer Complete clear */
+#define DMA_CHTIF3                              ((uint32_t)0x00000400) /* Channel 3 Half Transfer clear */
+#define DMA_CTEIF3                              ((uint32_t)0x00000800) /* Channel 3 Transfer Error clear */
+#define DMA_CGIF4                               ((uint32_t)0x00001000) /* Channel 4 Global interrupt clear */
+#define DMA_CTCIF4                              ((uint32_t)0x00002000) /* Channel 4 Transfer Complete clear */
+#define DMA_CHTIF4                              ((uint32_t)0x00004000) /* Channel 4 Half Transfer clear */
+#define DMA_CTEIF4                              ((uint32_t)0x00008000) /* Channel 4 Transfer Error clear */
+#define DMA_CGIF5                               ((uint32_t)0x00010000) /* Channel 5 Global interrupt clear */
+#define DMA_CTCIF5                              ((uint32_t)0x00020000) /* Channel 5 Transfer Complete clear */
+#define DMA_CHTIF5                              ((uint32_t)0x00040000) /* Channel 5 Half Transfer clear */
+#define DMA_CTEIF5                              ((uint32_t)0x00080000) /* Channel 5 Transfer Error clear */
+#define DMA_CGIF6                               ((uint32_t)0x00100000) /* Channel 6 Global interrupt clear */
+#define DMA_CTCIF6                              ((uint32_t)0x00200000) /* Channel 6 Transfer Complete clear */
+#define DMA_CHTIF6                              ((uint32_t)0x00400000) /* Channel 6 Half Transfer clear */
+#define DMA_CTEIF6                              ((uint32_t)0x00800000) /* Channel 6 Transfer Error clear */
+#define DMA_CGIF7                               ((uint32_t)0x01000000) /* Channel 7 Global interrupt clear */
+#define DMA_CTCIF7                              ((uint32_t)0x02000000) /* Channel 7 Transfer Complete clear */
+#define DMA_CHTIF7                              ((uint32_t)0x04000000) /* Channel 7 Half Transfer clear */
+#define DMA_CTEIF7                              ((uint32_t)0x08000000) /* Channel 7 Transfer Error clear */
+#define DMA_CGIF8                               ((uint32_t)0x10000000) /* Channel 8 Global interrupt clear */
+#define DMA_CTCIF8                              ((uint32_t)0x20000000) /* Channel 8 Transfer Complete clear */
+#define DMA_CHTIF8                              ((uint32_t)0x40000000) /* Channel 8 Half Transfer clear */
+#define DMA_CTEIF8                              ((uint32_t)0x80000000) /* Channel 8 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CFGR1 register  *******************/
+#define DMA_CFGR1_EN                            ((uint16_t)0x0001) /* Channel enable*/
+#define DMA_CFGR1_TCIE                          ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR1_HTIE                          ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR1_TEIE                          ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR1_DIR                           ((uint16_t)0x0010) /* Data transfer direction (Setting = Memory -> Peripheral) */
+#define DMA_CFGR1_CIRC                          ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR1_PINC                          ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR1_MINC                          ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR1_PSIZE                         ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR1_PSIZE_0                       ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR1_PSIZE_1                       ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR1_MSIZE                         ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR1_MSIZE_0                       ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR1_MSIZE_1                       ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR1_PL                            ((uint16_t)0x3000) /* PL[1:0] bits(Channel Priority level) */
+#define DMA_CFGR1_PL_0                          ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR1_PL_1                          ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR1_MEM2MEM                       ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFGR2 register  *******************/
+#define DMA_CFGR2_EN                            ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR2_TCIE                          ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR2_HTIE                          ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR2_TEIE                          ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR2_DIR                           ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR2_CIRC                          ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR2_PINC                          ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR2_MINC                          ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR2_PSIZE                         ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR2_PSIZE_0                       ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR2_PSIZE_1                       ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR2_MSIZE                         ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR2_MSIZE_0                       ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR2_MSIZE_1                       ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR2_PL                            ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR2_PL_0                          ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR2_PL_1                          ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR2_MEM2MEM                       ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFGR3 register  *******************/
+#define DMA_CFGR3_EN                            ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR3_TCIE                          ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR3_HTIE                          ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR3_TEIE                          ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR3_DIR                           ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR3_CIRC                          ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR3_PINC                          ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR3_MINC                          ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR3_PSIZE                         ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR3_PSIZE_0                       ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR3_PSIZE_1                       ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR3_MSIZE                         ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR3_MSIZE_0                       ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR3_MSIZE_1                       ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR3_PL                            ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR3_PL_0                          ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR3_PL_1                          ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR3_MEM2MEM                       ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFGR4 register  *******************/
+#define DMA_CFGR4_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR4_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR4_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR4_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR4_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR4_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR4_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR4_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR4_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR4_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR4_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR4_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR4_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR4_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR4_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR4_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR4_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR4_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode */
+
+/******************  Bit definition for DMA_CFGR5 register  *******************/
+#define DMA_CFGR5_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR5_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR5_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR5_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR5_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR5_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR5_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR5_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR5_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR5_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR5_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR5_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR5_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR5_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR5_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR5_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR5_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR5_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode enable */
+
+/*******************  Bit definition for DMA_CFGR6 register  *******************/
+#define DMA_CFGR6_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR6_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR6_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR6_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR6_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR6_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR6_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR6_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR6_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR6_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR6_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR6_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR6_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR6_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR6_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR6_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR6_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR6_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode */
+
+/*******************  Bit definition for DMA_CFGR7 register  *******************/
+#define DMA_CFGR7_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFGR7_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFGR7_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFGR7_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFGR7_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFGR7_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFGR7_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFGR7_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFGR7_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFGR7_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFGR7_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFGR7_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFGR7_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFGR7_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFGR7_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFGR7_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFGR7_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFGR7_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode enable */
+
+/*******************  Bit definition for DMA_CFG8 register  *******************/
+#define DMA_CFG8_EN                             ((uint16_t)0x0001) /* Channel enable */
+#define DMA_CFG8_TCIE                           ((uint16_t)0x0002) /* Transfer complete interrupt enable */
+#define DMA_CFG8_HTIE                           ((uint16_t)0x0004) /* Half Transfer interrupt enable */
+#define DMA_CFG8_TEIE                           ((uint16_t)0x0008) /* Transfer error interrupt enable */
+#define DMA_CFG8_DIR                            ((uint16_t)0x0010) /* Data transfer direction */
+#define DMA_CFG8_CIRC                           ((uint16_t)0x0020) /* Circular mode */
+#define DMA_CFG8_PINC                           ((uint16_t)0x0040) /* Peripheral increment mode */
+#define DMA_CFG8_MINC                           ((uint16_t)0x0080) /* Memory increment mode */
+
+#define DMA_CFG8_PSIZE                          ((uint16_t)0x0300) /* PSIZE[1:0] bits (Peripheral size) */
+#define DMA_CFG8_PSIZE_0                        ((uint16_t)0x0100) /* Bit 0 */
+#define DMA_CFG8_PSIZE_1                        ((uint16_t)0x0200) /* Bit 1 */
+
+#define DMA_CFG8_MSIZE                          ((uint16_t)0x0C00) /* MSIZE[1:0] bits (Memory size) */
+#define DMA_CFG8_MSIZE_0                        ((uint16_t)0x0400) /* Bit 0 */
+#define DMA_CFG8_MSIZE_1                        ((uint16_t)0x0800) /* Bit 1 */
+
+#define DMA_CFG8_PL                             ((uint16_t)0x3000) /* PL[1:0] bits (Channel Priority level) */
+#define DMA_CFG8_PL_0                           ((uint16_t)0x1000) /* Bit 0 */
+#define DMA_CFG8_PL_1                           ((uint16_t)0x2000) /* Bit 1 */
+
+#define DMA_CFG8_MEM2MEM                        ((uint16_t)0x4000) /* Memory to memory mode enable */
+
+/******************  Bit definition for DMA_CNTR1 register  ******************/
+#define DMA_CNTR1_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR2 register  ******************/
+#define DMA_CNTR2_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR3 register  ******************/
+#define DMA_CNTR3_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR4 register  ******************/
+#define DMA_CNTR4_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR5 register  ******************/
+#define DMA_CNTR5_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR6 register  ******************/
+#define DMA_CNTR6_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR7 register  ******************/
+#define DMA_CNTR7_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_CNTR8 register  ******************/
+#define DMA_CNTR8_NDT                           ((uint16_t)0xFFFF) /* Number of data to Transfer */
+
+/******************  Bit definition for DMA_PADDR1 register  *******************/
+#define DMA_PADDR1_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR2 register  *******************/
+#define DMA_PADDR2_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR3 register  *******************/
+#define DMA_PADDR3_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR4 register  *******************/
+#define DMA_PADDR4_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR5 register  *******************/
+#define DMA_PADDR5_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR6 register  *******************/
+#define DMA_PADDR6_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR7 register  *******************/
+#define DMA_PADDR7_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_PADDR8 register  *******************/
+#define DMA_PADDR8_PA                           ((uint32_t)0xFFFFFFFF) /* Peripheral Address */
+
+/******************  Bit definition for DMA_MADDR1 register  *******************/
+#define DMA_MADDR1_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR2 register  *******************/
+#define DMA_MADDR2_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR3 register  *******************/
+#define DMA_MADDR3_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR4 register  *******************/
+#define DMA_MADDR4_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR5 register  *******************/
+#define DMA_MADDR5_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR6 register  *******************/
+#define DMA_MADDR6_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR7 register  *******************/
+#define DMA_MADDR7_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************  Bit definition for DMA_MADDR8 register  *******************/
+#define DMA_MADDR8_MA                           ((uint32_t)0xFFFFFFFF) /* Memory Address */
+
+/******************************************************************************/
+/*                    External Interrupt/Event Controller                     */
+/******************************************************************************/
+
+/*******************  Bit definition for EXTI_INTENR register  *******************/
+#define EXTI_INTENR_MR0                         ((uint32_t)0x00000001) /* Interrupt Mask on line 0 */
+#define EXTI_INTENR_MR1                         ((uint32_t)0x00000002) /* Interrupt Mask on line 1 */
+#define EXTI_INTENR_MR2                         ((uint32_t)0x00000004) /* Interrupt Mask on line 2 */
+#define EXTI_INTENR_MR3                         ((uint32_t)0x00000008) /* Interrupt Mask on line 3 */
+#define EXTI_INTENR_MR4                         ((uint32_t)0x00000010) /* Interrupt Mask on line 4 */
+#define EXTI_INTENR_MR5                         ((uint32_t)0x00000020) /* Interrupt Mask on line 5 */
+#define EXTI_INTENR_MR6                         ((uint32_t)0x00000040) /* Interrupt Mask on line 6 */
+#define EXTI_INTENR_MR7                         ((uint32_t)0x00000080) /* Interrupt Mask on line 7 */
+#define EXTI_INTENR_MR8                         ((uint32_t)0x00000100) /* Interrupt Mask on line 8 */
+#define EXTI_INTENR_MR9                         ((uint32_t)0x00000200) /* Interrupt Mask on line 9 */
+#define EXTI_INTENR_MR10                        ((uint32_t)0x00000400) /* Interrupt Mask on line 10 */
+#define EXTI_INTENR_MR11                        ((uint32_t)0x00000800) /* Interrupt Mask on line 11 */
+#define EXTI_INTENR_MR12                        ((uint32_t)0x00001000) /* Interrupt Mask on line 12 */
+#define EXTI_INTENR_MR13                        ((uint32_t)0x00002000) /* Interrupt Mask on line 13 */
+#define EXTI_INTENR_MR14                        ((uint32_t)0x00004000) /* Interrupt Mask on line 14 */
+#define EXTI_INTENR_MR15                        ((uint32_t)0x00008000) /* Interrupt Mask on line 15 */
+#define EXTI_INTENR_MR16                        ((uint32_t)0x00010000) /* Interrupt Mask on line 16 */
+#define EXTI_INTENR_MR17                        ((uint32_t)0x00020000) /* Interrupt Mask on line 17 */
+#define EXTI_INTENR_MR18                        ((uint32_t)0x00040000) /* Interrupt Mask on line 18 */
+#define EXTI_INTENR_MR19                        ((uint32_t)0x00080000) /* Interrupt Mask on line 19 */
+#define EXTI_INTENR_MR20                        ((uint32_t)0x00100000) /* Interrupt Mask on line 20 */
+#define EXTI_INTENR_MR21                        ((uint32_t)0x00200000) /* Interrupt Mask on line 21 */
+#define EXTI_INTENR_MR22                        ((uint32_t)0x00400000) /* Interrupt Mask on line 22 */
+#define EXTI_INTENR_MR23                        ((uint32_t)0x00800000) /* Interrupt Mask on line 23 */
+#define EXTI_INTENR_MR24                        ((uint32_t)0x01000000) /* Interrupt Mask on line 24 */
+#define EXTI_INTENR_MR25                        ((uint32_t)0x02000000) /* Interrupt Mask on line 25 */
+#define EXTI_INTENR_MR26                        ((uint32_t)0x04000000) /* Interrupt Mask on line 26 */
+#define EXTI_INTENR_MR27                        ((uint32_t)0x08000000) /* Interrupt Mask on line 27 */
+#define EXTI_INTENR_MR28                        ((uint32_t)0x10000000) /* Interrupt Mask on line 28 */
+#define EXTI_INTENR_MR29                        ((uint32_t)0x20000000) /* Interrupt Mask on line 29 */
+
+/*******************  Bit definition for EXTI_EVENR register  *******************/
+#define EXTI_EVENR_MR0                          ((uint32_t)0x00000001) /* Event Mask on line 0 */
+#define EXTI_EVENR_MR1                          ((uint32_t)0x00000002) /* Event Mask on line 1 */
+#define EXTI_EVENR_MR2                          ((uint32_t)0x00000004) /* Event Mask on line 2 */
+#define EXTI_EVENR_MR3                          ((uint32_t)0x00000008) /* Event Mask on line 3 */
+#define EXTI_EVENR_MR4                          ((uint32_t)0x00000010) /* Event Mask on line 4 */
+#define EXTI_EVENR_MR5                          ((uint32_t)0x00000020) /* Event Mask on line 5 */
+#define EXTI_EVENR_MR6                          ((uint32_t)0x00000040) /* Event Mask on line 6 */
+#define EXTI_EVENR_MR7                          ((uint32_t)0x00000080) /* Event Mask on line 7 */
+#define EXTI_EVENR_MR8                          ((uint32_t)0x00000100) /* Event Mask on line 8 */
+#define EXTI_EVENR_MR9                          ((uint32_t)0x00000200) /* Event Mask on line 9 */
+#define EXTI_EVENR_MR10                         ((uint32_t)0x00000400) /* Event Mask on line 10 */
+#define EXTI_EVENR_MR11                         ((uint32_t)0x00000800) /* Event Mask on line 11 */
+#define EXTI_EVENR_MR12                         ((uint32_t)0x00001000) /* Event Mask on line 12 */
+#define EXTI_EVENR_MR13                         ((uint32_t)0x00002000) /* Event Mask on line 13 */
+#define EXTI_EVENR_MR14                         ((uint32_t)0x00004000) /* Event Mask on line 14 */
+#define EXTI_EVENR_MR15                         ((uint32_t)0x00008000) /* Event Mask on line 15 */
+#define EXTI_EVENR_MR16                         ((uint32_t)0x00010000) /* Event Mask on line 16 */
+#define EXTI_EVENR_MR17                         ((uint32_t)0x00020000) /* Event Mask on line 17 */
+#define EXTI_EVENR_MR18                         ((uint32_t)0x00040000) /* Event Mask on line 18 */
+#define EXTI_EVENR_MR19                         ((uint32_t)0x00080000) /* Event Mask on line 19 */
+#define EXTI_EVENR_MR20                         ((uint32_t)0x00100000) /* Event Mask on line 20 */
+#define EXTI_EVENR_MR21                         ((uint32_t)0x00200000) /* Event Mask on line 21 */
+#define EXTI_EVENR_MR22                         ((uint32_t)0x00400000) /* Event Mask on line 22 */
+#define EXTI_EVENR_MR23                         ((uint32_t)0x00800000) /* Event Mask on line 23 */
+#define EXTI_EVENR_MR24                         ((uint32_t)0x01000000) /* Event Mask on line 24 */
+#define EXTI_EVENR_MR25                         ((uint32_t)0x02000000) /* Event Mask on line 25 */
+#define EXTI_EVENR_MR26                         ((uint32_t)0x04000000) /* Event Mask on line 26 */
+#define EXTI_EVENR_MR27                         ((uint32_t)0x08000000) /* Event Mask on line 27 */
+#define EXTI_EVENR_MR28                         ((uint32_t)0x10000000) /* Event Mask on line 28 */
+#define EXTI_EVENR_MR29                         ((uint32_t)0x20000000) /* Event Mask on line 29 */
+
+/******************  Bit definition for EXTI_RTENR register  *******************/
+#define EXTI_RTENR_TR0                          ((uint32_t)0x00000001) /* Rising trigger event configuration bit of line 0 */
+#define EXTI_RTENR_TR1                          ((uint32_t)0x00000002) /* Rising trigger event configuration bit of line 1 */
+#define EXTI_RTENR_TR2                          ((uint32_t)0x00000004) /* Rising trigger event configuration bit of line 2 */
+#define EXTI_RTENR_TR3                          ((uint32_t)0x00000008) /* Rising trigger event configuration bit of line 3 */
+#define EXTI_RTENR_TR4                          ((uint32_t)0x00000010) /* Rising trigger event configuration bit of line 4 */
+#define EXTI_RTENR_TR5                          ((uint32_t)0x00000020) /* Rising trigger event configuration bit of line 5 */
+#define EXTI_RTENR_TR6                          ((uint32_t)0x00000040) /* Rising trigger event configuration bit of line 6 */
+#define EXTI_RTENR_TR7                          ((uint32_t)0x00000080) /* Rising trigger event configuration bit of line 7 */
+#define EXTI_RTENR_TR8                          ((uint32_t)0x00000100) /* Rising trigger event configuration bit of line 8 */
+#define EXTI_RTENR_TR9                          ((uint32_t)0x00000200) /* Rising trigger event configuration bit of line 9 */
+#define EXTI_RTENR_TR10                         ((uint32_t)0x00000400) /* Rising trigger event configuration bit of line 10 */
+#define EXTI_RTENR_TR11                         ((uint32_t)0x00000800) /* Rising trigger event configuration bit of line 11 */
+#define EXTI_RTENR_TR12                         ((uint32_t)0x00001000) /* Rising trigger event configuration bit of line 12 */
+#define EXTI_RTENR_TR13                         ((uint32_t)0x00002000) /* Rising trigger event configuration bit of line 13 */
+#define EXTI_RTENR_TR14                         ((uint32_t)0x00004000) /* Rising trigger event configuration bit of line 14 */
+#define EXTI_RTENR_TR15                         ((uint32_t)0x00008000) /* Rising trigger event configuration bit of line 15 */
+#define EXTI_RTENR_TR16                         ((uint32_t)0x00010000) /* Rising trigger event configuration bit of line 16 */
+#define EXTI_RTENR_TR17                         ((uint32_t)0x00020000) /* Rising trigger event configuration bit of line 17 */
+#define EXTI_RTENR_TR18                         ((uint32_t)0x00040000) /* Rising trigger event configuration bit of line 18 */
+#define EXTI_RTENR_TR19                         ((uint32_t)0x00080000) /* Rising trigger event configuration bit of line 19 */
+#define EXTI_RTENR_TR20                         ((uint32_t)0x00100000) /* Rising trigger event configuration bit of line 20 */
+#define EXTI_RTENR_TR21                         ((uint32_t)0x00200000) /* Rising trigger event configuration bit of line 21 */
+#define EXTI_RTENR_TR22                         ((uint32_t)0x00400000) /* Rising trigger event configuration bit of line 22 */
+#define EXTI_RTENR_TR23                         ((uint32_t)0x00800000) /* Rising trigger event configuration bit of line 23 */
+#define EXTI_RTENR_TR24                         ((uint32_t)0x01000000) /* Rising trigger event configuration bit of line 24 */
+#define EXTI_RTENR_TR25                         ((uint32_t)0x02000000) /* Rising trigger event configuration bit of line 25 */
+#define EXTI_RTENR_TR26                         ((uint32_t)0x04000000) /* Rising trigger event configuration bit of line 26 */
+#define EXTI_RTENR_TR27                         ((uint32_t)0x08000000) /* Rising trigger event configuration bit of line 27 */
+#define EXTI_RTENR_TR28                         ((uint32_t)0x10000000) /* Rising trigger event configuration bit of line 28 */
+#define EXTI_RTENR_TR29                         ((uint32_t)0x20000000) /* Rising trigger event configuration bit of line 29 */
+
+/******************  Bit definition for EXTI_FTENR register  *******************/
+#define EXTI_FTENR_TR0                          ((uint32_t)0x00000001) /* Falling trigger event configuration bit of line 0 */
+#define EXTI_FTENR_TR1                          ((uint32_t)0x00000002) /* Falling trigger event configuration bit of line 1 */
+#define EXTI_FTENR_TR2                          ((uint32_t)0x00000004) /* Falling trigger event configuration bit of line 2 */
+#define EXTI_FTENR_TR3                          ((uint32_t)0x00000008) /* Falling trigger event configuration bit of line 3 */
+#define EXTI_FTENR_TR4                          ((uint32_t)0x00000010) /* Falling trigger event configuration bit of line 4 */
+#define EXTI_FTENR_TR5                          ((uint32_t)0x00000020) /* Falling trigger event configuration bit of line 5 */
+#define EXTI_FTENR_TR6                          ((uint32_t)0x00000040) /* Falling trigger event configuration bit of line 6 */
+#define EXTI_FTENR_TR7                          ((uint32_t)0x00000080) /* Falling trigger event configuration bit of line 7 */
+#define EXTI_FTENR_TR8                          ((uint32_t)0x00000100) /* Falling trigger event configuration bit of line 8 */
+#define EXTI_FTENR_TR9                          ((uint32_t)0x00000200) /* Falling trigger event configuration bit of line 9 */
+#define EXTI_FTENR_TR10                         ((uint32_t)0x00000400) /* Falling trigger event configuration bit of line 10 */
+#define EXTI_FTENR_TR11                         ((uint32_t)0x00000800) /* Falling trigger event configuration bit of line 11 */
+#define EXTI_FTENR_TR12                         ((uint32_t)0x00001000) /* Falling trigger event configuration bit of line 12 */
+#define EXTI_FTENR_TR13                         ((uint32_t)0x00002000) /* Falling trigger event configuration bit of line 13 */
+#define EXTI_FTENR_TR14                         ((uint32_t)0x00004000) /* Falling trigger event configuration bit of line 14 */
+#define EXTI_FTENR_TR15                         ((uint32_t)0x00008000) /* Falling trigger event configuration bit of line 15 */
+#define EXTI_FTENR_TR16                         ((uint32_t)0x00010000) /* Falling trigger event configuration bit of line 16 */
+#define EXTI_FTENR_TR17                         ((uint32_t)0x00020000) /* Falling trigger event configuration bit of line 17 */
+#define EXTI_FTENR_TR18                         ((uint32_t)0x00040000) /* Falling trigger event configuration bit of line 18 */
+#define EXTI_FTENR_TR19                         ((uint32_t)0x00080000) /* Falling trigger event configuration bit of line 19 */
+#define EXTI_FTENR_TR20                         ((uint32_t)0x00100000) /* Falling trigger event configuration bit of line 20 */
+#define EXTI_FTENR_TR21                         ((uint32_t)0x00200000) /* Falling trigger event configuration bit of line 21 */
+#define EXTI_FTENR_TR22                         ((uint32_t)0x00400000) /* Falling trigger event configuration bit of line 22 */
+#define EXTI_FTENR_TR23                         ((uint32_t)0x00800000) /* Falling trigger event configuration bit of line 23 */
+#define EXTI_FTENR_TR24                         ((uint32_t)0x01000000) /* Falling trigger event configuration bit of line 24 */
+#define EXTI_FTENR_TR25                         ((uint32_t)0x02000000) /* Falling trigger event configuration bit of line 25 */
+#define EXTI_FTENR_TR26                         ((uint32_t)0x04000000) /* Falling trigger event configuration bit of line 26 */
+#define EXTI_FTENR_TR27                         ((uint32_t)0x08000000) /* Falling trigger event configuration bit of line 27 */
+#define EXTI_FTENR_TR28                         ((uint32_t)0x10000000) /* Falling trigger event configuration bit of line 28 */
+#define EXTI_FTENR_TR29                         ((uint32_t)0x20000000) /* Falling trigger event configuration bit of line 29 */
+
+/******************  Bit definition for EXTI_SWIEVR register  ******************/
+#define EXTI_SWIEVR_SWIEVR0                     ((uint32_t)0x00000001) /* Software Interrupt on line 0 */
+#define EXTI_SWIEVR_SWIEVR1                     ((uint32_t)0x00000002) /* Software Interrupt on line 1 */
+#define EXTI_SWIEVR_SWIEVR2                     ((uint32_t)0x00000004) /* Software Interrupt on line 2 */
+#define EXTI_SWIEVR_SWIEVR3                     ((uint32_t)0x00000008) /* Software Interrupt on line 3 */
+#define EXTI_SWIEVR_SWIEVR4                     ((uint32_t)0x00000010) /* Software Interrupt on line 4 */
+#define EXTI_SWIEVR_SWIEVR5                     ((uint32_t)0x00000020) /* Software Interrupt on line 5 */
+#define EXTI_SWIEVR_SWIEVR6                     ((uint32_t)0x00000040) /* Software Interrupt on line 6 */
+#define EXTI_SWIEVR_SWIEVR7                     ((uint32_t)0x00000080) /* Software Interrupt on line 7 */
+#define EXTI_SWIEVR_SWIEVR8                     ((uint32_t)0x00000100) /* Software Interrupt on line 8 */
+#define EXTI_SWIEVR_SWIEVR9                     ((uint32_t)0x00000200) /* Software Interrupt on line 9 */
+#define EXTI_SWIEVR_SWIEVR10                    ((uint32_t)0x00000400) /* Software Interrupt on line 10 */
+#define EXTI_SWIEVR_SWIEVR11                    ((uint32_t)0x00000800) /* Software Interrupt on line 11 */
+#define EXTI_SWIEVR_SWIEVR12                    ((uint32_t)0x00001000) /* Software Interrupt on line 12 */
+#define EXTI_SWIEVR_SWIEVR13                    ((uint32_t)0x00002000) /* Software Interrupt on line 13 */
+#define EXTI_SWIEVR_SWIEVR14                    ((uint32_t)0x00004000) /* Software Interrupt on line 14 */
+#define EXTI_SWIEVR_SWIEVR15                    ((uint32_t)0x00008000) /* Software Interrupt on line 15 */
+#define EXTI_SWIEVR_SWIEVR16                    ((uint32_t)0x00010000) /* Software Interrupt on line 16 */
+#define EXTI_SWIEVR_SWIEVR17                    ((uint32_t)0x00020000) /* Software Interrupt on line 17 */
+#define EXTI_SWIEVR_SWIEVR18                    ((uint32_t)0x00040000) /* Software Interrupt on line 18 */
+#define EXTI_SWIEVR_SWIEVR19                    ((uint32_t)0x00080000) /* Software Interrupt on line 19 */
+#define EXTI_SWIEVR_SWIEVR20                    ((uint32_t)0x00100000) /* Software Interrupt on line 20 */
+#define EXTI_SWIEVR_SWIEVR21                    ((uint32_t)0x00200000) /* Software Interrupt on line 21 */
+#define EXTI_SWIEVR_SWIEVR22                    ((uint32_t)0x00400000) /* Software Interrupt on line 22 */
+#define EXTI_SWIEVR_SWIEVR23                    ((uint32_t)0x00800000) /* Software Interrupt on line 23 */
+#define EXTI_SWIEVR_SWIEVR24                    ((uint32_t)0x01000000) /* Software Interrupt on line 24 */
+#define EXTI_SWIEVR_SWIEVR25                    ((uint32_t)0x02000000) /* Software Interrupt on line 25 */
+#define EXTI_SWIEVR_SWIEVR26                    ((uint32_t)0x04000000) /* Software Interrupt on line 26 */
+#define EXTI_SWIEVR_SWIEVR27                    ((uint32_t)0x08000000) /* Software Interrupt on line 27 */
+#define EXTI_SWIEVR_SWIEVR28                    ((uint32_t)0x10000000) /* Software Interrupt on line 28 */
+#define EXTI_SWIEVR_SWIEVR29                    ((uint32_t)0x20000000) /* Software Interrupt on line 29 */
+
+/*******************  Bit definition for EXTI_INTFR register  ********************/
+#define EXTI_INTF_INTF0                         ((uint32_t)0x00000001) /* Pending bit for line 0 */
+#define EXTI_INTF_INTF1                         ((uint32_t)0x00000002) /* Pending bit for line 1 */
+#define EXTI_INTF_INTF2                         ((uint32_t)0x00000004) /* Pending bit for line 2 */
+#define EXTI_INTF_INTF3                         ((uint32_t)0x00000008) /* Pending bit for line 3 */
+#define EXTI_INTF_INTF4                         ((uint32_t)0x00000010) /* Pending bit for line 4 */
+#define EXTI_INTF_INTF5                         ((uint32_t)0x00000020) /* Pending bit for line 5 */
+#define EXTI_INTF_INTF6                         ((uint32_t)0x00000040) /* Pending bit for line 6 */
+#define EXTI_INTF_INTF7                         ((uint32_t)0x00000080) /* Pending bit for line 7 */
+#define EXTI_INTF_INTF8                         ((uint32_t)0x00000100) /* Pending bit for line 8 */
+#define EXTI_INTF_INTF9                         ((uint32_t)0x00000200) /* Pending bit for line 9 */
+#define EXTI_INTF_INTF10                        ((uint32_t)0x00000400) /* Pending bit for line 10 */
+#define EXTI_INTF_INTF11                        ((uint32_t)0x00000800) /* Pending bit for line 11 */
+#define EXTI_INTF_INTF12                        ((uint32_t)0x00001000) /* Pending bit for line 12 */
+#define EXTI_INTF_INTF13                        ((uint32_t)0x00002000) /* Pending bit for line 13 */
+#define EXTI_INTF_INTF14                        ((uint32_t)0x00004000) /* Pending bit for line 14 */
+#define EXTI_INTF_INTF15                        ((uint32_t)0x00008000) /* Pending bit for line 15 */
+#define EXTI_INTF_INTF16                        ((uint32_t)0x00010000) /* Pending bit for line 16 */
+#define EXTI_INTF_INTF17                        ((uint32_t)0x00020000) /* Pending bit for line 17 */
+#define EXTI_INTF_INTF18                        ((uint32_t)0x00040000) /* Pending bit for line 18 */
+#define EXTI_INTF_INTF19                        ((uint32_t)0x00080000) /* Pending bit for line 19 */
+#define EXTI_INTF_INTF20                        ((uint32_t)0x00100000) /* Pending bit for line 20 */
+#define EXTI_INTF_INTF21                        ((uint32_t)0x00200000) /* Pending bit for line 21 */
+#define EXTI_INTF_INTF22                        ((uint32_t)0x00400000) /* Pending bit for line 22 */
+#define EXTI_INTF_INTF23                        ((uint32_t)0x00800000) /* Pending bit for line 23 */
+#define EXTI_INTF_INTF24                        ((uint32_t)0x01000000) /* Pending bit for line 24 */
+#define EXTI_INTF_INTF25                        ((uint32_t)0x02000000) /* Pending bit for line 25 */
+#define EXTI_INTF_INTF26                        ((uint32_t)0x04000000) /* Pending bit for line 26 */
+#define EXTI_INTF_INTF27                        ((uint32_t)0x08000000) /* Pending bit for line 27 */
+#define EXTI_INTF_INTF28                        ((uint32_t)0x10000000) /* Pending bit for line 28 */
+#define EXTI_INTF_INTF29                        ((uint32_t)0x20000000) /* Pending bit for line 29 */
+
+/******************************************************************************/
+/*                      FLASH and Option Bytes Registers                      */
+/******************************************************************************/
+
+/*******************  Bit definition for FLASH_ACTLR register  ******************/
+#define FLASH_ACTLR_LATENCY                     ((uint8_t)0x03) /* LATENCY[2:0] bits (Latency) */
+#define FLASH_ACTLR_LATENCY_0                   ((uint8_t)0x00) /* Bit 0 */
+#define FLASH_ACTLR_LATENCY_1                   ((uint8_t)0x01) /* Bit 0 */
+#define FLASH_ACTLR_LATENCY_2                   ((uint8_t)0x02) /* Bit 1 */
+#define FLASH_ACTLR_LATENCY_3                   ((uint8_t)0x03) /* required for SYSCLK > 48 MHz (RM 19.3.1) */
+
+
+/******************  Bit definition for FLASH_KEYR register  ******************/
+#define FLASH_KEYR_FKEYR                        ((uint32_t)0xFFFFFFFF) /* FPEC Key */
+
+/*****************  Bit definition for FLASH_OBKEYR register  ****************/
+#define FLASH_OBKEYR_OBKEYR                     ((uint32_t)0xFFFFFFFF) /* Option Byte Key */
+
+/******************  Bit definition for FLASH_STATR register  *******************/
+#define FLASH_STATR_BSY                         ((uint8_t)0x01) /* Busy */
+#define FLASH_STATR_WRPRTERR                    ((uint8_t)0x10) /* Write Protection Error */
+#define FLASH_STATR_EOP                         ((uint8_t)0x20) /* End of operation */
+#define FLASH_STATR_FWAKE_FLAG                  ((uint8_t)0x40) /* Flag of wake */
+#define FLASH_STATR_TURBO                       ((uint8_t)0x80) /* The state of TURBO Enable */
+#define FLASH_STATR_BOOT_AVA                    ((uint16_t)0x1000) /* The state of Init Config */
+#define FLASH_STATR_BOOT_STATUS                 ((uint16_t)0x2000) /* The source of Execute Program */
+#define FLASH_STATR_BOOT_MODE                   ((uint16_t)0x4000) /* The switch of user section or boot section*/
+#define FLASH_STATR_BOOT_LOCK                   ((uint16_t)0x8000) /* Lock boot area*/
+
+/*******************  Bit definition for FLASH_CTLR register  *******************/
+#define FLASH_CTLR_PG                           (0x0001)     /* Programming */
+#define FLASH_CTLR_PER                          (0x0002)     /* Page Erase 1KByte*/
+#define FLASH_CTLR_MER                          (0x0004)     /* Mass Erase */
+#define FLASH_CTLR_OPTPG                        (0x0010)     /* Option Byte Programming */
+#define FLASH_CTLR_OPTER                        (0x0020)     /* Option Byte Erase */
+#define FLASH_CTLR_STRT                         (0x0040)     /* Start */
+#define FLASH_CTLR_LOCK                         (0x0080)     /* Lock */
+#define FLASH_CTLR_OPTWRE                       (0x0200)     /* Option Bytes Write Enable */
+#define FLASH_CTLR_ERRIE                        (0x0400)     /* Error Interrupt Enable */
+#define FLASH_CTLR_EOPIE                        (0x1000)     /* End of operation interrupt enable */
+#define FLASH_CTLR_FWAKEIE                      ((uint32_t)0x00002000) /* Wake inter Enable */
+#define FLASH_CTLR_FLOCK                        ((uint32_t)0x00008000) /* Fast Lock */
+#define FLASH_CTLR_FTPG                         ((uint32_t)0x00010000) /* Fast Program */
+#define FLASH_CTLR_FTER                         ((uint32_t)0x00020000) /* Fast Erase */
+#define FLASH_CTLR_BUFLOAD                      ((uint32_t)0x00040000) /* BUF Load */
+#define FLASH_CTLR_BUFRST                       ((uint32_t)0x00080000) /* BUF Reset */
+#define FLASH_CTLR_BER32                        ((uint32_t)0x00800000) /* Block Erase 32K */
+
+#define FLASH_CTLR_PAGE_PG                      FLASH_CTLR_FTPG /* Page Programming 64Byte */
+#define FLASH_CTLR_PAGE_ER                      FLASH_CTLR_FTER /* Page Erase 64Byte */
+
+/*******************  Bit definition for FLASH_ADDR register  *******************/
+#define FLASH_ADDR_FAR                          ((uint32_t)0xFFFFFFFF) /* Flash Address */
+
+/******************  Bit definition for FLASH_OBR register  *******************/
+#define FLASH_OBR_OPTERR                        ((uint16_t)0x0001) /* Option Byte Error */
+#define FLASH_OBR_RDPRT                         ((uint16_t)0x0002) /* Read protection */
+
+#define FLASH_OBR_USER                          ((uint16_t)0x03FC) /* User Option Bytes */
+#define FLASH_OBR_WDG_SW                        ((uint16_t)0x0004) /* WDG_SW */
+#define FLASH_OBR_nRST_STOP                     ((uint16_t)0x0008) /* nRST_STOP */
+#define FLASH_OBR_nRST_STDBY                    ((uint16_t)0x0010) /* nRST_STDBY */
+#define FLASH_OBR_RST_MODE                      ((uint16_t)0x0060) /* RST_MODE */
+#define FLASH_OBR_CFGRSTT                       FLASH_OBR_RST_MODE /* Config Reset delay time */
+
+#define FLASH_OBR_FIX_11                        ((uint16_t)0x0300) /* fix 11 */
+#define FLASH_OBR_DATA0                         ((uint32_t)0x0003FC00) /* Data byte0 */
+#define FLASH_OBR_DATA1                         ((uint32_t)0x03FC0000) /* Data byte1 */
+
+/******************  Bit definition for FLASH_WPR register  ******************/
+#define FLASH_WPR_WRP                           ((uint32_t)0xFFFFFFFF) /* Write Protect */
+
+/******************  Bit definition for FLASH_MODEKEYR register  ******************/
+#define FLASH_MODEKEYR_MODEKEYR                 ((uint32_t)0xFFFFFFFF) /* Open fast program /erase */
+#define FLASH_MODEKEYR_MODEKEYR1                ((uint32_t)0x45670123) 
+#define FLASH_MODEKEYR_MODEKEYR2                ((uint32_t)0xCDEF89AB) 
+
+/******************  Bit definition for BOOT_MODEKEYP register  ******************/
+#define BOOT_MODEKEYP_MODEKEYR                  ((uint32_t)0xFFFFFFFF) /* Open Boot section */
+#define BOOT_MODEKEYP_MODEKEYR1                 ((uint32_t)0x45670123)
+#define BOOT_MODEKEYP_MODEKEYR2                 ((uint32_t)0xCDEF89AB)
+
+/******************  Bit definition for FLASH_RDPR register  *******************/
+#define FLASH_RDPR_RDPR                         ((uint32_t)0x000000FF) /* Read protection option byte */
+#define FLASH_RDPR_nRDPR                        ((uint32_t)0x0000FF00) /* Read protection complemented option byte */
+
+/******************  Bit definition for FLASH_USER register  ******************/
+#define FLASH_USER_USER                         ((uint32_t)0x00FF0000) /* User option byte */
+#define FLASH_USER_nUSER                        ((uint32_t)0xFF000000) /* User complemented option byte */
+
+/******************  Bit definition for FLASH_Data0 register  *****************/
+#define FLASH_Data0_Data0                       ((uint32_t)0x000000FF) /* User data storage option byte */
+#define FLASH_Data0_nData0                      ((uint32_t)0x0000FF00) /* User data storage complemented option byte */
+
+/******************  Bit definition for FLASH_Data1 register  *****************/
+#define FLASH_Data1_Data1                       ((uint32_t)0x00FF0000) /* User data storage option byte */
+#define FLASH_Data1_nData1                      ((uint32_t)0xFF000000) /* User data storage complemented option byte */
+
+/******************  Bit definition for FLASH_WRPR0 register  ******************/
+#define FLASH_WRPR0_WRPR0                       ((uint32_t)0x000000FF) /* Flash memory write protection option bytes */
+#define FLASH_WRPR0_nWRPR0                      ((uint32_t)0x0000FF00) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR1 register  ******************/
+#define FLASH_WRPR1_WRPR1                       ((uint32_t)0x00FF0000) /* Flash memory write protection option bytes */
+#define FLASH_WRPR1_nWRPR1                      ((uint32_t)0xFF000000) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR2 register  ******************/
+#define FLASH_WRPR2_WRPR2                       ((uint32_t)0x000000FF) /* Flash memory write protection option bytes */
+#define FLASH_WRPR2_nWRPR2                      ((uint32_t)0x0000FF00) /* Flash memory write protection complemented option bytes */
+
+/******************  Bit definition for FLASH_WRPR3 register  ******************/
+#define FLASH_WRPR3_WRPR3                       ((uint32_t)0x00FF0000) /* Flash memory write protection option bytes */
+#define FLASH_WRPR3_nWRPR3                      ((uint32_t)0xFF000000) /* Flash memory write protection complemented option bytes */
+
+/******************************************************************************/
+/*                General Purpose and Alternate Function I/O                  */
+/******************************************************************************/
+
+/*******************  Bit definition for GPIO_CFGLR register  *******************/
+#define GPIO_CFGLR_MODE                         ((uint32_t)0x33333333) /* Port x mode bits */
+
+#define GPIO_CFGLR_MODE0                        ((uint32_t)0x00000003) /* MODE0[1:0] bits (Port x mode bits, pin 0) */
+#define GPIO_CFGLR_MODE0_0                      ((uint32_t)0x00000001) /* Bit 0 */
+#define GPIO_CFGLR_MODE0_1                      ((uint32_t)0x00000002) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE1                        ((uint32_t)0x00000030) /* MODE1[1:0] bits (Port x mode bits, pin 1) */
+#define GPIO_CFGLR_MODE1_0                      ((uint32_t)0x00000010) /* Bit 0 */
+#define GPIO_CFGLR_MODE1_1                      ((uint32_t)0x00000020) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE2                        ((uint32_t)0x00000300) /* MODE2[1:0] bits (Port x mode bits, pin 2) */
+#define GPIO_CFGLR_MODE2_0                      ((uint32_t)0x00000100) /* Bit 0 */
+#define GPIO_CFGLR_MODE2_1                      ((uint32_t)0x00000200) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE3                        ((uint32_t)0x00003000) /* MODE3[1:0] bits (Port x mode bits, pin 3) */
+#define GPIO_CFGLR_MODE3_0                      ((uint32_t)0x00001000) /* Bit 0 */
+#define GPIO_CFGLR_MODE3_1                      ((uint32_t)0x00002000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE4                        ((uint32_t)0x00030000) /* MODE4[1:0] bits (Port x mode bits, pin 4) */
+#define GPIO_CFGLR_MODE4_0                      ((uint32_t)0x00010000) /* Bit 0 */
+#define GPIO_CFGLR_MODE4_1                      ((uint32_t)0x00020000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE5                        ((uint32_t)0x00300000) /* MODE5[1:0] bits (Port x mode bits, pin 5) */
+#define GPIO_CFGLR_MODE5_0                      ((uint32_t)0x00100000) /* Bit 0 */
+#define GPIO_CFGLR_MODE5_1                      ((uint32_t)0x00200000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE6                        ((uint32_t)0x03000000) /* MODE6[1:0] bits (Port x mode bits, pin 6) */
+#define GPIO_CFGLR_MODE6_0                      ((uint32_t)0x01000000) /* Bit 0 */
+#define GPIO_CFGLR_MODE6_1                      ((uint32_t)0x02000000) /* Bit 1 */
+
+#define GPIO_CFGLR_MODE7                        ((uint32_t)0x30000000) /* MODE7[1:0] bits (Port x mode bits, pin 7) */
+#define GPIO_CFGLR_MODE7_0                      ((uint32_t)0x10000000) /* Bit 0 */
+#define GPIO_CFGLR_MODE7_1                      ((uint32_t)0x20000000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF                          ((uint32_t)0xCCCCCCCC) /* Port x configuration bits */
+
+#define GPIO_CFGLR_CNF0                         ((uint32_t)0x0000000C) /* CNF0[1:0] bits (Port x configuration bits, pin 0) */
+#define GPIO_CFGLR_CNF0_0                       ((uint32_t)0x00000004) /* Bit 0 */
+#define GPIO_CFGLR_CNF0_1                       ((uint32_t)0x00000008) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF1                         ((uint32_t)0x000000C0) /* CNF1[1:0] bits (Port x configuration bits, pin 1) */
+#define GPIO_CFGLR_CNF1_0                       ((uint32_t)0x00000040) /* Bit 0 */
+#define GPIO_CFGLR_CNF1_1                       ((uint32_t)0x00000080) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF2                         ((uint32_t)0x00000C00) /* CNF2[1:0] bits (Port x configuration bits, pin 2) */
+#define GPIO_CFGLR_CNF2_0                       ((uint32_t)0x00000400) /* Bit 0 */
+#define GPIO_CFGLR_CNF2_1                       ((uint32_t)0x00000800) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF3                         ((uint32_t)0x0000C000) /* CNF3[1:0] bits (Port x configuration bits, pin 3) */
+#define GPIO_CFGLR_CNF3_0                       ((uint32_t)0x00004000) /* Bit 0 */
+#define GPIO_CFGLR_CNF3_1                       ((uint32_t)0x00008000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF4                         ((uint32_t)0x000C0000) /* CNF4[1:0] bits (Port x configuration bits, pin 4) */
+#define GPIO_CFGLR_CNF4_0                       ((uint32_t)0x00040000) /* Bit 0 */
+#define GPIO_CFGLR_CNF4_1                       ((uint32_t)0x00080000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF5                         ((uint32_t)0x00C00000) /* CNF5[1:0] bits (Port x configuration bits, pin 5) */
+#define GPIO_CFGLR_CNF5_0                       ((uint32_t)0x00400000) /* Bit 0 */
+#define GPIO_CFGLR_CNF5_1                       ((uint32_t)0x00800000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF6                         ((uint32_t)0x0C000000) /* CNF6[1:0] bits (Port x configuration bits, pin 6) */
+#define GPIO_CFGLR_CNF6_0                       ((uint32_t)0x04000000) /* Bit 0 */
+#define GPIO_CFGLR_CNF6_1                       ((uint32_t)0x08000000) /* Bit 1 */
+
+#define GPIO_CFGLR_CNF7                         ((uint32_t)0xC0000000) /* CNF7[1:0] bits (Port x configuration bits, pin 7) */
+#define GPIO_CFGLR_CNF7_0                       ((uint32_t)0x40000000) /* Bit 0 */
+#define GPIO_CFGLR_CNF7_1                       ((uint32_t)0x80000000) /* Bit 1 */
+
+/*******************  Bit definition for GPIO_CFGHR register  *******************/
+#define GPIO_CFGHR_MODE                         ((uint32_t)0x33333333) /* Port x mode bits */
+
+#define GPIO_CFGHR_MODE8                        ((uint32_t)0x00000003) /* MODE8[1:0] bits (Port x mode bits, pin 8) */
+#define GPIO_CFGHR_MODE8_0                      ((uint32_t)0x00000001) /* Bit 0 */
+#define GPIO_CFGHR_MODE8_1                      ((uint32_t)0x00000002) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE9                        ((uint32_t)0x00000030) /* MODE9[1:0] bits (Port x mode bits, pin 9) */
+#define GPIO_CFGHR_MODE9_0                      ((uint32_t)0x00000010) /* Bit 0 */
+#define GPIO_CFGHR_MODE9_1                      ((uint32_t)0x00000020) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE10                       ((uint32_t)0x00000300) /* MODE10[1:0] bits (Port x mode bits, pin 10) */
+#define GPIO_CFGHR_MODE10_0                     ((uint32_t)0x00000100) /* Bit 0 */
+#define GPIO_CFGHR_MODE10_1                     ((uint32_t)0x00000200) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE11                       ((uint32_t)0x00003000) /* MODE11[1:0] bits (Port x mode bits, pin 11) */
+#define GPIO_CFGHR_MODE11_0                     ((uint32_t)0x00001000) /* Bit 0 */
+#define GPIO_CFGHR_MODE11_1                     ((uint32_t)0x00002000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE12                       ((uint32_t)0x00030000) /* MODE12[1:0] bits (Port x mode bits, pin 12) */
+#define GPIO_CFGHR_MODE12_0                     ((uint32_t)0x00010000) /* Bit 0 */
+#define GPIO_CFGHR_MODE12_1                     ((uint32_t)0x00020000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE13                       ((uint32_t)0x00300000) /* MODE13[1:0] bits (Port x mode bits, pin 13) */
+#define GPIO_CFGHR_MODE13_0                     ((uint32_t)0x00100000) /* Bit 0 */
+#define GPIO_CFGHR_MODE13_1                     ((uint32_t)0x00200000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE14                       ((uint32_t)0x03000000) /* MODE14[1:0] bits (Port x mode bits, pin 14) */
+#define GPIO_CFGHR_MODE14_0                     ((uint32_t)0x01000000) /* Bit 0 */
+#define GPIO_CFGHR_MODE14_1                     ((uint32_t)0x02000000) /* Bit 1 */
+
+#define GPIO_CFGHR_MODE15                       ((uint32_t)0x30000000) /* MODE15[1:0] bits (Port x mode bits, pin 15) */
+#define GPIO_CFGHR_MODE15_0                     ((uint32_t)0x10000000) /* Bit 0 */
+#define GPIO_CFGHR_MODE15_1                     ((uint32_t)0x20000000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF                          ((uint32_t)0xCCCCCCCC) /* Port x configuration bits */
+
+#define GPIO_CFGHR_CNF8                         ((uint32_t)0x0000000C) /* CNF8[1:0] bits (Port x configuration bits, pin 8) */
+#define GPIO_CFGHR_CNF8_0                       ((uint32_t)0x00000004) /* Bit 0 */
+#define GPIO_CFGHR_CNF8_1                       ((uint32_t)0x00000008) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF9                         ((uint32_t)0x000000C0) /* CNF9[1:0] bits (Port x configuration bits, pin 9) */
+#define GPIO_CFGHR_CNF9_0                       ((uint32_t)0x00000040) /* Bit 0 */
+#define GPIO_CFGHR_CNF9_1                       ((uint32_t)0x00000080) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF10                        ((uint32_t)0x00000C00) /* CNF10[1:0] bits (Port x configuration bits, pin 10) */
+#define GPIO_CFGHR_CNF10_0                      ((uint32_t)0x00000400) /* Bit 0 */
+#define GPIO_CFGHR_CNF10_1                      ((uint32_t)0x00000800) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF11                        ((uint32_t)0x0000C000) /* CNF11[1:0] bits (Port x configuration bits, pin 11) */
+#define GPIO_CFGHR_CNF11_0                      ((uint32_t)0x00004000) /* Bit 0 */
+#define GPIO_CFGHR_CNF11_1                      ((uint32_t)0x00008000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF12                        ((uint32_t)0x000C0000) /* CNF12[1:0] bits (Port x configuration bits, pin 12) */
+#define GPIO_CFGHR_CNF12_0                      ((uint32_t)0x00040000) /* Bit 0 */
+#define GPIO_CFGHR_CNF12_1                      ((uint32_t)0x00080000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF13                        ((uint32_t)0x00C00000) /* CNF13[1:0] bits (Port x configuration bits, pin 13) */
+#define GPIO_CFGHR_CNF13_0                      ((uint32_t)0x00400000) /* Bit 0 */
+#define GPIO_CFGHR_CNF13_1                      ((uint32_t)0x00800000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF14                        ((uint32_t)0x0C000000) /* CNF14[1:0] bits (Port x configuration bits, pin 14) */
+#define GPIO_CFGHR_CNF14_0                      ((uint32_t)0x04000000) /* Bit 0 */
+#define GPIO_CFGHR_CNF14_1                      ((uint32_t)0x08000000) /* Bit 1 */
+
+#define GPIO_CFGHR_CNF15                        ((uint32_t)0xC0000000) /* CNF15[1:0] bits (Port x configuration bits, pin 15) */
+#define GPIO_CFGHR_CNF15_0                      ((uint32_t)0x40000000) /* Bit 0 */
+#define GPIO_CFGHR_CNF15_1                      ((uint32_t)0x80000000) /* Bit 1 */
+
+/*******************  Bit definition for GPIO_INDR register  *******************/
+#define GPIO_INDR_IDR0                          ((uint16_t)0x0001) /* Port input data, bit 0 */
+#define GPIO_INDR_IDR1                          ((uint16_t)0x0002) /* Port input data, bit 1 */
+#define GPIO_INDR_IDR2                          ((uint16_t)0x0004) /* Port input data, bit 2 */
+#define GPIO_INDR_IDR3                          ((uint16_t)0x0008) /* Port input data, bit 3 */
+#define GPIO_INDR_IDR4                          ((uint16_t)0x0010) /* Port input data, bit 4 */
+#define GPIO_INDR_IDR5                          ((uint16_t)0x0020) /* Port input data, bit 5 */
+#define GPIO_INDR_IDR6                          ((uint16_t)0x0040) /* Port input data, bit 6 */
+#define GPIO_INDR_IDR7                          ((uint16_t)0x0080) /* Port input data, bit 7 */
+#define GPIO_INDR_IDR8                          ((uint16_t)0x0100) /* Port input data, bit 8 */
+#define GPIO_INDR_IDR9                          ((uint16_t)0x0200) /* Port input data, bit 9 */
+#define GPIO_INDR_IDR10                         ((uint16_t)0x0400) /* Port input data, bit 10 */
+#define GPIO_INDR_IDR11                         ((uint16_t)0x0800) /* Port input data, bit 11 */
+#define GPIO_INDR_IDR12                         ((uint16_t)0x1000) /* Port input data, bit 12 */
+#define GPIO_INDR_IDR13                         ((uint16_t)0x2000) /* Port input data, bit 13 */
+#define GPIO_INDR_IDR14                         ((uint16_t)0x4000) /* Port input data, bit 14 */
+#define GPIO_INDR_IDR15                         ((uint16_t)0x8000) /* Port input data, bit 15 */
+#define GPIO_INDR_IDR16                         ((uint32_t)0x10000) /* Port input data, bit 16 */
+#define GPIO_INDR_IDR17                         ((uint32_t)0x20000) /* Port input data, bit 17 */
+#define GPIO_INDR_IDR18                         ((uint32_t)0x40000) /* Port input data, bit 18 */
+#define GPIO_INDR_IDR19                         ((uint32_t)0x80000) /* Port input data, bit 19 */
+#define GPIO_INDR_IDR20                         ((uint32_t)0x100000) /* Port input data, bit 20 */
+#define GPIO_INDR_IDR21                         ((uint32_t)0x200000) /* Port input data, bit 21 */
+#define GPIO_INDR_IDR22                         ((uint32_t)0x400000) /* Port input data, bit 22 */
+#define GPIO_INDR_IDR23                         ((uint32_t)0x800000) /* Port input data, bit 23 */
+
+/*******************  Bit definition for GPIO_OUTDR register  *******************/
+#define GPIO_OUTDR_ODR0                         ((uint16_t)0x0001) /* Port output data, bit 0 */
+#define GPIO_OUTDR_ODR1                         ((uint16_t)0x0002) /* Port output data, bit 1 */
+#define GPIO_OUTDR_ODR2                         ((uint16_t)0x0004) /* Port output data, bit 2 */
+#define GPIO_OUTDR_ODR3                         ((uint16_t)0x0008) /* Port output data, bit 3 */
+#define GPIO_OUTDR_ODR4                         ((uint16_t)0x0010) /* Port output data, bit 4 */
+#define GPIO_OUTDR_ODR5                         ((uint16_t)0x0020) /* Port output data, bit 5 */
+#define GPIO_OUTDR_ODR6                         ((uint16_t)0x0040) /* Port output data, bit 6 */
+#define GPIO_OUTDR_ODR7                         ((uint16_t)0x0080) /* Port output data, bit 7 */
+#define GPIO_OUTDR_ODR8                         ((uint16_t)0x0100) /* Port output data, bit 8 */
+#define GPIO_OUTDR_ODR9                         ((uint16_t)0x0200) /* Port output data, bit 9 */
+#define GPIO_OUTDR_ODR10                        ((uint16_t)0x0400) /* Port output data, bit 10 */
+#define GPIO_OUTDR_ODR11                        ((uint16_t)0x0800) /* Port output data, bit 11 */
+#define GPIO_OUTDR_ODR12                        ((uint16_t)0x1000) /* Port output data, bit 12 */
+#define GPIO_OUTDR_ODR13                        ((uint16_t)0x2000) /* Port output data, bit 13 */
+#define GPIO_OUTDR_ODR14                        ((uint16_t)0x4000) /* Port output data, bit 14 */
+#define GPIO_OUTDR_ODR15                        ((uint16_t)0x8000) /* Port output data, bit 15 */
+#define GPIO_OUTDR_ODR16                        ((uint32_t)0x10000) /* Port output data, bit 16 */
+#define GPIO_OUTDR_ODR17                        ((uint32_t)0x20000) /* Port output data, bit 17 */
+#define GPIO_OUTDR_ODR18                        ((uint32_t)0x40000) /* Port output data, bit 18 */
+#define GPIO_OUTDR_ODR19                        ((uint32_t)0x80000) /* Port output data, bit 19 */
+#define GPIO_OUTDR_ODR20                        ((uint32_t)0x100000) /* Port output data, bit 20 */
+#define GPIO_OUTDR_ODR21                        ((uint32_t)0x200000) /* Port output data, bit 21 */
+#define GPIO_OUTDR_ODR22                        ((uint32_t)0x400000) /* Port output data, bit 22 */
+#define GPIO_OUTDR_ODR23                        ((uint32_t)0x800000) /* Port output data, bit 23 */
+
+/******************  Bit definition for GPIO_BSHR register  *******************/
+#define GPIO_BSHR_BS0                           ((uint32_t)0x00000001) /* Port x Set bit 0 */
+#define GPIO_BSHR_BS1                           ((uint32_t)0x00000002) /* Port x Set bit 1 */
+#define GPIO_BSHR_BS2                           ((uint32_t)0x00000004) /* Port x Set bit 2 */
+#define GPIO_BSHR_BS3                           ((uint32_t)0x00000008) /* Port x Set bit 3 */
+#define GPIO_BSHR_BS4                           ((uint32_t)0x00000010) /* Port x Set bit 4 */
+#define GPIO_BSHR_BS5                           ((uint32_t)0x00000020) /* Port x Set bit 5 */
+#define GPIO_BSHR_BS6                           ((uint32_t)0x00000040) /* Port x Set bit 6 */
+#define GPIO_BSHR_BS7                           ((uint32_t)0x00000080) /* Port x Set bit 7 */
+#define GPIO_BSHR_BS8                           ((uint32_t)0x00000100) /* Port x Set bit 8 */
+#define GPIO_BSHR_BS9                           ((uint32_t)0x00000200) /* Port x Set bit 9 */
+#define GPIO_BSHR_BS10                          ((uint32_t)0x00000400) /* Port x Set bit 10 */
+#define GPIO_BSHR_BS11                          ((uint32_t)0x00000800) /* Port x Set bit 11 */
+#define GPIO_BSHR_BS12                          ((uint32_t)0x00001000) /* Port x Set bit 12 */
+#define GPIO_BSHR_BS13                          ((uint32_t)0x00002000) /* Port x Set bit 13 */
+#define GPIO_BSHR_BS14                          ((uint32_t)0x00004000) /* Port x Set bit 14 */
+#define GPIO_BSHR_BS15                          ((uint32_t)0x00008000) /* Port x Set bit 15 */
+
+#define GPIO_BSHR_BR0                           ((uint32_t)0x00010000) /* Port x Reset bit 0 */
+#define GPIO_BSHR_BR1                           ((uint32_t)0x00020000) /* Port x Reset bit 1 */
+#define GPIO_BSHR_BR2                           ((uint32_t)0x00040000) /* Port x Reset bit 2 */
+#define GPIO_BSHR_BR3                           ((uint32_t)0x00080000) /* Port x Reset bit 3 */
+#define GPIO_BSHR_BR4                           ((uint32_t)0x00100000) /* Port x Reset bit 4 */
+#define GPIO_BSHR_BR5                           ((uint32_t)0x00200000) /* Port x Reset bit 5 */
+#define GPIO_BSHR_BR6                           ((uint32_t)0x00400000) /* Port x Reset bit 6 */
+#define GPIO_BSHR_BR7                           ((uint32_t)0x00800000) /* Port x Reset bit 7 */
+#define GPIO_BSHR_BR8                           ((uint32_t)0x01000000) /* Port x Reset bit 8 */
+#define GPIO_BSHR_BR9                           ((uint32_t)0x02000000) /* Port x Reset bit 9 */
+#define GPIO_BSHR_BR10                          ((uint32_t)0x04000000) /* Port x Reset bit 10 */
+#define GPIO_BSHR_BR11                          ((uint32_t)0x08000000) /* Port x Reset bit 11 */
+#define GPIO_BSHR_BR12                          ((uint32_t)0x10000000) /* Port x Reset bit 12 */
+#define GPIO_BSHR_BR13                          ((uint32_t)0x20000000) /* Port x Reset bit 13 */
+#define GPIO_BSHR_BR14                          ((uint32_t)0x40000000) /* Port x Reset bit 14 */
+#define GPIO_BSHR_BR15                          ((uint32_t)0x80000000) /* Port x Reset bit 15 */
+
+/*******************  Bit definition for GPIO_BCR register  *******************/
+#define GPIO_BCR_BR0                            ((uint16_t)0x0001) /* Port x Reset bit 0 */
+#define GPIO_BCR_BR1                            ((uint16_t)0x0002) /* Port x Reset bit 1 */
+#define GPIO_BCR_BR2                            ((uint16_t)0x0004) /* Port x Reset bit 2 */
+#define GPIO_BCR_BR3                            ((uint16_t)0x0008) /* Port x Reset bit 3 */
+#define GPIO_BCR_BR4                            ((uint16_t)0x0010) /* Port x Reset bit 4 */
+#define GPIO_BCR_BR5                            ((uint16_t)0x0020) /* Port x Reset bit 5 */
+#define GPIO_BCR_BR6                            ((uint16_t)0x0040) /* Port x Reset bit 6 */
+#define GPIO_BCR_BR7                            ((uint16_t)0x0080) /* Port x Reset bit 7 */
+#define GPIO_BCR_BR8                            ((uint16_t)0x0100) /* Port x Reset bit 8 */
+#define GPIO_BCR_BR9                            ((uint16_t)0x0200) /* Port x Reset bit 9 */
+#define GPIO_BCR_BR10                           ((uint16_t)0x0400) /* Port x Reset bit 10 */
+#define GPIO_BCR_BR11                           ((uint16_t)0x0800) /* Port x Reset bit 11 */
+#define GPIO_BCR_BR12                           ((uint16_t)0x1000) /* Port x Reset bit 12 */
+#define GPIO_BCR_BR13                           ((uint16_t)0x2000) /* Port x Reset bit 13 */
+#define GPIO_BCR_BR14                           ((uint16_t)0x4000) /* Port x Reset bit 14 */
+#define GPIO_BCR_BR15                           ((uint16_t)0x8000) /* Port x Reset bit 15 */
+#define GPIO_BCR_BR16                           ((uint32_t)0x10000) /* Port x Reset bit 16 */
+#define GPIO_BCR_BR17                           ((uint32_t)0x20000) /* Port x Reset bit 17 */
+#define GPIO_BCR_BR18                           ((uint32_t)0x40000) /* Port x Reset bit 18 */
+#define GPIO_BCR_BR19                           ((uint32_t)0x80000) /* Port x Reset bit 19 */
+#define GPIO_BCR_BR20                           ((uint32_t)0x100000) /* Port x Reset bit 20 */
+#define GPIO_BCR_BR21                           ((uint32_t)0x200000) /* Port x Reset bit 21 */
+#define GPIO_BCR_BR22                           ((uint32_t)0x400000) /* Port x Reset bit 22 */
+#define GPIO_BCR_BR23                           ((uint32_t)0x800000) /* Port x Reset bit 23 */
+
+
+/******************  Bit definition for GPIO_LCKR register  *******************/
+#define GPIO_LCK0                               ((uint32_t)0x00000001) /* Port x Lock bit 0 */
+#define GPIO_LCK1                               ((uint32_t)0x00000002) /* Port x Lock bit 1 */
+#define GPIO_LCK2                               ((uint32_t)0x00000004) /* Port x Lock bit 2 */
+#define GPIO_LCK3                               ((uint32_t)0x00000008) /* Port x Lock bit 3 */
+#define GPIO_LCK4                               ((uint32_t)0x00000010) /* Port x Lock bit 4 */
+#define GPIO_LCK5                               ((uint32_t)0x00000020) /* Port x Lock bit 5 */
+#define GPIO_LCK6                               ((uint32_t)0x00000040) /* Port x Lock bit 6 */
+#define GPIO_LCK7                               ((uint32_t)0x00000080) /* Port x Lock bit 7 */
+#define GPIO_LCK8                               ((uint32_t)0x00000100) /* Port x Lock bit 8 */
+#define GPIO_LCK9                               ((uint32_t)0x00000200) /* Port x Lock bit 9 */
+#define GPIO_LCK10                              ((uint32_t)0x00000400) /* Port x Lock bit 10 */
+#define GPIO_LCK11                              ((uint32_t)0x00000800) /* Port x Lock bit 11 */
+#define GPIO_LCK12                              ((uint32_t)0x00001000) /* Port x Lock bit 12 */
+#define GPIO_LCK13                              ((uint32_t)0x00002000) /* Port x Lock bit 13 */
+#define GPIO_LCK14                              ((uint32_t)0x00004000) /* Port x Lock bit 14 */
+#define GPIO_LCK15                              ((uint32_t)0x00008000) /* Port x Lock bit 15 */
+#define GPIO_LCK16                              ((uint32_t)0x00010000) /* Port x Lock bit 16 */
+#define GPIO_LCK17                              ((uint32_t)0x00020000) /* Port x Lock bit 17 */
+#define GPIO_LCK18                              ((uint32_t)0x00040000) /* Port x Lock bit 18 */
+#define GPIO_LCK19                              ((uint32_t)0x00080000) /* Port x Lock bit 19 */
+#define GPIO_LCK20                              ((uint32_t)0x00100000) /* Port x Lock bit 20 */
+#define GPIO_LCK21                              ((uint32_t)0x00200000) /* Port x Lock bit 21 */
+#define GPIO_LCK22                              ((uint32_t)0x00400000) /* Port x Lock bit 22 */
+#define GPIO_LCK23                              ((uint32_t)0x00800000) /* Port x Lock bit 23 */
+
+#define GPIO_LCKK                               ((uint32_t)0x01000000) /* Lock key */
+
+/*******************  Bit definition for GPIO_CFGXR register  *******************/
+#define GPIO_CFGXR_MODE                         ((uint32_t)0x33333333) /* Port x mode bits */
+
+#define GPIO_CFGXR_MODE16                       ((uint32_t)0x00000003) /* MODE16[1:0] bits (Port x mode bits, pin 0) */
+#define GPIO_CFGXR_MODE16_0                     ((uint32_t)0x00000001) /* Bit 0 */
+#define GPIO_CFGXR_MODE16_1                     ((uint32_t)0x00000002) /* Bit 1 */
+
+#define GPIO_CFGXR_MODE17                       ((uint32_t)0x00000030) /* MODE17[1:0] bits (Port x mode bits, pin 1) */
+#define GPIO_CFGXR_MODE17_0                     ((uint32_t)0x00000010) /* Bit 0 */
+#define GPIO_CFGXR_MODE17_1                     ((uint32_t)0x00000020) /* Bit 1 */
+
+#define GPIO_CFGXR_MODE18                       ((uint32_t)0x00000300) /* MODE18[1:0] bits (Port x mode bits, pin 2) */
+#define GPIO_CFGXR_MODE18_0                     ((uint32_t)0x00000100) /* Bit 0 */
+#define GPIO_CFGXR_MODE18_1                     ((uint32_t)0x00000200) /* Bit 1 */
+
+#define GPIO_CFGXR_MODE19                       ((uint32_t)0x00003000) /* MODE19[1:0] bits (Port x mode bits, pin 3) */
+#define GPIO_CFGXR_MODE19_0                     ((uint32_t)0x00001000) /* Bit 0 */
+#define GPIO_CFGXR_MODE19_1                     ((uint32_t)0x00002000) /* Bit 1 */
+
+#define GPIO_CFGXR_MODE20                       ((uint32_t)0x00030000) /* MODE20[1:0] bits (Port x mode bits, pin 4) */
+#define GPIO_CFGXR_MODE20_0                     ((uint32_t)0x00010000) /* Bit 0 */
+#define GPIO_CFGXR_MODE20_1                     ((uint32_t)0x00020000) /* Bit 1 */
+
+#define GPIO_CFGXR_MODE21                       ((uint32_t)0x00300000) /* MODE21[1:0] bits (Port x mode bits, pin 5) */
+#define GPIO_CFGXR_MODE21_0                     ((uint32_t)0x00100000) /* Bit 0 */
+#define GPIO_CFGXR_MODE21_1                     ((uint32_t)0x00200000) /* Bit 1 */
+
+#define GPIO_CFGXR_MODE22                       ((uint32_t)0x03000000) /* MODE22[1:0] bits (Port x mode bits, pin 6) */
+#define GPIO_CFGXR_MODE22_0                     ((uint32_t)0x01000000) /* Bit 0 */
+#define GPIO_CFGXR_MODE22_1                     ((uint32_t)0x02000000) /* Bit 1 */
+
+#define GPIO_CFGXR_MODE23                       ((uint32_t)0x30000000) /* MODE23[1:0] bits (Port x mode bits, pin 7) */
+#define GPIO_CFGXR_MODE23_0                     ((uint32_t)0x10000000) /* Bit 0 */
+#define GPIO_CFGXR_MODE23_1                     ((uint32_t)0x20000000) /* Bit 1 */
+
+#define GPIO_CFGXR_CNF                          ((uint32_t)0xCCCCCCCC) /* Port x configuration bits */
+
+#define GPIO_CFGXR_CNF16                        ((uint32_t)0x0000000C) /* CNF16[1:0] bits (Port x configuration bits, pin 0) */
+#define GPIO_CFGXR_CNF16_0                      ((uint32_t)0x00000004) /* Bit 0 */
+#define GPIO_CFGXR_CNF16_1                      ((uint32_t)0x00000008) /* Bit 1 */
+
+#define GPIO_CFGXR_CNF17                        ((uint32_t)0x000000C0) /* CNF17[1:0] bits (Port x configuration bits, pin 1) */
+#define GPIO_CFGXR_CNF17_0                      ((uint32_t)0x00000040) /* Bit 0 */
+#define GPIO_CFGXR_CNF17_1                      ((uint32_t)0x00000080) /* Bit 1 */
+
+#define GPIO_CFGXR_CNF18                        ((uint32_t)0x00000C00) /* CNF18[1:0] bits (Port x configuration bits, pin 2) */
+#define GPIO_CFGXR_CNF18_0                      ((uint32_t)0x00000400) /* Bit 0 */
+#define GPIO_CFGXR_CNF18_1                      ((uint32_t)0x00000800) /* Bit 1 */
+
+#define GPIO_CFGXR_CNF19                        ((uint32_t)0x0000C000) /* CNF19[1:0] bits (Port x configuration bits, pin 3) */
+#define GPIO_CFGXR_CNF19_0                      ((uint32_t)0x00004000) /* Bit 0 */
+#define GPIO_CFGXR_CNF19_1                      ((uint32_t)0x00008000) /* Bit 1 */
+
+#define GPIO_CFGXR_CNF20                        ((uint32_t)0x000C0000) /* CNF20[1:0] bits (Port x configuration bits, pin 4) */
+#define GPIO_CFGXR_CNF20_0                      ((uint32_t)0x00040000) /* Bit 0 */
+#define GPIO_CFGXR_CNF20_1                      ((uint32_t)0x00080000) /* Bit 1 */
+
+#define GPIO_CFGXR_CNF21                        ((uint32_t)0x00C00000) /* CNF21[1:0] bits (Port x configuration bits, pin 5) */
+#define GPIO_CFGXR_CNF21_0                      ((uint32_t)0x00400000) /* Bit 0 */
+#define GPIO_CFGXR_CNF21_1                      ((uint32_t)0x00800000) /* Bit 1 */
+
+#define GPIO_CFGXR_CNF22                        ((uint32_t)0x0C000000) /* CNF22[1:0] bits (Port x configuration bits, pin 6) */
+#define GPIO_CFGXR_CNF22_0                      ((uint32_t)0x04000000) /* Bit 0 */
+#define GPIO_CFGXR_CNF22_1                      ((uint32_t)0x08000000) /* Bit 1 */
+
+#define GPIO_CFGXR_CNF23                        ((uint32_t)0xC0000000) /* CNF23[1:0] bits (Port x configuration bits, pin 7) */
+#define GPIO_CFGXR_CNF23_0                      ((uint32_t)0x40000000) /* Bit 0 */
+#define GPIO_CFGXR_CNF23_1                      ((uint32_t)0x80000000) /* Bit 1 */
+
+/******************  Bit definition for GPIO_BSXR register  *******************/
+#define GPIO_BSXR_BS16                          ((uint32_t)0x00000001) /* Port x Set bit 0 */
+#define GPIO_BSXR_BS17                          ((uint32_t)0x00000002) /* Port x Set bit 1 */
+#define GPIO_BSXR_BS18                          ((uint32_t)0x00000004) /* Port x Set bit 2 */
+#define GPIO_BSXR_BS19                          ((uint32_t)0x00000008) /* Port x Set bit 3 */
+#define GPIO_BSXR_BS20                          ((uint32_t)0x00000010) /* Port x Set bit 4 */
+#define GPIO_BSXR_BS21                          ((uint32_t)0x00000020) /* Port x Set bit 5 */
+#define GPIO_BSXR_BS22                          ((uint32_t)0x00000040) /* Port x Set bit 6 */
+#define GPIO_BSXR_BS23                          ((uint32_t)0x00000080) /* Port x Set bit 7 */
+
+#define GPIO_BSXR_BR16                          ((uint32_t)0x00010000) /* Port x Reset bit 0 */
+#define GPIO_BSXR_BR17                          ((uint32_t)0x00020000) /* Port x Reset bit 1 */
+#define GPIO_BSXR_BR18                          ((uint32_t)0x00040000) /* Port x Reset bit 2 */
+#define GPIO_BSXR_BR19                          ((uint32_t)0x00080000) /* Port x Reset bit 3 */
+#define GPIO_BSXR_BR20                          ((uint32_t)0x00100000) /* Port x Reset bit 4 */
+#define GPIO_BSXR_BR21                          ((uint32_t)0x00200000) /* Port x Reset bit 5 */
+#define GPIO_BSXR_BR22                          ((uint32_t)0x00400000) /* Port x Reset bit 6 */
+#define GPIO_BSXR_BR23                          ((uint32_t)0x00800000) /* Port x Reset bit 7 */
+
+/******************  Bit definition for AFIO_PCFR1register  *******************/
+#define AFIO_PCFR1_SPI1_REMAP                   ((uint32_t)0x00000003) /* SPI1_REMAP[1:0] bits (SPI1 remapping) */
+#define AFIO_PCFR1_SPI1_REMAP_0                 ((uint32_t)0x00000001) /* Bit 0 */
+#define AFIO_PCFR1_SPI1_REMAP_1                 ((uint32_t)0x00000002) /* Bit 1 */
+
+#define AFIO_PCFR1_I2C1_REMAP                   ((uint32_t)0x0000001C) /* I2C1_REMAP[4:2] bits (I2C1 remapping) */
+#define AFIO_PCFR1_I2C1_REMAP_0                 ((uint32_t)0x00000004) /* Bit 0 */
+#define AFIO_PCFR1_I2C1_REMAP_1                 ((uint32_t)0x00000008) /* Bit 1 */
+#define AFIO_PCFR1_I2C1_REMAP_2                 ((uint32_t)0x00000010) /* Bit 2 */
+
+#define AFIO_PCFR1_USART1_REMAP                 ((uint32_t)0x00000060) /* USART1_REMAP[6:5] bits (USART1 remapping) */
+#define AFIO_PCFR1_USART1_REMAP_0               ((uint32_t)0x00000020) /* Bit 0 */
+#define AFIO_PCFR1_USART1_REMAP_1               ((uint32_t)0x00000040) /* Bit 1 */
+
+#define AFIO_PCFR1_USART2_REMAP                 ((uint32_t)0x00000380) /* USART2_REMAP[9:7] bits (USART2 remapping) */
+#define AFIO_PCFR1_USART2_REMAP_0               ((uint32_t)0x00000080) /* Bit 0 */
+#define AFIO_PCFR1_USART2_REMAP_1               ((uint32_t)0x00000100) /* Bit 1 */
+#define AFIO_PCFR1_USART2_REMAP_2               ((uint32_t)0x00000200) /* Bit 2 */
+
+#define AFIO_PCFR1_USART3_REMAP                 ((uint32_t)0x00000C00) /* USART3_REMAP[11:10] bits (USART3 remapping) */
+#define AFIO_PCFR1_USART3_REMAP_0               ((uint32_t)0x00000400) /* Bit 0 */
+#define AFIO_PCFR1_USART3_REMAP_1               ((uint32_t)0x00000800) /* Bit 1 */
+
+#define AFIO_PCFR1_USART4_REMAP                 ((uint32_t)0x00007000) /* USART4_REMAP[14:12] bits (USART4 remapping) */
+#define AFIO_PCFR1_USART4_REMAP_0               ((uint32_t)0x00001000) /* Bit 0 */
+#define AFIO_PCFR1_USART4_REMAP_1               ((uint32_t)0x00002000) /* Bit 1 */
+#define AFIO_PCFR1_USART4_REMAP_2               ((uint32_t)0x00004000) /* Bit 2 */
+
+#define AFIO_PCFR1_TIM1_REMAP                   ((uint32_t)0x00038000) /* TIM1_REMAP[17:15] bits (TIM1 remapping) */
+#define AFIO_PCFR1_TIM1_REMAP_0                 ((uint32_t)0x00008000) /* Bit 0 */
+#define AFIO_PCFR1_TIM1_REMAP_1                 ((uint32_t)0x00010000) /* Bit 1 */
+#define AFIO_PCFR1_TIM1_REMAP_2                 ((uint32_t)0x00020000) /* Bit 2 */
+
+#define AFIO_PCFR1_TIM2_REMAP                   ((uint32_t)0x001C0000) /* TIM2_REMAP[20:18] bits (TIM2 remapping) */
+#define AFIO_PCFR1_TIM2_REMAP_0                 ((uint32_t)0x00040000) /* Bit 0 */
+#define AFIO_PCFR1_TIM2_REMAP_1                 ((uint32_t)0x00080000) /* Bit 1 */
+#define AFIO_PCFR1_TIM2_REMAP_2                 ((uint32_t)0x00100000) /* Bit 2 */
+
+#define AFIO_PCFR1_TIM3_REMAP                   ((uint32_t)0x00600000) /* TIM3_REMAP[22:21] bits (TIM3 remapping) */
+#define AFIO_PCFR1_TIM3_REMAP_0                 ((uint32_t)0x00200000) /* Bit 0 */
+#define AFIO_PCFR1_TIM3_REMAP_1                 ((uint32_t)0x00400000) /* Bit 1 */
+
+#define AFIO_PCFR1_PIOC_REMAP                   ((uint32_t)0x00800000) /* PIOC[23] bits (PIOC remapping) */
+
+#define AFIO_PCFR1_SWJ_CFG                      ((uint32_t)0x07000000) /* SWJ_CFG[2:0] bits (Serial Wire JTAG configuration) */
+#define AFIO_PCFR1_SWJ_CFG_0                    ((uint32_t)0x01000000) /* Bit 0 */
+#define AFIO_PCFR1_SWJ_CFG_1                    ((uint32_t)0x02000000) /* Bit 1 */
+#define AFIO_PCFR1_SWJ_CFG_2                    ((uint32_t)0x04000000) /* Bit 2 */
+
+#define AFIO_PCFR1_SWJ_CFG_RESET                ((uint32_t)0x00000000) /* Full SWJ (JTAG-DP + SW-DP) : Reset State */
+#define AFIO_PCFR1_SWJ_CFG_NOJNTRST             ((uint32_t)0x01000000) /* Full SWJ (JTAG-DP + SW-DP) but without JNTRST */
+#define AFIO_PCFR1_SWJ_CFG_JTAGDISABLE          ((uint32_t)0x02000000) /* JTAG-DP Disabled and SW-DP Enabled */
+#define AFIO_PCFR1_SWJ_CFG_DISABLE              ((uint32_t)0x04000000) /* JTAG-DP Disabled and SW-DP Disabled */
+
+
+/*****************  Bit definition for AFIO_EXTICR1 register  *****************/
+#define AFIO_EXTICR1_EXTI0                      ((uint32_t)0x00000003) /* EXTI 0 configuration */
+#define AFIO_EXTICR1_EXTI1                      ((uint32_t)0x0000000C) /* EXTI 1 configuration */
+#define AFIO_EXTICR1_EXTI2                      ((uint32_t)0x00000030) /* EXTI 2 configuration */
+#define AFIO_EXTICR1_EXTI3                      ((uint32_t)0x000000C0) /* EXTI 3 configuration */
+#define AFIO_EXTICR1_EXTI4                      ((uint32_t)0x00000300) /* EXTI 4 configuration */
+#define AFIO_EXTICR1_EXTI5                      ((uint32_t)0x00000C00) /* EXTI 5 configuration */
+#define AFIO_EXTICR1_EXTI6                      ((uint32_t)0x00003000) /* EXTI 6 configuration */
+#define AFIO_EXTICR1_EXTI7                      ((uint32_t)0x0000C000) /* EXTI 7 configuration */
+#define AFIO_EXTICR1_EXTI8                      ((uint32_t)0x00030000) /* EXTI 8 configuration */
+#define AFIO_EXTICR1_EXTI9                      ((uint32_t)0x000C0000) /* EXTI 9 configuration */
+#define AFIO_EXTICR1_EXTI10                     ((uint32_t)0x00300000) /* EXTI 10 configuration */
+#define AFIO_EXTICR1_EXTI11                     ((uint32_t)0x00C00000) /* EXTI 11 configuration */
+#define AFIO_EXTICR1_EXTI12                     ((uint32_t)0x03000000) /* EXTI 12 configuration */
+#define AFIO_EXTICR1_EXTI13                     ((uint32_t)0x0C000000) /* EXTI 13 configuration */
+#define AFIO_EXTICR1_EXTI14                     ((uint32_t)0x30000000) /* EXTI 14 configuration */
+#define AFIO_EXTICR1_EXTI15                     ((uint32_t)0xC0000000) /* EXTI 15 configuration */
+
+#define AFIO_EXTICR1_EXTI0_PA                   ((uint32_t)0x00000000) /* PA[0] pin */
+#define AFIO_EXTICR1_EXTI0_PB                   ((uint32_t)0x00000001) /* PB[0] pin */
+#define AFIO_EXTICR1_EXTI0_PC                   ((uint32_t)0x00000002) /* PC[0] pin */
+
+#define AFIO_EXTICR1_EXTI1_PA                   ((uint32_t)0x00000000) /* PA[1] pin */
+#define AFIO_EXTICR1_EXTI1_PB                   ((uint32_t)0x00000004) /* PB[1] pin */
+#define AFIO_EXTICR1_EXTI1_PC                   ((uint32_t)0x00000008) /* PC[1] pin */
+
+#define AFIO_EXTICR1_EXTI2_PA                   ((uint32_t)0x00000000) /* PA[2] pin */
+#define AFIO_EXTICR1_EXTI2_PB                   ((uint32_t)0x00000010) /* PB[2] pin */
+#define AFIO_EXTICR1_EXTI2_PC                   ((uint32_t)0x00000020) /* PC[2] pin */
+
+#define AFIO_EXTICR1_EXTI3_PA                   ((uint32_t)0x00000000) /* PA[3] pin */
+#define AFIO_EXTICR1_EXTI3_PB                   ((uint32_t)0x00000040) /* PB[3] pin */
+#define AFIO_EXTICR1_EXTI3_PC                   ((uint32_t)0x00000080) /* PC[3] pin */
+
+#define AFIO_EXTICR1_EXTI4_PA                   ((uint32_t)0x00000000) /* PA[4] pin */
+#define AFIO_EXTICR1_EXTI4_PB                   ((uint32_t)0x00000100) /* PB[4] pin */
+#define AFIO_EXTICR1_EXTI4_PC                   ((uint32_t)0x00000200) /* PC[4] pin */
+
+#define AFIO_EXTICR1_EXTI5_PA                   ((uint32_t)0x00000000) /* PA[5] pin */
+#define AFIO_EXTICR1_EXTI5_PB                   ((uint32_t)0x00000400) /* PB[5] pin */
+#define AFIO_EXTICR1_EXTI5_PC                   ((uint32_t)0x00000800) /* PC[5] pin */
+
+#define AFIO_EXTICR1_EXTI6_PA                   ((uint32_t)0x00000000) /* PA[6] pin */
+#define AFIO_EXTICR1_EXTI6_PB                   ((uint32_t)0x00001000) /* PB[6] pin */
+#define AFIO_EXTICR1_EXTI6_PC                   ((uint32_t)0x00002000) /* PC[6] pin */
+
+#define AFIO_EXTICR1_EXTI7_PA                   ((uint32_t)0x00000000) /* PA[7] pin */
+#define AFIO_EXTICR1_EXTI7_PB                   ((uint32_t)0x00004000) /* PB[7] pin */
+#define AFIO_EXTICR1_EXTI7_PC                   ((uint32_t)0x00008000) /* PC[7] pin */
+
+#define AFIO_EXTICR1_EXTI8_PA                   ((uint32_t)0x00000000) /* PA[8] pin */
+#define AFIO_EXTICR1_EXTI8_PB                   ((uint32_t)0x00010000) /* PB[8] pin */
+#define AFIO_EXTICR1_EXTI8_PC                   ((uint32_t)0x00020000) /* PC[8] pin */
+
+#define AFIO_EXTICR1_EXTI9_PA                   ((uint32_t)0x00000000) /* PA[9] pin */
+#define AFIO_EXTICR1_EXTI9_PB                   ((uint32_t)0x00040000) /* PB[9] pin */
+#define AFIO_EXTICR1_EXTI9_PC                   ((uint32_t)0x00080000) /* PC[9] pin */
+
+#define AFIO_EXTICR1_EXTI10_PA                  ((uint32_t)0x00000000) /* PA[10] pin */
+#define AFIO_EXTICR1_EXTI10_PB                  ((uint32_t)0x00100000) /* PB[10] pin */
+#define AFIO_EXTICR1_EXTI10_PC                  ((uint32_t)0x00200000) /* PC[10] pin */
+
+#define AFIO_EXTICR1_EXTI11_PA                  ((uint32_t)0x00000000) /* PA[11] pin */
+#define AFIO_EXTICR1_EXTI11_PB                  ((uint32_t)0x00400000) /* PB[11] pin */
+#define AFIO_EXTICR1_EXTI11_PC                  ((uint32_t)0x00800000) /* PC[11] pin */
+
+#define AFIO_EXTICR1_EXTI12_PA                  ((uint32_t)0x00000000) /* PA[12] pin */
+#define AFIO_EXTICR1_EXTI12_PB                  ((uint32_t)0x01000000) /* PB[12] pin */
+#define AFIO_EXTICR1_EXTI12_PC                  ((uint32_t)0x02000000) /* PC[12] pin */
+
+#define AFIO_EXTICR1_EXTI13_PA                  ((uint32_t)0x00000000) /* PA[13] pin */
+#define AFIO_EXTICR1_EXTI13_PB                  ((uint32_t)0x04000000) /* PB[13] pin */
+#define AFIO_EXTICR1_EXTI13_PC                  ((uint32_t)0x08000000) /* PC[13] pin */
+
+#define AFIO_EXTICR1_EXTI14_PA                  ((uint32_t)0x00000000) /* PA[14] pin */
+#define AFIO_EXTICR1_EXTI14_PB                  ((uint32_t)0x10000000) /* PB[14] pin */
+#define AFIO_EXTICR1_EXTI14_PC                  ((uint32_t)0x20000000) /* PC[14] pin */
+
+#define AFIO_EXTICR1_EXTI15_PA                  ((uint32_t)0x00000000) /* PA[15] pin */
+#define AFIO_EXTICR1_EXTI15_PB                  ((uint32_t)0x40000000) /* PB[15] pin */
+#define AFIO_EXTICR1_EXTI15_PC                  ((uint32_t)0x80000000) /* PC[15] pin */
+
+/*****************  Bit definition for AFIO_EXTICR2 register  *****************/
+#define AFIO_EXTICR2_EXTI16                     ((uint16_t)0x00000003) /* EXTI 16 configuration */
+#define AFIO_EXTICR2_EXTI17                     ((uint16_t)0x0000000C) /* EXTI 17 configuration */
+#define AFIO_EXTICR2_EXTI18                     ((uint16_t)0x00000030) /* EXTI 18 configuration */
+#define AFIO_EXTICR2_EXTI19                     ((uint16_t)0x000000C0) /* EXTI 19 configuration */
+#define AFIO_EXTICR2_EXTI20                     ((uint16_t)0x00000300) /* EXTI 20 configuration */
+#define AFIO_EXTICR2_EXTI21                     ((uint16_t)0x00000C00) /* EXTI 21 configuration */
+#define AFIO_EXTICR2_EXTI22                     ((uint16_t)0x00003000) /* EXTI 22 configuration */
+#define AFIO_EXTICR2_EXTI23                     ((uint16_t)0x0000C000) /* EXTI 23 configuration */
+
+#define AFIO_EXTICR2_EXTI16_PA                  ((uint16_t)0x00000000) /* PA[16] pin */
+#define AFIO_EXTICR2_EXTI16_PB                  ((uint16_t)0x00000001) /* PB[16] pin */
+#define AFIO_EXTICR2_EXTI16_PC                  ((uint16_t)0x00000002) /* PC[16] pin */
+
+#define AFIO_EXTICR2_EXTI17_PA                  ((uint16_t)0x00000000) /* PA[17] pin */
+#define AFIO_EXTICR2_EXTI17_PB                  ((uint16_t)0x00000004) /* PB[17] pin */
+#define AFIO_EXTICR2_EXTI17_PC                  ((uint16_t)0x00000008) /* PC[17] pin */
+
+#define AFIO_EXTICR2_EXTI18_PA                  ((uint16_t)0x00000000) /* PA[18] pin */
+#define AFIO_EXTICR2_EXTI18_PB                  ((uint16_t)0x00000010) /* PB[18] pin */
+#define AFIO_EXTICR2_EXTI18_PC                  ((uint16_t)0x00000020) /* PC[18] pin */
+
+#define AFIO_EXTICR2_EXTI19_PA                  ((uint16_t)0x00000000) /* PA[19] pin */
+#define AFIO_EXTICR2_EXTI19_PB                  ((uint16_t)0x00000040) /* PB[19] pin */
+#define AFIO_EXTICR2_EXTI19_PC                  ((uint16_t)0x00000080) /* PC[19] pin */
+
+#define AFIO_EXTICR2_EXTI20_PA                  ((uint16_t)0x00000000) /* PA[20] pin */
+#define AFIO_EXTICR2_EXTI20_PB                  ((uint16_t)0x00000100) /* PB[20] pin */
+#define AFIO_EXTICR2_EXTI20_PC                  ((uint16_t)0x00000200) /* PC[20] pin */
+
+#define AFIO_EXTICR2_EXTI21_PA                  ((uint16_t)0x00000000) /* PA[21] pin */
+#define AFIO_EXTICR2_EXTI21_PB                  ((uint16_t)0x00000400) /* PB[21] pin */
+#define AFIO_EXTICR2_EXTI21_PC                  ((uint16_t)0x00000800) /* PC[21] pin */
+
+#define AFIO_EXTICR2_EXTI22_PA                  ((uint16_t)0x00000000) /* PA[22] pin */
+#define AFIO_EXTICR2_EXTI22_PB                  ((uint16_t)0x00001000) /* PB[22] pin */
+#define AFIO_EXTICR2_EXTI22_PC                  ((uint16_t)0x00002000) /* PC[22] pin */
+
+#define AFIO_EXTICR2_EXTI23_PA                  ((uint16_t)0x00000000) /* PA[23] pin */
+#define AFIO_EXTICR2_EXTI23_PB                  ((uint16_t)0x00004000) /* PB[23] pin */
+#define AFIO_EXTICR2_EXTI23_PC                  ((uint16_t)0x00008000) /* PC[23] pin */
+
+/*******************  Bit definition for AFIO_CTLR register  ********************/
+#define AFIO_CTLR_UDM_PUE                       ((uint32_t)0x00000003) /* PC16/UDM Pin pull-up Mode*/
+#define AFIO_CTLR_UDM_PUE_0                     ((uint32_t)0x00000001) /* bit[0] */
+#define AFIO_CTLR_UDM_PUE_1                     ((uint32_t)0x00000002) /* bit[1] */
+
+#define UDM_PUE_MASK                0x00000003
+#define UDM_PUE_DISABLE             0x00000000
+#define UDM_PUE_35UA                0x00000001
+#define UDM_PUE_10K                 0x00000002
+#define UDM_PUE_1K5                 0x00000003
+
+#define AFIO_CTLR_UDP_PUE                       ((uint32_t)0x0000000C) /* PC17/UDP Pin pull-up Mode*/
+#define AFIO_CTLR_UDP_PUE_0                     ((uint32_t)0x00000004) /* bit[2] */
+#define AFIO_CTLR_UDP_PUE_1                     ((uint32_t)0x00000008) /* bit[3] */
+
+#define UDP_PUE_MASK                0x0000000C
+#define UDP_PUE_DISABLE             0x00000000
+#define UDP_PUE_35UA                0x00000004
+#define UDP_PUE_10K                 0x00000008
+#define UDP_PUE_1K5                 0x0000000C
+
+#define AFIO_CTLR_USB_PHY_V33                   ((uint32_t)0x00000040) /* USB transceiver PHY output and pull-up limiter configuration */
+#define AFIO_CTLR_USB_IOEN                      ((uint32_t)0x00000080) /* USB Remap pin enable */
+#define AFIO_CTLR_USBPD_PHY_V33                 ((uint32_t)0x00000100) /* USBPD transceiver PHY output and pull-up limiter configuration */
+#define AFIO_CTLR_USBPD_IN_HVT                  ((uint32_t)0x00000200) /* PD pin PC14/PC15 high threshold input mode */
+#define AFIO_CTLR_UDP_BC_VSRC                   ((uint32_t)0x00010000) /* PC17/UDP pin BC protocol source voltage enable */
+#define AFIO_CTLR_UDM_BC_VSRC                   ((uint32_t)0x00020000) /* PC16/UDM pin BC protocol source voltage enable */
+#define AFIO_CTLR_UDP_BC_CMPO                   ((uint32_t)0x00040000) /* PC17/UDP pin BC protocol comparator status */
+#define AFIO_CTLR_UDM_BC_CMPO                   ((uint32_t)0x00080000) /* PC16/UDM pin BC protocol comparator status */
+#define AFIO_CTLR_PA3_FILT_EN                   ((uint32_t)0x01000000) /* Controls the input filtering of the PA3 pin */
+#define AFIO_CTLR_PA4_FILT_EN                   ((uint32_t)0x02000000) /* Controls the input filtering of the PA4 pin */
+#define AFIO_CTLR_PB5_FILT_EN                   ((uint32_t)0x04000000) /* Controls the input filtering of the PB5 pin */
+#define AFIO_CTLR_PB6_FILT_EN                   ((uint32_t)0x08000000) /* Controls the input filtering of the PB6 pin */
+
+#define USB_IOEN       AFIO_CTLR_USB_IOEN
+#define USB_PHY_V33    AFIO_CTLR_USB_PHY_V33
+
+/******************************************************************************/
+/*                           Independent WATCHDOG                             */
+/******************************************************************************/
+
+/*******************  Bit definition for IWDG_CTLR register  ********************/
+#define IWDG_KEY                                ((uint16_t)0xFFFF) /* Key value (write only, read 0000h) */
+
+/*******************  Bit definition for IWDG_PSCR register  ********************/
+#define IWDG_PR                                 ((uint8_t)0x07) /* PR[2:0] (Prescaler divider) */
+#define IWDG_PR_0                               ((uint8_t)0x01) /* Bit 0 */
+#define IWDG_PR_1                               ((uint8_t)0x02) /* Bit 1 */
+#define IWDG_PR_2                               ((uint8_t)0x04) /* Bit 2 */
+
+/*******************  Bit definition for IWDG_RLDR register  *******************/
+#define IWDG_RL                                 ((uint16_t)0x0FFF) /* Watchdog counter reload value */
+
+/*******************  Bit definition for IWDG_STATR register  ********************/
+#define IWDG_PVU                                ((uint8_t)0x01) /* Watchdog prescaler value update */
+#define IWDG_RVU                                ((uint8_t)0x02) /* Watchdog counter reload value update */
+
+/******************************************************************************/
+/*                      Inter-integrated Circuit Interface                    */
+/******************************************************************************/
+
+/*******************  Bit definition for I2C_CTLR1 register  ********************/
+#define I2C_CTLR1_PE                            ((uint16_t)0x0001) /* Peripheral Enable */
+#define I2C_CTLR1_SMBUS                         ((uint16_t)0x0002) /* SMBus Mode */
+#define I2C_CTLR1_SMBTYPE                       ((uint16_t)0x0008) /* SMBus Type */
+#define I2C_CTLR1_ENARP                         ((uint16_t)0x0010) /* ARP Enable */
+#define I2C_CTLR1_ENPEC                         ((uint16_t)0x0020) /* PEC Enable */
+#define I2C_CTLR1_ENGC                          ((uint16_t)0x0040) /* General Call Enable */
+#define I2C_CTLR1_NOSTRETCH                     ((uint16_t)0x0080) /* Clock Stretching Disable (Slave mode) */
+#define I2C_CTLR1_START                         ((uint16_t)0x0100) /* Start Generation */
+#define I2C_CTLR1_STOP                          ((uint16_t)0x0200) /* Stop Generation */
+#define I2C_CTLR1_ACK                           ((uint16_t)0x0400) /* Acknowledge Enable */
+#define I2C_CTLR1_POS                           ((uint16_t)0x0800) /* Acknowledge/PEC Position (for data reception) */
+#define I2C_CTLR1_PEC                           ((uint16_t)0x1000) /* Packet Error Checking */
+#define I2C_CTLR1_ALERT                         ((uint16_t)0x2000) /* SMBus Alert */
+#define I2C_CTLR1_SWRST                         ((uint16_t)0x8000) /* Software Reset */
+
+/*******************  Bit definition for I2C_CTLR2 register  ********************/
+#define I2C_CTLR2_FREQ                          ((uint16_t)0x003F) /* FREQ[5:0] bits (Peripheral Clock Frequency) */
+#define I2C_CTLR2_FREQ_0                        ((uint16_t)0x0001) /* Bit 0 */
+#define I2C_CTLR2_FREQ_1                        ((uint16_t)0x0002) /* Bit 1 */
+#define I2C_CTLR2_FREQ_2                        ((uint16_t)0x0004) /* Bit 2 */
+#define I2C_CTLR2_FREQ_3                        ((uint16_t)0x0008) /* Bit 3 */
+#define I2C_CTLR2_FREQ_4                        ((uint16_t)0x0010) /* Bit 4 */
+#define I2C_CTLR2_FREQ_5                        ((uint16_t)0x0020) /* Bit 5 */
+
+#define I2C_CTLR2_ITERREN                       ((uint16_t)0x0100) /* Error Interrupt Enable */
+#define I2C_CTLR2_ITEVTEN                       ((uint16_t)0x0200) /* Event Interrupt Enable */
+#define I2C_CTLR2_ITBUFEN                       ((uint16_t)0x0400) /* Buffer Interrupt Enable */
+#define I2C_CTLR2_DMAEN                         ((uint16_t)0x0800) /* DMA Requests Enable */
+#define I2C_CTLR2_LAST                          ((uint16_t)0x1000) /* DMA Last Transfer */
+
+/*******************  Bit definition for I2C_OADDR1 register  *******************/
+#define I2C_OADDR1_ADD1_7                       ((uint16_t)0x00FE) /* Interface Address */
+#define I2C_OADDR1_ADD8_9                       ((uint16_t)0x0300) /* Interface Address */
+
+#define I2C_OADDR1_ADD0                         ((uint16_t)0x0001) /* Bit 0 */
+#define I2C_OADDR1_ADD1                         ((uint16_t)0x0002) /* Bit 1 */
+#define I2C_OADDR1_ADD2                         ((uint16_t)0x0004) /* Bit 2 */
+#define I2C_OADDR1_ADD3                         ((uint16_t)0x0008) /* Bit 3 */
+#define I2C_OADDR1_ADD4                         ((uint16_t)0x0010) /* Bit 4 */
+#define I2C_OADDR1_ADD5                         ((uint16_t)0x0020) /* Bit 5 */
+#define I2C_OADDR1_ADD6                         ((uint16_t)0x0040) /* Bit 6 */
+#define I2C_OADDR1_ADD7                         ((uint16_t)0x0080) /* Bit 7 */
+#define I2C_OADDR1_ADD8                         ((uint16_t)0x0100) /* Bit 8 */
+#define I2C_OADDR1_ADD9                         ((uint16_t)0x0200) /* Bit 9 */
+
+#define I2C_OADDR1_ADDMODE                      ((uint16_t)0x8000) /* Addressing Mode (Slave mode) */
+
+/*******************  Bit definition for I2C_OADDR2 register  *******************/
+#define I2C_OADDR2_ENDUAL                       ((uint8_t)0x01) /* Dual addressing mode enable */
+#define I2C_OADDR2_ADD2                         ((uint8_t)0xFE) /* Interface address */
+
+/********************  Bit definition for I2C_DATAR register  ********************/
+#define I2C_DR_DATAR                            ((uint8_t)0xFF) /* 8-bit Data Register */
+
+/*******************  Bit definition for I2C_STAR1 register  ********************/
+#define I2C_STAR1_SB                            ((uint16_t)0x0001) /* Start Bit (Master mode) */
+#define I2C_STAR1_ADDR                          ((uint16_t)0x0002) /* Address sent (master mode)/matched (slave mode) */
+#define I2C_STAR1_BTF                           ((uint16_t)0x0004) /* Byte Transfer Finished */
+#define I2C_STAR1_ADD10                         ((uint16_t)0x0008) /* 10-bit header sent (Master mode) */
+#define I2C_STAR1_STOPF                         ((uint16_t)0x0010) /* Stop detection (Slave mode) */
+#define I2C_STAR1_RXNE                          ((uint16_t)0x0040) /* Data Register not Empty (receivers) */
+#define I2C_STAR1_TXE                           ((uint16_t)0x0080) /* Data Register Empty (transmitters) */
+#define I2C_STAR1_BERR                          ((uint16_t)0x0100) /* Bus Error */
+#define I2C_STAR1_ARLO                          ((uint16_t)0x0200) /* Arbitration Lost (master mode) */
+#define I2C_STAR1_AF                            ((uint16_t)0x0400) /* Acknowledge Failure */
+#define I2C_STAR1_OVR                           ((uint16_t)0x0800) /* Overrun/Underrun */
+#define I2C_STAR1_PECERR                        ((uint16_t)0x1000) /* PEC Error in reception */
+#define I2C_STAR1_TIMEOUT                       ((uint16_t)0x4000) /* Timeout or Tlow Error */
+#define I2C_STAR1_SMBALERT                      ((uint16_t)0x8000) /* SMBus Alert */
+
+/*******************  Bit definition for I2C_STAR2 register  ********************/
+#define I2C_STAR2_MSL                           ((uint16_t)0x0001) /* Master/Slave */
+#define I2C_STAR2_BUSY                          ((uint16_t)0x0002) /* Bus Busy */
+#define I2C_STAR2_TRA                           ((uint16_t)0x0004) /* Transmitter/Receiver */
+#define I2C_STAR2_GENCALL                       ((uint16_t)0x0010) /* General Call Address (Slave mode) */
+#define I2C_STAR2_SMBDEFAULT                    ((uint16_t)0x0020) /* SMBus Device Default Address (Slave mode) */
+#define I2C_STAR2_SMBHOST                       ((uint16_t)0x0040) /* SMBus Host Header (Slave mode) */
+#define I2C_STAR2_DUALF                         ((uint16_t)0x0080) /* Dual Flag (Slave mode) */
+#define I2C_STAR2_PEC                           ((uint16_t)0xFF00) /* Packet Error Checking Register */
+
+/*******************  Bit definition for I2C_CKCFGR register  ********************/
+#define I2C_CKCFGR_CCR                          ((uint16_t)0x0FFF) /* Clock Control Register in Fast/Standard mode (Master mode) */
+#define I2C_CKCFGR_DUTY                         ((uint16_t)0x4000) /* Fast Mode Duty Cycle */
+#define I2C_CKCFGR_FS                           ((uint16_t)0x8000) /* I2C Master Mode Selection */
+
+
+/******************************************************************************/
+/*                             Power Control                                  */
+/******************************************************************************/
+
+/********************  Bit definition for PWR_CTLR register  ********************/
+#define PWR_CTLR_LPDS                           ((uint16_t)0x0001) /* Low-Power Deepsleep */
+#define PWR_CTLR_PDDS                           ((uint16_t)0x0002) /* Power Down Deepsleep */
+#define PWR_CTLR_CWUF                           ((uint16_t)0x0004) /* Clear Wakeup Flag */
+#define PWR_CTLR_CSBF                           ((uint16_t)0x0008) /* Clear Standby Flag */
+#define PWR_CTLR_PVDE                           ((uint16_t)0x0010) /* Power Voltage Detector Enable */
+
+#define PWR_CTLR_PLS                            ((uint16_t)0x00E0) /* PLS[2:0] bits (PVD Level Selection) */
+#define PWR_CTLR_PLS_0                          ((uint16_t)0x0020) /* Bit 0 */
+#define PWR_CTLR_PLS_1                          ((uint16_t)0x0040) /* Bit 1 */
+#define PWR_CTLR_PLS_2                          ((uint16_t)0x0080) /* Bit 2 */
+
+#define PWR_CTLR_PLS_MODE0                      ((uint16_t)0x0000) /* PVD level 0 */
+#define PWR_CTLR_PLS_MODE1                      ((uint16_t)0x0020) /* PVD level 1 */
+#define PWR_CTLR_PLS_MODE2                      ((uint16_t)0x0040) /* PVD level 2 */
+#define PWR_CTLR_PLS_MODE3                      ((uint16_t)0x0060) /* PVD level 3 */
+
+#define PWR_CTLR_DBP                            ((uint16_t)0x0100) /* Disable Backup Domain write protection */
+
+#define PWR_CTLR_LP_REG                         ((uint16_t)0x0200) /* Software configure flash into lower energy mode */
+#define PWR_CTLR_LP                             ((uint16_t)0x0C00) /* Software configure flash Status */
+#define PWR_CTLR_LP_0                           ((uint16_t)0x0400)
+#define PWR_CTLR_LP_1                           ((uint16_t)0x0800)
+
+/*******************  Bit definition for PWR_CSR register  ********************/
+#define PWR_CSR_WUF                             ((uint16_t)0x0001) /* Wakeup Flag */
+#define PWR_CSR_SBF                             ((uint16_t)0x0002) /* Standby Flag */
+#define PWR_CSR_PVDO                            ((uint16_t)0x0004) /* PVD Output */
+#define PWR_CSR_EWUP                            ((uint16_t)0x0100) /* Enable WKUP pin */
+#define PWR_CSR_Flash_ack                       ((uint16_t)0x0200) /* Flash Status */
+
+/******************************************************************************/
+/*                         Reset and Clock Control                            */
+/******************************************************************************/
+
+/********************  Bit definition for RCC_CTLR register  ********************/
+#define RCC_HSION                               ((uint32_t)0x00000001) /* Internal High Speed clock enable */
+#define RCC_HSIRDY                              ((uint32_t)0x00000002) /* Internal High Speed clock ready flag */
+#define RCC_HSITRIM                             ((uint32_t)0x000000F8) /* Internal High Speed clock trimming [7:3] */
+#define RCC_HSICAL                              ((uint32_t)0x0000FF00) /* Internal High Speed clock Calibration [15:8] */
+#define RCC_HSEON                               ((uint32_t)0x00010000) /* External High Speed clock enable */
+#define RCC_HSERDY                              ((uint32_t)0x00020000) /* External High Speed clock ready flag */
+#define RCC_HSEBYP                              ((uint32_t)0x00040000) /* External High Speed clock Bypass */
+/* CSSON does not exist on M030 — removed */
+#define RCC_PLLON                               ((uint32_t)0x01000000) /* PLL enable (bit 24) */
+#define RCC_PLLRDY                              ((uint32_t)0x02000000) /* PLL clock ready flag (bit 25) */
+
+
+/*******************  Bit definition for RCC_CFGR0 register  *******************/
+/* System clock switch SW[1:0] */
+#define RCC_SW                                  ((uint32_t)0x00000003)
+#define RCC_SW_0                                ((uint32_t)0x00000001)
+#define RCC_SW_1                                ((uint32_t)0x00000002)
+
+#define RCC_SW_HSI                              ((uint32_t)0x00000000) /* HSI selected as system clock */
+#define RCC_SW_HSE                              ((uint32_t)0x00000001) /* HSE selected as system clock */
+#define RCC_SW_PLL                              ((uint32_t)0x00000002) /* PLL selected as system clock */
+
+/* System clock switch status SWS[3:2] */
+#define RCC_SWS                                 ((uint32_t)0x0000000C)
+#define RCC_SWS_0                               ((uint32_t)0x00000004)
+#define RCC_SWS_1                               ((uint32_t)0x00000008)
+
+#define RCC_SWS_HSI                             ((uint32_t)0x00000000) /* HSI used as system clock */
+#define RCC_SWS_HSE                             ((uint32_t)0x00000004) /* HSE used as system clock */
+#define RCC_SWS_PLL                             ((uint32_t)0x00000008) /* PLL used as system clock */
+
+/* HB clock source prescaler HPRE[10:4] — M030 has 7-bit HPRE, not X035's 4-bit.
+   Encoding: 0000000=/1, 0000001=/2, 0000010=/3, ... 1111111=/128 (per RM 3.4.2). */
+#define RCC_HPRE                                ((uint32_t)0x000007F0) /* HPRE[6:0] field mask */
+#define RCC_HPRE_DIV1                           ((uint32_t)0x00000000) /* SYSCLK not divided */
+#define RCC_HPRE_DIV2                           ((uint32_t)0x00000010) /* SYSCLK divided by 2 */
+#define RCC_HPRE_DIV3                           ((uint32_t)0x00000020) /* SYSCLK divided by 3 */
+#define RCC_HPRE_DIV4                           ((uint32_t)0x00000030) /* SYSCLK divided by 4 */
+#define RCC_HPRE_DIV8                           ((uint32_t)0x00000070) /* SYSCLK divided by 8 */
+#define RCC_HPRE_DIV16                          ((uint32_t)0x000000F0) /* SYSCLK divided by 16 */
+#define RCC_HPRE_DIV32                          ((uint32_t)0x000001F0) /* SYSCLK divided by 32 */
+#define RCC_HPRE_DIV64                          ((uint32_t)0x000003F0) /* SYSCLK divided by 64 */
+#define RCC_HPRE_DIV128                         ((uint32_t)0x000007F0) /* SYSCLK divided by 128 */
+
+/* M030 has NO PPRE1 / PPRE2 fields — APB1 and APB2 buses run at HCLK on this chip.
+   The X035-style RCC_PPRE1_xxx and RCC_PPRE2_xxx defines are deliberately omitted. */
+
+/* ADC clock source prescaler ADCPRE[15:11] — M030 has 5-bit ADCPRE, not X035's 2-bit.
+   Only a subset of encodings are commonly used; see RM 3.4.2 for full table. */
+#define RCC_ADCPRE                              ((uint32_t)0x0000F800) /* ADCPRE[4:0] field mask */
+#define RCC_ADCPRE_DIV2                         ((uint32_t)0x00000000) /* HB/2 */
+#define RCC_ADCPRE_DIV4                         ((uint32_t)0x00002000) /* HB/4  (encoding 00100b << 11) */
+#define RCC_ADCPRE_DIV6                         ((uint32_t)0x00004000) /* HB/6  (encoding 01000b << 11) */
+#define RCC_ADCPRE_DIV8                         ((uint32_t)0x00006000) /* HB/8  (encoding 01100b << 11) */
+#define RCC_ADCPRE_DIV12                        ((uint32_t)0x0000A000) /* HB/12 (encoding 10100b << 11) */
+#define RCC_ADCPRE_DIV16                        ((uint32_t)0x0000E000) /* HB/16 (encoding 11100b << 11) */
+
+/* PLL entry clock source */
+#define RCC_PLLSRC                              ((uint32_t)0x00010000) /* PLLSRC bit 16: 1=HSE, 0=HSI */
+
+/* M030 PLL has a FIXED multiplier (not user-programmable). The X035-style
+   RCC_PLLMULL, RCC_PLLMULL2..16, RCC_PLLXTPRE, RCC_USBPRE defines do not apply
+   and are deliberately omitted. SYSCLK target is 72 MHz from 8 MHz HSI (see RM
+   clock-tree diagram); the multiplier is selected internally by the chip. */
+
+/* MCO[2:0] microcontroller clock output */
+#define RCC_CFGR0_MCO                           ((uint32_t)0x07000000) /* MCO[26:24] mask */
+#define RCC_MCO_0                               ((uint32_t)0x01000000)
+#define RCC_MCO_1                               ((uint32_t)0x02000000)
+#define RCC_MCO_2                               ((uint32_t)0x04000000)
+
+#define RCC_MCO_NOCLOCK                         ((uint32_t)0x00000000) /* 0xx: no clock output */
+#define RCC_CFGR0_MCO_SYSCLK                    ((uint32_t)0x04000000) /* 100: SYSCLK output */
+#define RCC_CFGR0_MCO_HSI                       ((uint32_t)0x05000000) /* 101: HSI output */
+#define RCC_CFGR0_MCO_HSE                       ((uint32_t)0x06000000) /* 110: HSE output */
+/* 111 is Reserved on M030 (X035 used it for PLL/2 output) */
+
+/* ADC clock duty-cycle select (M030-only addition vs X035 CFGR0) */
+#define RCC_ADC_DUTY_SEL                        ((uint32_t)0x10000000) /* bit 28: 1=75% duty, 0=50% */
+
+
+/*******************  Bit definition for RCC_INTR register  ********************/
+/* M030 has no LSE crystal — LSE flag/IE/clear bits are NOT defined */
+#define RCC_LSIRDYF                             ((uint32_t)0x00000001) /* LSI Ready Interrupt flag */
+#define RCC_HSIRDYF                             ((uint32_t)0x00000004) /* HSI Ready Interrupt flag */
+#define RCC_HSERDYF                             ((uint32_t)0x00000008) /* HSE Ready Interrupt flag */
+#define RCC_PLLRDYF                             ((uint32_t)0x00000010) /* PLL Ready Interrupt flag */
+#define RCC_LSIRDYIE                            ((uint32_t)0x00000100) /* LSI Ready Interrupt Enable */
+#define RCC_HSIRDYIE                            ((uint32_t)0x00000400) /* HSI Ready Interrupt Enable */
+#define RCC_HSERDYIE                            ((uint32_t)0x00000800) /* HSE Ready Interrupt Enable */
+#define RCC_PLLRDYIE                            ((uint32_t)0x00001000) /* PLL Ready Interrupt Enable */
+#define RCC_LSIRDYC                             ((uint32_t)0x00010000) /* LSI Ready Interrupt Clear */
+#define RCC_HSIRDYC                             ((uint32_t)0x00040000) /* HSI Ready Interrupt Clear */
+#define RCC_HSERDYC                             ((uint32_t)0x00080000) /* HSE Ready Interrupt Clear */
+#define RCC_PLLRDYC                             ((uint32_t)0x00100000) /* PLL Ready Interrupt Clear */
+
+
+/*****************  Bit definition for RCC_PB2PRSTR register  *****************/
+/* (M030 RM calls this PB2PRSTR; the struct field stays named APB2PRSTR for X035 compat) */
+#define RCC_AFIORST                             ((uint32_t)0x00000001) /* AFIO reset, bit 0 */
+#define RCC_IOPARST                             ((uint32_t)0x00000004) /* GPIOA reset, bit 2 */
+#define RCC_IOPBRST                             ((uint32_t)0x00000008) /* GPIOB reset, bit 3 */
+#define RCC_IOPCRST                             ((uint32_t)0x00000010) /* GPIOC reset, bit 4 */
+#define RCC_ADC1RST                             ((uint32_t)0x00000200) /* ADC1 reset, bit 9 */
+#define RCC_TIM1RST                             ((uint32_t)0x00000800) /* TIM1 reset, bit 11 */
+#define RCC_SPI1RST                             ((uint32_t)0x00001000) /* SPI1 reset, bit 12 */
+#define RCC_USART1RST                           ((uint32_t)0x00004000) /* UART1 reset, bit 14 */
+#define RCC_UART1RST                            RCC_USART1RST          /* Alias matching M030 RM */
+/* Removed (not present on M030): IOPDRST, IOPERST, ADC2RST */
+
+
+/*****************  Bit definition for RCC_PB1PRSTR register  *****************/
+/* (M030 RM calls this PB1PRSTR; struct field stays named APB1PRSTR for X035 compat) */
+#define RCC_TIM2RST                             ((uint32_t)0x00000001) /* TIM2 reset, bit 0 */
+#define RCC_TIM3RST                             ((uint32_t)0x00000002) /* TIM3 reset, bit 1 */
+#define RCC_WWDGRST                             ((uint32_t)0x00000800) /* WWDG reset, bit 11 */
+#define RCC_I2C1RST                             ((uint32_t)0x00200000) /* I2C1 reset, bit 21 */
+#define RCC_PWRRST                              ((uint32_t)0x10000000) /* PWR reset, bit 28 */
+/* Removed (not present on M030): USART2/3/4 RST, CAN1RST, BKPRST,
+   TIM4RST (bit 2 collides with TIM3RST!), SPI2RST, I2C2RST, USBRST */
+
+
+/******************  Bit definition for RCC_AHBPCENR register  ******************/
+#define RCC_DMA1EN                              ((uint32_t)0x00000001) /* DMA1 clock enable, bit 0 */
+#define RCC_SRAMEN                              ((uint32_t)0x00000004) /* SRAM interface clock enable, bit 2 */
+#define RCC_USBFSEN                             ((uint32_t)0x00000008) /* USBFS clock enable, bit 3 */
+#define RCC_USBFS                               RCC_USBFSEN            /* Alias kept for source compat */
+#define RCC_USBPD0EN                            ((uint32_t)0x00000010) /* USBPD0 clock enable, bit 4 */
+#define RCC_USBPD1EN                            ((uint32_t)0x00000020) /* USBPD1 clock enable, bit 5 */
+#define RCC_OPAEN                               ((uint32_t)0x00000080) /* OPA/CMP block clock enable, bit 7 */
+/* Removed (not present on M030): FLITFEN, CRCEN, USBHD, single USBPD bit */
+
+
+/******************  Bit definition for RCC_PB2PCENR register  *****************/
+/* (M030 RM calls this PB2PCENR; struct field stays APB2PCENR for X035 compat) */
+#define RCC_AFIOEN                              ((uint32_t)0x00000001) /* AFIO clock enable, bit 0 */
+#define RCC_IOPAEN                              ((uint32_t)0x00000004) /* GPIOA clock enable, bit 2 */
+#define RCC_IOPBEN                              ((uint32_t)0x00000008) /* GPIOB clock enable, bit 3 */
+#define RCC_IOPCEN                              ((uint32_t)0x00000010) /* GPIOC clock enable, bit 4 */
+#define RCC_ADC1EN                              ((uint32_t)0x00000200) /* ADC1 clock enable, bit 9 */
+#define RCC_TIM1EN                              ((uint32_t)0x00000800) /* TIM1 clock enable, bit 11 */
+#define RCC_SPI1EN                              ((uint32_t)0x00001000) /* SPI1 clock enable, bit 12 */
+#define RCC_USART1EN                            ((uint32_t)0x00004000) /* UART1 clock enable, bit 14 */
+#define RCC_UART1EN                             RCC_USART1EN           /* Alias matching M030 RM */
+/* Removed (not present on M030): IOPDEN, ADC2EN */
+
+
+/*****************  Bit definition for RCC_PB1PCENR register  ******************/
+/* (M030 RM calls this PB1PCENR; struct field stays APB1PCENR for X035 compat) */
+#define RCC_TIM2EN                              ((uint32_t)0x00000001) /* TIM2 clock enable, bit 0 */
+#define RCC_TIM3EN                              ((uint32_t)0x00000002) /* TIM3 clock enable, bit 1 */
+#define RCC_WWDGEN                              ((uint32_t)0x00000800) /* WWDG clock enable, bit 11 */
+#define RCC_I2C1EN                              ((uint32_t)0x00200000) /* I2C1 clock enable, bit 21 */
+#define RCC_PWREN                               ((uint32_t)0x10000000) /* PWR clock enable, bit 28 */
+/* Removed (not present on M030): USART2/3/4 EN, BKPEN, USBEN */
+
+
+/*******************  Bit definition for RCC_RSTSCKR register  ********************/
+#define RCC_LSION                               ((uint32_t)0x00000001) /* LSI enable, bit 0 */
+#define RCC_LSIRDY                              ((uint32_t)0x00000002) /* LSI ready flag, bit 1 */
+#define RCC_USBPD0RSTF                          ((uint32_t)0x00400000) /* USBPD0 reset flag, bit 22 */
+#define RCC_USBPD1RSTF                          ((uint32_t)0x00800000) /* USBPD1 reset flag, bit 23 */
+#define RCC_RMVF                                ((uint32_t)0x01000000) /* Clear reset flags, bit 24 */
+#define RCC_ADC_AWDRSTF                         ((uint32_t)0x02000000) /* ADC analog watchdog reset flag, bit 25 */
+#define RCC_PINRSTF                             ((uint32_t)0x04000000) /* NRST pin reset flag, bit 26 */
+#define RCC_PORRSTF                             ((uint32_t)0x08000000) /* POR/PDR reset flag, bit 27 */
+#define RCC_SFTRSTF                             ((uint32_t)0x10000000) /* Software reset flag, bit 28 */
+#define RCC_WWDGRSTF                            ((uint32_t)0x40000000) /* Window watchdog reset flag, bit 30 */
+#define RCC_LPWRRSTF                            ((uint32_t)0x80000000) /* Low-power reset flag, bit 31 */
+/* Removed (not present on M030): OPARSTF (was bit 25, M030 reuses bit 25 for ADC_AWDRSTF),
+   IWDGRSTF (M030 has no IWDG) */
+
+
+/******************  Bit definition for RCC_AHBRSTR register  *****************/
+#define RCC_USBFSRST                            ((uint32_t)0x00000008) /* USBFS reset, bit 3 */
+#define RCC_USBPD0RST                           ((uint32_t)0x00000010) /* USBPD0 reset, bit 4 */
+#define RCC_USBPD1RST                           ((uint32_t)0x00000020) /* USBPD1 reset, bit 5 */
+#define RCC_OPARST                              ((uint32_t)0x00000080) /* OPA/CMP reset, bit 7 */
+/* Removed (not present on M030): PIOCRST, single USBPDRST */
+
+/******************************************************************************/
+/*                        Serial Peripheral Interface                         */
+/******************************************************************************/
+
+/*******************  Bit definition for SPI_CTLR1 register  ********************/
+#define SPI_CTLR1_CPHA                          ((uint16_t)0x0001) /* Clock Phase */
+#define SPI_CTLR1_CPOL                          ((uint16_t)0x0002) /* Clock Polarity */
+#define SPI_CTLR1_MSTR                          ((uint16_t)0x0004) /* Master Selection */
+
+#define SPI_CTLR1_BR                            ((uint16_t)0x0038) /* BR[2:0] bits (Baud Rate Control) */
+#define SPI_CTLR1_BR_0                          ((uint16_t)0x0008) /* Bit 0 */
+#define SPI_CTLR1_BR_1                          ((uint16_t)0x0010) /* Bit 1 */
+#define SPI_CTLR1_BR_2                          ((uint16_t)0x0020) /* Bit 2 */
+
+#define SPI_CTLR1_SPE                           ((uint16_t)0x0040) /* SPI Enable */
+#define SPI_CTLR1_LSBFIRST                      ((uint16_t)0x0080) /* Frame Format */
+#define SPI_CTLR1_SSI                           ((uint16_t)0x0100) /* Internal slave select */
+#define SPI_CTLR1_SSM                           ((uint16_t)0x0200) /* Software slave management */
+#define SPI_CTLR1_RXONLY                        ((uint16_t)0x0400) /* Receive only */
+#define SPI_CTLR1_DFF                           ((uint16_t)0x0800) /* Data Frame Format */
+#define SPI_CTLR1_CRCNEXT                       ((uint16_t)0x1000) /* Transmit CRC next */
+#define SPI_CTLR1_CRCEN                         ((uint16_t)0x2000) /* Hardware CRC calculation enable */
+#define SPI_CTLR1_BIDIOE                        ((uint16_t)0x4000) /* Output enable in bidirectional mode */
+#define SPI_CTLR1_BIDIMODE                      ((uint16_t)0x8000) /* Bidirectional data mode enable */
+
+/*******************  Bit definition for SPI_CTLR2 register  ********************/
+#define SPI_CTLR2_RXDMAEN                       ((uint8_t)0x01) /* Rx Buffer DMA Enable */
+#define SPI_CTLR2_TXDMAEN                       ((uint8_t)0x02) /* Tx Buffer DMA Enable */
+#define SPI_CTLR2_SSOE                          ((uint8_t)0x04) /* SS Output Enable */
+#define SPI_CTLR2_ERRIE                         ((uint8_t)0x20) /* Error Interrupt Enable */
+#define SPI_CTLR2_RXNEIE                        ((uint8_t)0x40) /* RX buffer Not Empty Interrupt Enable */
+#define SPI_CTLR2_TXEIE                         ((uint8_t)0x80) /* Tx buffer Empty Interrupt Enable */
+#define SPI_CTLR2_ODEN                          ((uint16_t)0x8000) /* SPI OD output Enable */
+
+/********************  Bit definition for SPI_STATR register  ********************/
+#define SPI_STATR_RXNE                          ((uint8_t)0x01) /* Receive buffer Not Empty */
+#define SPI_STATR_TXE                           ((uint8_t)0x02) /* Transmit buffer Empty */
+#define SPI_STATR_CHSIDE                        ((uint8_t)0x04) /* Channel side */
+#define SPI_STATR_UDR                           ((uint8_t)0x08) /* Underrun flag */
+#define SPI_STATR_CRCERR                        ((uint8_t)0x10) /* CRC Error flag */
+#define SPI_STATR_MODF                          ((uint8_t)0x20) /* Mode fault */
+#define SPI_STATR_OVR                           ((uint8_t)0x40) /* Overrun flag */
+#define SPI_STATR_BSY                           ((uint8_t)0x80) /* Busy flag */
+
+/********************  Bit definition for SPI_DATAR register  ********************/
+#define SPI_DATAR_DR                            ((uint16_t)0xFFFF) /* Data Register */
+
+/*******************  Bit definition for SPI_CRCR register  ******************/
+#define SPI_CRCR_CRCPOLY                        ((uint16_t)0xFFFF) /* CRC polynomial register */
+
+/******************  Bit definition for SPI_RCRCR register  ******************/
+#define SPI_RCRCR_RXCRC                         ((uint16_t)0xFFFF) /* Rx CRC Register */
+
+/******************  Bit definition for SPI_TCRCR register  ******************/
+#define SPI_TCRCR_TXCRC                         ((uint16_t)0xFFFF) /* Tx CRC Register */
+
+/******************  Bit definition for SPI_HSCR register  *****************/
+#define SPI_HSCR_HSRXEN                         ((uint16_t)0x0001) /* Read Enable under SPI High speed mode */
+
+/******************************************************************************/
+/*                                    TIM                                     */
+/******************************************************************************/
+
+/*******************  Bit definition for TIM_CTLR1 register  ********************/
+#define TIM_CEN                                 ((uint16_t)0x0001) /* Counter enable */
+#define TIM_UDIS                                ((uint16_t)0x0002) /* Update disable */
+#define TIM_URS                                 ((uint16_t)0x0004) /* Update request source */
+#define TIM_OPM                                 ((uint16_t)0x0008) /* One pulse mode */
+#define TIM_DIR                                 ((uint16_t)0x0010) /* Direction */
+
+#define TIM_CMS                                 ((uint16_t)0x0060) /* CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CMS_0                               ((uint16_t)0x0020) /* Bit 0 */
+#define TIM_CMS_1                               ((uint16_t)0x0040) /* Bit 1 */
+
+#define TIM_ARPE                                ((uint16_t)0x0080) /* Auto-reload preload enable */
+
+#define TIM_CTLR1_CKD                           ((uint16_t)0x0300) /* CKD[1:0] bits (clock division) */
+#define TIM_CKD_0                               ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_CKD_1                               ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_CMP_BK                              ((uint16_t)0x1000) /* voltage comparator break enable, TIM1 only */
+#define TIM_CAPOV                               ((uint16_t)0x4000) /* Cfg mode of capture value */
+#define TIM_CAPLVL                              ((uint16_t)0x8000) 
+
+/*******************  Bit definition for TIM_CTLR2 register  ********************/
+#define TIM_CCPC                                ((uint16_t)0x0001) /* Capture/Compare Preloaded Control */
+#define TIM_CCUS                                ((uint16_t)0x0004) /* Capture/Compare Control Update Selection */
+#define TIM_CCDS                                ((uint16_t)0x0008) /* Capture/Compare DMA Selection */
+
+#define TIM_MMS                                 ((uint16_t)0x0070) /* MMS[2:0] bits (Master Mode Selection) */
+#define TIM_MMS_0                               ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_MMS_1                               ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_MMS_2                               ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_TI1S                                ((uint16_t)0x0080) /* TI1 Selection */
+#define TIM_OIS1                                ((uint16_t)0x0100) /* Output Idle state 1 (OC1 output) */
+#define TIM_OIS1N                               ((uint16_t)0x0200) /* Output Idle state 1 (OC1N output) */
+#define TIM_OIS2                                ((uint16_t)0x0400) /* Output Idle state 2 (OC2 output) */
+#define TIM_OIS2N                               ((uint16_t)0x0800) /* Output Idle state 2 (OC2N output) */
+#define TIM_OIS3                                ((uint16_t)0x1000) /* Output Idle state 3 (OC3 output) */
+#define TIM_OIS3N                               ((uint16_t)0x2000) /* Output Idle state 3 (OC3N output) */
+#define TIM_OIS4                                ((uint16_t)0x4000) /* Output Idle state 4 (OC4 output) */
+
+/*******************  Bit definition for TIM_SMCFGR register  *******************/
+#define TIM_SMS                                 ((uint16_t)0x0007) /* SMS[2:0] bits (Slave mode selection) */
+#define TIM_SMS_0                               ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_SMS_1                               ((uint16_t)0x0002) /* Bit 1 */
+#define TIM_SMS_2                               ((uint16_t)0x0004) /* Bit 2 */
+
+#define TIM_TS                                  ((uint16_t)0x0070) /* TS[2:0] bits (Trigger selection) */
+#define TIM_TS_0                                ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_TS_1                                ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_TS_2                                ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_MSM                                 ((uint16_t)0x0080) /* Master/slave mode */
+
+#define TIM_ETF                                 ((uint16_t)0x0F00) /* ETF[3:0] bits (External trigger filter) */
+#define TIM_ETF_0                               ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_ETF_1                               ((uint16_t)0x0200) /* Bit 1 */
+#define TIM_ETF_2                               ((uint16_t)0x0400) /* Bit 2 */
+#define TIM_ETF_3                               ((uint16_t)0x0800) /* Bit 3 */
+
+#define TIM_ETPS                                ((uint16_t)0x3000) /* ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_ETPS_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_ETPS_1                              ((uint16_t)0x2000) /* Bit 1 */
+
+#define TIM_ECE                                 ((uint16_t)0x4000) /* External clock enable */
+#define TIM_ETP                                 ((uint16_t)0x8000) /* External trigger polarity */
+
+/*******************  Bit definition for TIM_DMAINTENR register  *******************/
+#define TIM_UIE                                 ((uint16_t)0x0001) /* Update interrupt enable */
+#define TIM_CC1IE                               ((uint16_t)0x0002) /* Capture/Compare 1 interrupt enable */
+#define TIM_CC2IE                               ((uint16_t)0x0004) /* Capture/Compare 2 interrupt enable */
+#define TIM_CC3IE                               ((uint16_t)0x0008) /* Capture/Compare 3 interrupt enable */
+#define TIM_CC4IE                               ((uint16_t)0x0010) /* Capture/Compare 4 interrupt enable */
+#define TIM_COMIE                               ((uint16_t)0x0020) /* COM interrupt enable */
+#define TIM_TIE                                 ((uint16_t)0x0040) /* Trigger interrupt enable */
+#define TIM_BIE                                 ((uint16_t)0x0080) /* Break interrupt enable */
+#define TIM_UDE                                 ((uint16_t)0x0100) /* Update DMA request enable */
+#define TIM_CC1DE                               ((uint16_t)0x0200) /* Capture/Compare 1 DMA request enable */
+#define TIM_CC2DE                               ((uint16_t)0x0400) /* Capture/Compare 2 DMA request enable */
+#define TIM_CC3DE                               ((uint16_t)0x0800) /* Capture/Compare 3 DMA request enable */
+#define TIM_CC4DE                               ((uint16_t)0x1000) /* Capture/Compare 4 DMA request enable */
+#define TIM_COMDE                               ((uint16_t)0x2000) /* COM DMA request enable */
+#define TIM_TDE                                 ((uint16_t)0x4000) /* Trigger DMA request enable */
+
+/********************  Bit definition for TIM_INTFR register  ********************/
+#define TIM_UIF                                 ((uint16_t)0x0001) /* Update interrupt Flag */
+#define TIM_CC1IF                               ((uint16_t)0x0002) /* Capture/Compare 1 interrupt Flag */
+#define TIM_CC2IF                               ((uint16_t)0x0004) /* Capture/Compare 2 interrupt Flag */
+#define TIM_CC3IF                               ((uint16_t)0x0008) /* Capture/Compare 3 interrupt Flag */
+#define TIM_CC4IF                               ((uint16_t)0x0010) /* Capture/Compare 4 interrupt Flag */
+#define TIM_COMIF                               ((uint16_t)0x0020) /* COM interrupt Flag */
+#define TIM_TIF                                 ((uint16_t)0x0040) /* Trigger interrupt Flag */
+#define TIM_BIF                                 ((uint16_t)0x0080) /* Break interrupt Flag */
+#define TIM_CC1OF                               ((uint16_t)0x0200) /* Capture/Compare 1 Overcapture Flag */
+#define TIM_CC2OF                               ((uint16_t)0x0400) /* Capture/Compare 2 Overcapture Flag */
+#define TIM_CC3OF                               ((uint16_t)0x0800) /* Capture/Compare 3 Overcapture Flag */
+#define TIM_CC4OF                               ((uint16_t)0x1000) /* Capture/Compare 4 Overcapture Flag */
+
+/*******************  Bit definition for TIM_SWEVGR register  ********************/
+#define TIM_UG                                  ((uint8_t)0x01) /* Update Generation */
+#define TIM_CC1G                                ((uint8_t)0x02) /* Capture/Compare 1 Generation */
+#define TIM_CC2G                                ((uint8_t)0x04) /* Capture/Compare 2 Generation */
+#define TIM_CC3G                                ((uint8_t)0x08) /* Capture/Compare 3 Generation */
+#define TIM_CC4G                                ((uint8_t)0x10) /* Capture/Compare 4 Generation */
+#define TIM_COMG                                ((uint8_t)0x20) /* Capture/Compare Control Update Generation */
+#define TIM_TG                                  ((uint8_t)0x40) /* Trigger Generation */
+#define TIM_BG                                  ((uint8_t)0x80) /* Break Generation */
+
+/******************  Bit definition for TIM_CHCTLR1 register  *******************/
+#define TIM_CC1S                                ((uint16_t)0x0003) /* CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CC1S_0                              ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_CC1S_1                              ((uint16_t)0x0002) /* Bit 1 */
+
+#define TIM_OC1FE                               ((uint16_t)0x0004) /* Output Compare 1 Fast enable */
+#define TIM_OC1PE                               ((uint16_t)0x0008) /* Output Compare 1 Preload enable */
+
+#define TIM_OC1M                                ((uint16_t)0x0070) /* OC1M[2:0] bits (Output Compare 1 Mode) */
+#define TIM_OC1M_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_OC1M_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_OC1M_2                              ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_OC1CE                               ((uint16_t)0x0080) /* Output Compare 1Clear Enable */
+
+#define TIM_CC2S                                ((uint16_t)0x0300) /* CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CC2S_0                              ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_CC2S_1                              ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_OC2FE                               ((uint16_t)0x0400) /* Output Compare 2 Fast enable */
+#define TIM_OC2PE                               ((uint16_t)0x0800) /* Output Compare 2 Preload enable */
+
+#define TIM_OC2M                                ((uint16_t)0x7000) /* OC2M[2:0] bits (Output Compare 2 Mode) */
+#define TIM_OC2M_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_OC2M_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_OC2M_2                              ((uint16_t)0x4000) /* Bit 2 */
+
+#define TIM_OC2CE                               ((uint16_t)0x8000) /* Output Compare 2 Clear Enable */
+
+#define TIM_IC1PSC                              ((uint16_t)0x000C) /* IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_IC1PSC_0                            ((uint16_t)0x0004) /* Bit 0 */
+#define TIM_IC1PSC_1                            ((uint16_t)0x0008) /* Bit 1 */
+
+#define TIM_IC1F                                ((uint16_t)0x00F0) /* IC1F[3:0] bits (Input Capture 1 Filter) */
+#define TIM_IC1F_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_IC1F_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_IC1F_2                              ((uint16_t)0x0040) /* Bit 2 */
+#define TIM_IC1F_3                              ((uint16_t)0x0080) /* Bit 3 */
+
+#define TIM_IC2PSC                              ((uint16_t)0x0C00) /* IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define TIM_IC2PSC_0                            ((uint16_t)0x0400) /* Bit 0 */
+#define TIM_IC2PSC_1                            ((uint16_t)0x0800) /* Bit 1 */
+
+#define TIM_IC2F                                ((uint16_t)0xF000) /* IC2F[3:0] bits (Input Capture 2 Filter) */
+#define TIM_IC2F_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_IC2F_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_IC2F_2                              ((uint16_t)0x4000) /* Bit 2 */
+#define TIM_IC2F_3                              ((uint16_t)0x8000) /* Bit 3 */
+
+/******************  Bit definition for TIM_CHCTLR2 register  *******************/
+#define TIM_CC3S                                ((uint16_t)0x0003) /* CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define TIM_CC3S_0                              ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_CC3S_1                              ((uint16_t)0x0002) /* Bit 1 */
+
+#define TIM_OC3FE                               ((uint16_t)0x0004) /* Output Compare 3 Fast enable */
+#define TIM_OC3PE                               ((uint16_t)0x0008) /* Output Compare 3 Preload enable */
+
+#define TIM_OC3M                                ((uint16_t)0x0070) /* OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_OC3M_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_OC3M_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_OC3M_2                              ((uint16_t)0x0040) /* Bit 2 */
+
+#define TIM_OC3CE                               ((uint16_t)0x0080) /* Output Compare 3 Clear Enable */
+
+#define TIM_CC4S                                ((uint16_t)0x0300) /* CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CC4S_0                              ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_CC4S_1                              ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_OC4FE                               ((uint16_t)0x0400) /* Output Compare 4 Fast enable */
+#define TIM_OC4PE                               ((uint16_t)0x0800) /* Output Compare 4 Preload enable */
+
+#define TIM_OC4M                                ((uint16_t)0x7000) /* OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_OC4M_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_OC4M_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_OC4M_2                              ((uint16_t)0x4000) /* Bit 2 */
+
+#define TIM_OC4CE                               ((uint16_t)0x8000) /* Output Compare 4 Clear Enable */
+
+#define TIM_IC3PSC                              ((uint16_t)0x000C) /* IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_IC3PSC_0                            ((uint16_t)0x0004) /* Bit 0 */
+#define TIM_IC3PSC_1                            ((uint16_t)0x0008) /* Bit 1 */
+
+#define TIM_IC3F                                ((uint16_t)0x00F0) /* IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_IC3F_0                              ((uint16_t)0x0010) /* Bit 0 */
+#define TIM_IC3F_1                              ((uint16_t)0x0020) /* Bit 1 */
+#define TIM_IC3F_2                              ((uint16_t)0x0040) /* Bit 2 */
+#define TIM_IC3F_3                              ((uint16_t)0x0080) /* Bit 3 */
+
+#define TIM_IC4PSC                              ((uint16_t)0x0C00) /* IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_IC4PSC_0                            ((uint16_t)0x0400) /* Bit 0 */
+#define TIM_IC4PSC_1                            ((uint16_t)0x0800) /* Bit 1 */
+
+#define TIM_IC4F                                ((uint16_t)0xF000) /* IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_IC4F_0                              ((uint16_t)0x1000) /* Bit 0 */
+#define TIM_IC4F_1                              ((uint16_t)0x2000) /* Bit 1 */
+#define TIM_IC4F_2                              ((uint16_t)0x4000) /* Bit 2 */
+#define TIM_IC4F_3                              ((uint16_t)0x8000) /* Bit 3 */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CC1E                                ((uint16_t)0x0001) /* Capture/Compare 1 output enable */
+#define TIM_CC1P                                ((uint16_t)0x0002) /* Capture/Compare 1 output Polarity */
+#define TIM_CC1NE                               ((uint16_t)0x0004) /* Capture/Compare 1 Complementary output enable */
+#define TIM_CC1NP                               ((uint16_t)0x0008) /* Capture/Compare 1 Complementary output Polarity */
+#define TIM_CC2E                                ((uint16_t)0x0010) /* Capture/Compare 2 output enable */
+#define TIM_CC2P                                ((uint16_t)0x0020) /* Capture/Compare 2 output Polarity */
+#define TIM_CC2NE                               ((uint16_t)0x0040) /* Capture/Compare 2 Complementary output enable */
+#define TIM_CC2NP                               ((uint16_t)0x0080) /* Capture/Compare 2 Complementary output Polarity */
+#define TIM_CC3E                                ((uint16_t)0x0100) /* Capture/Compare 3 output enable */
+#define TIM_CC3P                                ((uint16_t)0x0200) /* Capture/Compare 3 output Polarity */
+#define TIM_CC3NE                               ((uint16_t)0x0400) /* Capture/Compare 3 Complementary output enable */
+#define TIM_CC3NP                               ((uint16_t)0x0800) /* Capture/Compare 3 Complementary output Polarity */
+#define TIM_CC4E                                ((uint16_t)0x1000) /* Capture/Compare 4 output enable */
+#define TIM_CC4P                                ((uint16_t)0x2000) /* Capture/Compare 4 output Polarity */
+#define TIM_CC4NP                               ((uint16_t)0x8000) /* Capture/Compare 4 Complementary output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT                                 ((uint16_t)0xFFFF) /* Counter Value */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC                                 ((uint16_t)0xFFFF) /* Prescaler Value */
+
+/*******************  Bit definition for TIM_ATRLR register  ********************/
+#define TIM_ARR                                 ((uint16_t)0xFFFF) /* actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RPTCR register  ********************/
+#define TIM_REP                                 ((uint8_t)0xFF) /* Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CH1CVR register  *******************/
+#define TIM_CCR1                                ((uint16_t)0xFFFF) /* Capture/Compare 1 Value */
+#define TIM_LEVEL1                              ((uint32_t)0x00010000)
+
+/*******************  Bit definition for TIM_CH2CVR register  *******************/
+#define TIM_CCR2                                ((uint16_t)0xFFFF) /* Capture/Compare 2 Value */
+#define TIM_LEVEL2                              ((uint32_t)0x00010000)
+
+/*******************  Bit definition for TIM_CH3CVR register  *******************/
+#define TIM_CCR3                                ((uint16_t)0xFFFF) /* Capture/Compare 3 Value */
+#define TIM_LEVEL3                              ((uint32_t)0x00010000)
+
+/*******************  Bit definition for TIM_CH4CVR register  *******************/
+#define TIM_CCR4                                ((uint16_t)0xFFFF) /* Capture/Compare 4 Value */
+#define TIM_LEVEL4                              ((uint32_t)0x00010000)
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_DTG                                 ((uint16_t)0x00FF) /* DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_DTG_0                               ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_DTG_1                               ((uint16_t)0x0002) /* Bit 1 */
+#define TIM_DTG_2                               ((uint16_t)0x0004) /* Bit 2 */
+#define TIM_DTG_3                               ((uint16_t)0x0008) /* Bit 3 */
+#define TIM_DTG_4                               ((uint16_t)0x0010) /* Bit 4 */
+#define TIM_DTG_5                               ((uint16_t)0x0020) /* Bit 5 */
+#define TIM_DTG_6                               ((uint16_t)0x0040) /* Bit 6 */
+#define TIM_DTG_7                               ((uint16_t)0x0080) /* Bit 7 */
+
+#define TIM_LOCK                                ((uint16_t)0x0300) /* LOCK[1:0] bits (Lock Configuration) */
+#define TIM_LOCK_0                              ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_LOCK_1                              ((uint16_t)0x0200) /* Bit 1 */
+
+#define TIM_OSSI                                ((uint16_t)0x0400) /* Off-State Selection for Idle mode */
+#define TIM_OSSR                                ((uint16_t)0x0800) /* Off-State Selection for Run mode */
+#define TIM_BKE                                 ((uint16_t)0x1000) /* Break enable */
+#define TIM_BKP                                 ((uint16_t)0x2000) /* Break Polarity */
+#define TIM_AOE                                 ((uint16_t)0x4000) /* Automatic Output enable */
+#define TIM_MOE                                 ((uint16_t)0x8000) /* Main Output enable */
+
+/*******************  Bit definition for TIM_DMACFGR register  ********************/
+#define TIM_DBA                                 ((uint16_t)0x001F) /* DBA[4:0] bits (DMA Base Address) */
+#define TIM_DBA_0                               ((uint16_t)0x0001) /* Bit 0 */
+#define TIM_DBA_1                               ((uint16_t)0x0002) /* Bit 1 */
+#define TIM_DBA_2                               ((uint16_t)0x0004) /* Bit 2 */
+#define TIM_DBA_3                               ((uint16_t)0x0008) /* Bit 3 */
+#define TIM_DBA_4                               ((uint16_t)0x0010) /* Bit 4 */
+
+#define TIM_DBL                                 ((uint16_t)0x1F00) /* DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DBL_0                               ((uint16_t)0x0100) /* Bit 0 */
+#define TIM_DBL_1                               ((uint16_t)0x0200) /* Bit 1 */
+#define TIM_DBL_2                               ((uint16_t)0x0400) /* Bit 2 */
+#define TIM_DBL_3                               ((uint16_t)0x0800) /* Bit 3 */
+#define TIM_DBL_4                               ((uint16_t)0x1000) /* Bit 4 */
+
+/*******************  Bit definition for TIM_DMAADR register  *******************/
+#define TIM_DMAR_DMAB                           ((uint16_t)0xFFFF) /* DMA register for burst accesses */
+
+/*******************  Bit definition for TIM_SPEC register  *******************/
+#define TIM_SPEC_PWM_EN_1_2                     ((uint16_t)0x0001) /* Channel 1 and Channel 2 alternate */
+#define TIM_SPEC_PWM_EN_3_4                     ((uint16_t)0x0002) /* Channel 3 and Channel 4 alternate */
+#define TIM_SPEC_PWM_OC1                        ((uint16_t)0x0010) /* Channel 1 invalid level under alternate mode */
+#define TIM_SPEC_PWM_OC2                        ((uint16_t)0x0020) /* Channel 2 invalid level under alternate mode */
+#define TIM_SPEC_PWM_OC3                        ((uint16_t)0x0040) /* Channel 3 invalid level under alternate mode */
+#define TIM_SPEC_PWM_OC4                        ((uint16_t)0x0080) /* Channel 4 invalid level under alternate mode */
+#define TIM_SPEC_TOGGLE                         ((uint16_t)0x8000) /* valid channel indicator */
+
+/******************************************************************************/
+/*         Universal Synchronous Asynchronous Receiver Transmitter            */
+/******************************************************************************/
+
+/*******************  Bit definition for USART_STATR register  *******************/
+#define USART_STATR_PE                          ((uint16_t)0x0001) /* Parity Error */
+#define USART_STATR_FE                          ((uint16_t)0x0002) /* Framing Error */
+#define USART_STATR_NE                          ((uint16_t)0x0004) /* Noise Error Flag */
+#define USART_STATR_ORE                         ((uint16_t)0x0008) /* OverRun Error */
+#define USART_STATR_IDLE                        ((uint16_t)0x0010) /* IDLE line detected */
+#define USART_STATR_RXNE                        ((uint16_t)0x0020) /* Read Data Register Not Empty */
+#define USART_STATR_TC                          ((uint16_t)0x0040) /* Transmission Complete */
+#define USART_STATR_TXE                         ((uint16_t)0x0080) /* Transmit Data Register Empty */
+#define USART_STATR_LBD                         ((uint16_t)0x0100) /* LIN Break Detection Flag */
+#define USART_STATR_CTS                         ((uint16_t)0x0200) /* CTS Flag */
+
+/*******************  Bit definition for USART_DATAR register  *******************/
+#define USART_DATAR_DR                          ((uint16_t)0x01FF) /* Data value */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_DIV_Fraction                  ((uint16_t)0x000F) /* Fraction of USARTDIV */
+#define USART_BRR_DIV_Mantissa                  ((uint16_t)0xFFF0) /* Mantissa of USARTDIV */
+
+/******************  Bit definition for USART_CTLR1 register  *******************/
+#define USART_CTLR1_SBK                         ((uint16_t)0x0001) /* Send Break */
+#define USART_CTLR1_RWU                         ((uint16_t)0x0002) /* Receiver wakeup */
+#define USART_CTLR1_RE                          ((uint16_t)0x0004) /* Receiver Enable */
+#define USART_CTLR1_TE                          ((uint16_t)0x0008) /* Transmitter Enable */
+#define USART_CTLR1_IDLEIE                      ((uint16_t)0x0010) /* IDLE Interrupt Enable */
+#define USART_CTLR1_RXNEIE                      ((uint16_t)0x0020) /* RXNE Interrupt Enable */
+#define USART_CTLR1_TCIE                        ((uint16_t)0x0040) /* Transmission Complete Interrupt Enable */
+#define USART_CTLR1_TXEIE                       ((uint16_t)0x0080) /* PE Interrupt Enable */
+#define USART_CTLR1_PEIE                        ((uint16_t)0x0100) /* PE Interrupt Enable */
+#define USART_CTLR1_PS                          ((uint16_t)0x0200) /* Parity Selection */
+#define USART_CTLR1_PCE                         ((uint16_t)0x0400) /* Parity Control Enable */
+#define USART_CTLR1_WAKE                        ((uint16_t)0x0800) /* Wakeup method */
+#define USART_CTLR1_M                           ((uint16_t)0x1000) /* Word length */
+#define USART_CTLR1_UE                          ((uint16_t)0x2000) /* USART Enable */
+#define USART_CTLR1_OVER8                       ((uint16_t)0x8000) /* USART Oversmapling 8-bits */
+
+/******************  Bit definition for USART_CTLR2 register  *******************/
+#define USART_CTLR2_ADD                         ((uint16_t)0x000F) /* Address of the USART node */
+#define USART_CTLR2_LBDL                        ((uint16_t)0x0020) /* LIN Break Detection Length */
+#define USART_CTLR2_LBDIE                       ((uint16_t)0x0040) /* LIN Break Detection Interrupt Enable */
+#define USART_CTLR2_LBCL                        ((uint16_t)0x0100) /* Last Bit Clock pulse */
+#define USART_CTLR2_CPHA                        ((uint16_t)0x0200) /* Clock Phase */
+#define USART_CTLR2_CPOL                        ((uint16_t)0x0400) /* Clock Polarity */
+#define USART_CTLR2_CLKEN                       ((uint16_t)0x0800) /* Clock Enable */
+
+#define USART_CTLR2_STOP                        ((uint16_t)0x3000) /* STOP[1:0] bits (STOP bits) */
+#define USART_CTLR2_STOP_0                      ((uint16_t)0x1000) /* Bit 0 */
+#define USART_CTLR2_STOP_1                      ((uint16_t)0x2000) /* Bit 1 */
+
+#define USART_CTLR2_LINEN                       ((uint16_t)0x4000) /* LIN mode enable */
+
+/******************  Bit definition for USART_CTLR3 register  *******************/
+#define USART_CTLR3_EIE                         ((uint16_t)0x0001) /* Error Interrupt Enable */
+#define USART_CTLR3_IREN                        ((uint16_t)0x0002) /* IrDA mode Enable */
+#define USART_CTLR3_IRLP                        ((uint16_t)0x0004) /* IrDA Low-Power */
+#define USART_CTLR3_HDSEL                       ((uint16_t)0x0008) /* Half-Duplex Selection */
+#define USART_CTLR3_NACK                        ((uint16_t)0x0010) /* Smartcard NACK enable */
+#define USART_CTLR3_SCEN                        ((uint16_t)0x0020) /* Smartcard mode enable */
+#define USART_CTLR3_DMAR                        ((uint16_t)0x0040) /* DMA Enable Receiver */
+#define USART_CTLR3_DMAT                        ((uint16_t)0x0080) /* DMA Enable Transmitter */
+#define USART_CTLR3_RTSE                        ((uint16_t)0x0100) /* RTS Enable */
+#define USART_CTLR3_CTSE                        ((uint16_t)0x0200) /* CTS Enable */
+#define USART_CTLR3_CTSIE                       ((uint16_t)0x0400) /* CTS Interrupt Enable */
+#define USART_CTLR3_ONEBIT                      ((uint16_t)0x0800) /* One Bit method */
+
+/******************  Bit definition for USART_GPR register  ******************/
+#define USART_GPR_PSC                           ((uint16_t)0x00FF) /* PSC[7:0] bits (Prescaler value) */
+#define USART_GPR_PSC_0                         ((uint16_t)0x0001) /* Bit 0 */
+#define USART_GPR_PSC_1                         ((uint16_t)0x0002) /* Bit 1 */
+#define USART_GPR_PSC_2                         ((uint16_t)0x0004) /* Bit 2 */
+#define USART_GPR_PSC_3                         ((uint16_t)0x0008) /* Bit 3 */
+#define USART_GPR_PSC_4                         ((uint16_t)0x0010) /* Bit 4 */
+#define USART_GPR_PSC_5                         ((uint16_t)0x0020) /* Bit 5 */
+#define USART_GPR_PSC_6                         ((uint16_t)0x0040) /* Bit 6 */
+#define USART_GPR_PSC_7                         ((uint16_t)0x0080) /* Bit 7 */
+
+#define USART_GPR_GT                            ((uint16_t)0xFF00) /* Guard time value */
+
+/******************************************************************************/
+/*                            Window WATCHDOG                                 */
+/******************************************************************************/
+
+/*******************  Bit definition for WWDG_CTLR register  ********************/
+#define WWDG_CTLR_T                             ((uint8_t)0x7F) /* T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CTLR_T0                            ((uint8_t)0x01) /* Bit 0 */
+#define WWDG_CTLR_T1                            ((uint8_t)0x02) /* Bit 1 */
+#define WWDG_CTLR_T2                            ((uint8_t)0x04) /* Bit 2 */
+#define WWDG_CTLR_T3                            ((uint8_t)0x08) /* Bit 3 */
+#define WWDG_CTLR_T4                            ((uint8_t)0x10) /* Bit 4 */
+#define WWDG_CTLR_T5                            ((uint8_t)0x20) /* Bit 5 */
+#define WWDG_CTLR_T6                            ((uint8_t)0x40) /* Bit 6 */
+
+#define WWDG_CTLR_WDGA                          ((uint8_t)0x80) /* Activation bit */
+
+/*******************  Bit definition for WWDG_CFGR register  *******************/
+#define WWDG_CFGR_W                             ((uint16_t)0x007F) /* W[6:0] bits (7-bit window value) */
+#define WWDG_CFGR_W0                            ((uint16_t)0x0001) /* Bit 0 */
+#define WWDG_CFGR_W1                            ((uint16_t)0x0002) /* Bit 1 */
+#define WWDG_CFGR_W2                            ((uint16_t)0x0004) /* Bit 2 */
+#define WWDG_CFGR_W3                            ((uint16_t)0x0008) /* Bit 3 */
+#define WWDG_CFGR_W4                            ((uint16_t)0x0010) /* Bit 4 */
+#define WWDG_CFGR_W5                            ((uint16_t)0x0020) /* Bit 5 */
+#define WWDG_CFGR_W6                            ((uint16_t)0x0040) /* Bit 6 */
+
+#define WWDG_CFGR_WDGTB                         ((uint16_t)0x0180) /* WDGTB[1:0] bits (Timer Base) */
+#define WWDG_CFGR_WDGTB0                        ((uint16_t)0x0080) /* Bit 0 */
+#define WWDG_CFGR_WDGTB1                        ((uint16_t)0x0100) /* Bit 1 */
+
+#define WWDG_CFGR_EWI                           ((uint16_t)0x0200) /* Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_STATR register  ********************/
+#define WWDG_STATR_EWIF                         ((uint8_t)0x01) /* Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                          ENHANCED FUNNCTION                                */
+/******************************************************************************/
+
+/****************************  Enhanced register  *****************************/
+#define EXTEN_LOCKUP_EN                         ((uint32_t)0x00000040) /* Bit 5 */
+#define EXTEN_LOCKUP_RSTF                       ((uint32_t)0x00000080) /* Bit 7 */
+
+
+
+#define EXTEN_LDO_TRIM                          ((uint32_t)0x00000400) /* Bit 10 */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+/* ch32v00x_gpio.c -----------------------------------------------------------*/
+/* MASK */
+#define LSB_MASK                  ((uint16_t)0xFFFF)
+#define DBGAFR_POSITION_MASK      ((uint32_t)0x000F0000)
+#define DBGAFR_SDI_MASK           ((uint32_t)0xF8FFFFFF)
+#define DBGAFR_LOCATION_MASK      ((uint32_t)0x00200000)
+#define DBGAFR_NUMBITS_MASK       ((uint32_t)0x00100000)
+
+
+/* ch32v00x_adc.c ------------------------------------------------------------*/
+
+/* ADC DISCNUM mask */
+#define CTLR1_DISCNUM_Reset              ((uint32_t)0xFFFF1FFF)
+
+/* ADC DISCEN mask */
+#define CTLR1_DISCEN_Set                 ((uint32_t)0x00000800)
+#define CTLR1_DISCEN_Reset               ((uint32_t)0xFFFFF7FF)
+
+/* ADC JAUTO mask */
+#define CTLR1_JAUTO_Set                  ((uint32_t)0x00000400)
+#define CTLR1_JAUTO_Reset                ((uint32_t)0xFFFFFBFF)
+
+/* ADC JDISCEN mask */
+#define CTLR1_JDISCEN_Set                ((uint32_t)0x00001000)
+#define CTLR1_JDISCEN_Reset              ((uint32_t)0xFFFFEFFF)
+
+/* ADC AWDCH mask */
+#define CTLR1_AWDCH_Reset                ((uint32_t)0xFFFFFFE0)
+
+/* ADC Analog watchdog enable mode mask */
+#define CTLR1_AWDMode_Reset              ((uint32_t)0xFF3FFDFF)
+
+///* CTLR1 register Mask */
+//Editor's Note: Overloaded Definition
+#define ADC_CTLR1_CLEAR_MASK                 ((uint32_t)0xFFF0FEFF)
+
+/* ADC ADON mask */
+#define CTLR2_ADON_Set                   ((uint32_t)0x00000001)
+#define CTLR2_ADON_Reset                 ((uint32_t)0xFFFFFFFE)
+
+/* ADC DMA mask */
+#define CTLR2_DMA_Set                    ((uint32_t)0x00000100)
+#define CTLR2_DMA_Reset                  ((uint32_t)0xFFFFFEFF)
+
+/* ADC RSTCAL mask */
+#define CTLR2_RSTCAL_Set                 ((uint32_t)0x00000008)
+
+/* ADC CAL mask */
+#define CTLR2_CAL_Set                    ((uint32_t)0x00000004)
+
+/* ADC SWSTART mask */
+#define CTLR2_SWSTART_Set                ((uint32_t)0x00400000)
+
+/* ADC EXTTRIG mask */
+#define CTLR2_EXTTRIG_Set                ((uint32_t)0x00100000)
+#define CTLR2_EXTTRIG_Reset              ((uint32_t)0xFFEFFFFF)
+
+/* ADC Software start mask */
+#define CTLR2_EXTTRIG_SWSTART_Set        ((uint32_t)0x00500000)
+#define CTLR2_EXTTRIG_SWSTART_Reset      ((uint32_t)0xFFAFFFFF)
+
+/* ADC JEXTSEL mask */
+#define CTLR2_JEXTSEL_Reset              ((uint32_t)0xFFFF8FFF)
+
+/* ADC JEXTTRIG mask */
+#define CTLR2_JEXTTRIG_Set               ((uint32_t)0x00008000)
+#define CTLR2_JEXTTRIG_Reset             ((uint32_t)0xFFFF7FFF)
+
+/* ADC JSWSTART mask */
+#define CTLR2_JSWSTART_Set               ((uint32_t)0x00200000)
+
+/* ADC injected software start mask */
+#define CTLR2_JEXTTRIG_JSWSTART_Set      ((uint32_t)0x00208000)
+#define CTLR2_JEXTTRIG_JSWSTART_Reset    ((uint32_t)0xFFDF7FFF)
+
+/* ADC TSPD mask */
+#define CTLR2_TSVREFE_Set                ((uint32_t)0x00800000)
+#define CTLR2_TSVREFE_Reset              ((uint32_t)0xFF7FFFFF)
+
+/* CTLR2 register Mask */
+#define CTLR2_CLEAR_MASK                 ((uint32_t)0xFFF1F7FD)
+
+/* ADC SQx mask */
+#define RSQR3_SQ_Set                     ((uint32_t)0x0000001F)
+#define RSQR2_SQ_Set                     ((uint32_t)0x0000001F)
+#define RSQR1_SQ_Set                     ((uint32_t)0x0000001F)
+
+/* RSQR1 register Mask */
+#define RSQR1_CLEAR_MASK                 ((uint32_t)0xFF0FFFFF)
+
+/* ADC JSQx mask */
+#define ISQR_JSQ_Set                     ((uint32_t)0x0000001F)
+
+/* ADC JL mask */
+#define ISQR_JL_Set                      ((uint32_t)0x00300000)
+#define ISQR_JL_Reset                    ((uint32_t)0xFFCFFFFF)
+
+/* ADC SMPx mask */
+#define SAMPTR1_SMP_Set                  ((uint32_t)0x00000007)
+#define SAMPTR2_SMP_Set                  ((uint32_t)0x00000007)
+
+/* ADC IDATARx registers offset */
+#define IDATAR_Offset                    ((uint8_t)0x28)
+
+
+
+
+/* ch32v00x_dbgmcu.c ---------------------------------------------------------*/
+#define IDCODE_DEVID_MASK    ((uint32_t)0x0000FFFF)
+
+
+/* ch32v00x_dma.c ------------------------------------------------------------*/
+
+/* DMA1 Channelx interrupt pending bit masks */
+#define DMA1_Channel1_IT_MASK    ((uint32_t)(DMA_GIF1 | DMA_TCIF1 | DMA_HTIF1 | DMA_TEIF1))
+#define DMA1_Channel2_IT_MASK    ((uint32_t)(DMA_GIF2 | DMA_TCIF2 | DMA_HTIF2 | DMA_TEIF2))
+#define DMA1_Channel3_IT_MASK    ((uint32_t)(DMA_GIF3 | DMA_TCIF3 | DMA_HTIF3 | DMA_TEIF3))
+#define DMA1_Channel4_IT_MASK    ((uint32_t)(DMA_GIF4 | DMA_TCIF4 | DMA_HTIF4 | DMA_TEIF4))
+#define DMA1_Channel5_IT_MASK    ((uint32_t)(DMA_GIF5 | DMA_TCIF5 | DMA_HTIF5 | DMA_TEIF5))
+#define DMA1_Channel6_IT_MASK    ((uint32_t)(DMA_GIF6 | DMA_TCIF6 | DMA_HTIF6 | DMA_TEIF6))
+#define DMA1_Channel7_IT_MASK    ((uint32_t)(DMA_GIF7 | DMA_TCIF7 | DMA_HTIF7 | DMA_TEIF7))
+
+
+/* DMA2 FLAG mask */
+// Editor's note: Overloaded Definition.
+#define DMA2_FLAG_MASK            ((uint32_t)0x10000000)
+
+/* DMA registers Masks */
+#define CFGR_CLEAR_MASK          ((uint32_t)0xFFFF800F)
+
+/* ch32v00x_exti.c -----------------------------------------------------------*/
+
+
+/* No interrupt selected */
+#define EXTI_LINENONE    ((uint32_t)0x00000)
+
+/* ch32v00x_flash.c ----------------------------------------------------------*/
+
+
+
+/* Flash Control Register bits */
+#define CR_PG_Set                  ((uint32_t)0x00000001)
+#define CR_PG_Reset                ((uint32_t)0xFFFFFFFE)
+#define CR_PER_Set                 ((uint32_t)0x00000002)
+#define CR_PER_Reset               ((uint32_t)0xFFFFFFFD)
+#define CR_MER_Set                 ((uint32_t)0x00000004)
+#define CR_MER_Reset               ((uint32_t)0xFFFFFFFB)
+#define CR_OPTPG_Set               ((uint32_t)0x00000010)
+#define CR_OPTPG_Reset             ((uint32_t)0xFFFFFFEF)
+#define CR_OPTER_Set               ((uint32_t)0x00000020)
+#define CR_OPTER_Reset             ((uint32_t)0xFFFFFFDF)
+#define CR_STRT_Set                ((uint32_t)0x00000040)
+#define CR_LOCK_Set                ((uint32_t)0x00000080)
+#define CR_PAGE_PG                 ((uint32_t)0x00010000)
+#define CR_PAGE_ER                 ((uint32_t)0x00020000)
+
+/* FLASH Status Register bits */
+#define SR_BSY                     ((uint32_t)0x00000001)
+#define SR_WRPRTERR                ((uint32_t)0x00000010)
+#define SR_EOP                     ((uint32_t)0x00000020)
+
+/* FLASH Mask */
+#define RDPRT_MASK                 ((uint32_t)0x00000002)
+#define WRP0_MASK                  ((uint32_t)0x000000FF)
+#define WRP1_MASK                  ((uint32_t)0x0000FF00)
+#define WRP2_MASK                  ((uint32_t)0x00FF0000)
+#define WRP3_MASK                  ((uint32_t)0xFF000000)
+
+/* FLASH Keys */
+#define RDP_Key                    ((uint16_t)0x00A5)
+#define FLASH_KEY1                 ((uint32_t)0x45670123)
+#define FLASH_KEY2                 ((uint32_t)0xCDEF89AB)
+
+/* FLASH BANK address */
+#define FLASH_BANK1_END_ADDRESS    ((uint32_t)0x807FFFF)
+
+
+/* Delay definition */
+#define EraseTimeout               ((uint32_t)0x000B0000)
+
+/* Flash Program Valid Address */
+#define ValidAddrStart             (FLASH_BASE)
+#define ValidAddrEnd               (FLASH_BASE + 0x4000)
+
+
+/* ch32v00x_i2c.c ------------------------------------------------------------*/
+
+
+/* I2C SPE mask */
+#define CTLR1_PE_Set             ((uint16_t)0x0001)
+#define CTLR1_PE_Reset           ((uint16_t)0xFFFE)
+
+/* I2C START mask */
+#define CTLR1_START_Set          ((uint16_t)0x0100)
+#define CTLR1_START_Reset        ((uint16_t)0xFEFF)
+
+/* I2C STOP mask */
+#define CTLR1_STOP_Set           ((uint16_t)0x0200)
+#define CTLR1_STOP_Reset         ((uint16_t)0xFDFF)
+
+/* I2C ACK mask */
+#define CTLR1_ACK_Set            ((uint16_t)0x0400)
+#define CTLR1_ACK_Reset          ((uint16_t)0xFBFF)
+
+/* I2C ENGC mask */
+#define CTLR1_ENGC_Set           ((uint16_t)0x0040)
+#define CTLR1_ENGC_Reset         ((uint16_t)0xFFBF)
+
+/* I2C SWRST mask */
+#define CTLR1_SWRST_Set          ((uint16_t)0x8000)
+#define CTLR1_SWRST_Reset        ((uint16_t)0x7FFF)
+
+/* I2C PEC mask */
+#define CTLR1_PEC_Set            ((uint16_t)0x1000)
+#define CTLR1_PEC_Reset          ((uint16_t)0xEFFF)
+
+/* I2C ENPEC mask */
+#define CTLR1_ENPEC_Set          ((uint16_t)0x0020)
+#define CTLR1_ENPEC_Reset        ((uint16_t)0xFFDF)
+
+/* I2C ENARP mask */
+#define CTLR1_ENARP_Set          ((uint16_t)0x0010)
+#define CTLR1_ENARP_Reset        ((uint16_t)0xFFEF)
+
+/* I2C NOSTRETCH mask */
+#define CTLR1_NOSTRETCH_Set      ((uint16_t)0x0080)
+#define CTLR1_NOSTRETCH_Reset    ((uint16_t)0xFF7F)
+
+////* I2C registers Masks */
+// Editor's note: Overloaded Definition.
+#define I2C_CTLR1_CLEAR_MASK         ((uint16_t)0xFBF5)
+
+/* I2C DMAEN mask */
+#define CTLR2_DMAEN_Set          ((uint16_t)0x0800)
+#define CTLR2_DMAEN_Reset        ((uint16_t)0xF7FF)
+
+/* I2C LAST mask */
+#define CTLR2_LAST_Set           ((uint16_t)0x1000)
+#define CTLR2_LAST_Reset         ((uint16_t)0xEFFF)
+
+/* I2C FREQ mask */
+#define CTLR2_FREQ_Reset         ((uint16_t)0xFFC0)
+
+/* I2C ADD0 mask */
+#define OADDR1_ADD0_Set          ((uint16_t)0x0001)
+#define OADDR1_ADD0_Reset        ((uint16_t)0xFFFE)
+
+/* I2C ENDUAL mask */
+#define OADDR2_ENDUAL_Set        ((uint16_t)0x0001)
+#define OADDR2_ENDUAL_Reset      ((uint16_t)0xFFFE)
+
+/* I2C ADD2 mask */
+#define OADDR2_ADD2_Reset        ((uint16_t)0xFF01)
+
+/* I2C F/S mask */
+#define CKCFGR_FS_Set            ((uint16_t)0x8000)
+
+/* I2C CCR mask */
+#define CKCFGR_CCR_Set           ((uint16_t)0x0FFF)
+
+/* I2C FLAG mask */
+//Editor's Note: Overloaded Definition
+#define I2c_FLAG_MASK            ((uint32_t)0x00FFFFFF)
+
+/* I2C Interrupt Enable mask */
+#define ITEN_MASK                ((uint32_t)0x07000000)
+
+/* ch32v00x_iwdg.c -----------------------------------------------------------*/
+
+/* CTLR register bit mask */
+#define CTLR_KEY_Reload    ((uint16_t)0xAAAA)
+#define CTLR_KEY_Enable    ((uint16_t)0xCCCC)
+
+
+/* ch32v00x_pwr.c ------------------------------------------------------------*/
+
+
+/* PWR registers bit mask */
+/* CTLR register bit mask */
+#define CTLR_DS_MASK     ((uint32_t)0xFFFFFFFD)
+#define CTLR_PLS_MASK    ((uint32_t)0xFFFFFF1F)
+
+/* ch32v00x_rcc.c ------------------------------------------------------------*/
+
+/* RCC registers bit address in the alias region */
+#define RCC_OFFSET                 (RCC_BASE - PERIPH_BASE)
+
+/* BDCTLR Register */
+#define BDCTLR_OFFSET              (RCC_OFFSET + 0x20)
+
+/* RCC registers bit mask */
+
+/* CTLR register bit mask */
+#define CTLR_HSEBYP_Reset          ((uint32_t)0xFFFBFFFF)
+#define CTLR_HSEBYP_Set            ((uint32_t)0x00040000)
+#define CTLR_HSEON_Reset           ((uint32_t)0xFFFEFFFF)
+#define CTLR_HSEON_Set             ((uint32_t)0x00010000)
+#define CTLR_HSITRIM_MASK          ((uint32_t)0xFFFFFF07)
+
+#define CFGR0_PLL_MASK             ((uint32_t)0xFFC0FFFF)
+#define CFGR0_PLLMull_MASK         ((uint32_t)0x003C0000)
+#define CFGR0_PLLSRC_MASK          ((uint32_t)0x00010000)
+#define CFGR0_PLLXTPRE_MASK        ((uint32_t)0x00020000)
+#define CFGR0_SWS_MASK             ((uint32_t)0x0000000C)
+#define CFGR0_SW_MASK              ((uint32_t)0xFFFFFFFC)
+#define CFGR0_HPRE_Reset_MASK      ((uint32_t)0xFFFFFF0F)
+#define CFGR0_HPRE_Set_MASK        ((uint32_t)0x000000F0)
+#define CFGR0_PPRE1_Reset_MASK     ((uint32_t)0xFFFFF8FF)
+#define CFGR0_PPRE1_Set_MASK       ((uint32_t)0x00000700)
+#define CFGR0_PPRE2_Reset_MASK     ((uint32_t)0xFFFFC7FF)
+#define CFGR0_PPRE2_Set_MASK       ((uint32_t)0x00003800)
+#define CFGR0_ADCPRE_Reset_MASK    ((uint32_t)0xFFFF07FF)
+#define CFGR0_ADCPRE_Set_MASK      ((uint32_t)0x0000F800)
+
+/* RSTSCKR register bit mask */
+#define RSTSCKR_RMVF_Set           ((uint32_t)0x01000000)
+
+
+/* RCC Flag Mask */
+//Editor's Note: Overloaded Definition
+#define RCC_FLAG_MASK                  ((uint8_t)0x1F)
+
+/* INTR register byte 2 (Bits[15:8]) base address */
+#define INTR_BYTE2_ADDRESS         ((uint32_t)0x40021009)
+
+/* INTR register byte 3 (Bits[23:16]) base address */
+#define INTR_BYTE3_ADDRESS         ((uint32_t)0x4002100A)
+
+/* CFGR0 register byte 4 (Bits[31:24]) base address */
+#define CFGR0_BYTE4_ADDRESS        ((uint32_t)0x40021007)
+
+/* BDCTLR register base address */
+#define BDCTLR_ADDRESS             (PERIPH_BASE + BDCTLR_OFFSET)
+
+#ifndef __ASSEMBLER__
+#endif
+
+
+
+/* ch32v00x_spi.c ------------------------------------------------------------*/
+
+/* SPI SPE mask */
+#define CTLR1_SPE_Set         ((uint16_t)0x0040)
+#define CTLR1_SPE_Reset       ((uint16_t)0xFFBF)
+
+
+/* SPI CRCNext mask */
+#define CTLR1_CRCNext_Set     ((uint16_t)0x1000)
+
+/* SPI CRCEN mask */
+#define CTLR1_CRCEN_Set       ((uint16_t)0x2000)
+#define CTLR1_CRCEN_Reset     ((uint16_t)0xDFFF)
+
+/* SPI SSOE mask */
+#define CTLR2_SSOE_Set        ((uint16_t)0x0004)
+#define CTLR2_SSOE_Reset      ((uint16_t)0xFFFB)
+
+/* SPI registers Masks */
+//Editor's Note: Overloaded Definition
+#define SPI_CTLR1_CLEAR_MASK  ((uint16_t)0x3040)
+#define I2SCFGR_CLEAR_MASK    ((uint16_t)0xF040)
+
+
+
+/* ch32v00x_tim.c ------------------------------------------------------------*/
+
+/* TIM registers bit mask */
+#define SMCFGR_ETR_MASK    ((uint16_t)0x00FF)
+#define CHCTLR_Offset      ((uint16_t)0x0018)
+#define CCER_CCE_Set       ((uint16_t)0x0001)
+#define CCER_CCNE_Set      ((uint16_t)0x0004)
+
+/* ch32v00x_usart.c ----------------------------------------------------------*/
+
+/* USART_Private_Defines */
+#define CTLR1_UE_Set              ((uint16_t)0x2000) /* USART Enable Mask */
+#define CTLR1_UE_Reset            ((uint16_t)0xDFFF) /* USART Disable Mask */
+
+#define CTLR1_WAKE_MASK           ((uint16_t)0xF7FF) /* USART WakeUp Method Mask */
+
+#define CTLR1_RWU_Set             ((uint16_t)0x0002) /* USART mute mode Enable Mask */
+#define CTLR1_RWU_Reset           ((uint16_t)0xFFFD) /* USART mute mode Enable Mask */
+#define CTLR1_SBK_Set             ((uint16_t)0x0001) /* USART Break Character send Mask */
+//Editor's Note: Overloaded Definition
+#define USART_CTLR1_CLEAR_MASK          ((uint16_t)0xE9F3) /* USART CR1 Mask */
+#define CTLR2_Address_MASK        ((uint16_t)0xFFF0) /* USART address Mask */
+
+#define CTLR2_LINEN_Set           ((uint16_t)0x4000) /* USART LIN Enable Mask */
+#define CTLR2_LINEN_Reset         ((uint16_t)0xBFFF) /* USART LIN Disable Mask */
+
+#define CTLR2_LBDL_MASK           ((uint16_t)0xFFDF) /* USART LIN Break detection Mask */
+#define CTLR2_STOP_CLEAR_MASK     ((uint16_t)0xCFFF) /* USART CR2 STOP Bits Mask */
+#define CTLR2_CLOCK_CLEAR_MASK    ((uint16_t)0xF0FF) /* USART CR2 Clock Mask */
+
+#define CTLR3_SCEN_Set            ((uint16_t)0x0020) /* USART SC Enable Mask */
+#define CTLR3_SCEN_Reset          ((uint16_t)0xFFDF) /* USART SC Disable Mask */
+
+#define CTLR3_NACK_Set            ((uint16_t)0x0010) /* USART SC NACK Enable Mask */
+#define CTLR3_NACK_Reset          ((uint16_t)0xFFEF) /* USART SC NACK Disable Mask */
+
+#define CTLR3_HDSEL_Set           ((uint16_t)0x0008) /* USART Half-Duplex Enable Mask */
+#define CTLR3_HDSEL_Reset         ((uint16_t)0xFFF7) /* USART Half-Duplex Disable Mask */
+
+#define CTLR3_IRLP_MASK           ((uint16_t)0xFFFB) /* USART IrDA LowPower mode Mask */
+#define CTLR3_CLEAR_MASK          ((uint16_t)0xFCFF) /* USART CR3 Mask */
+
+#define CTLR3_IREN_Set            ((uint16_t)0x0002) /* USART IrDA Enable Mask */
+#define CTLR3_IREN_Reset          ((uint16_t)0xFFFD) /* USART IrDA Disable Mask */
+#define GPR_LSB_MASK              ((uint16_t)0x00FF) /* Guard Time Register LSB Mask */
+#define GPR_MSB_MASK              ((uint16_t)0xFF00) /* Guard Time Register MSB Mask */
+#define IT_MASK                   ((uint16_t)0x001F) /* USART Interrupt Mask */
+
+/* USART OverSampling-8 Mask */
+#define CTLR1_OVER8_Set           ((uint16_t)0x8000) /* USART OVER8 mode Enable Mask */
+#define CTLR1_OVER8_Reset         ((uint16_t)0x7FFF) /* USART OVER8 mode Disable Mask */
+
+/* USART One Bit Sampling Mask */
+#define CTLR3_ONEBITE_Set         ((uint16_t)0x0800) /* USART ONEBITE mode Enable Mask */
+#define CTLR3_ONEBITE_Reset       ((uint16_t)0xF7FF) /* USART ONEBITE mode Disable Mask */
+
+/* ch32v00x_wwdg.c ------------------------------------------------------------*/
+
+/* CTLR register bit mask */
+#define CTLR_WDGA_Set      ((uint32_t)0x00000080)
+
+/* CFGR register bit mask */
+#define CFGR_WDGTB_MASK    ((uint32_t)0xFFFFFE7F)
+#define CFGR_W_MASK        ((uint32_t)0xFFFFFF80)
+#define BIT_MASK           ((uint8_t)0x7F)
+
+
+/* ch32v00x_adc.h ------------------------------------------------------------*/
+
+/* ADC_mode */
+#define ADC_Mode_Independent                           ((uint32_t)0x00000000)
+
+/* ADC_external_trigger_sources_for_regular_channels_conversion */
+#define ADC_ExternalTrigConv_T1_TRGO                   ((uint32_t)0x00000000)
+#define ADC_ExternalTrigConv_T1_CC1                    ((uint32_t)0x00020000)
+#define ADC_ExternalTrigConv_T1_CC2                    ((uint32_t)0x00040000)
+#define ADC_ExternalTrigConv_T2_TRGO                   ((uint32_t)0x00060000)
+#define ADC_ExternalTrigConv_T2_CC1                    ((uint32_t)0x00080000)
+#define ADC_ExternalTrigConv_T3_CC1                    ((uint32_t)0x000A0000)
+#define ADC_ExternalTrigConv_Ext_IT11                  ((uint32_t)0x000C0000)
+#define ADC_ExternalTrigConv_None                      ((uint32_t)0x000E0000)
+
+/* ADC_data_align */
+#define ADC_DataAlign_Right                            ((uint32_t)0x00000000)
+#define ADC_DataAlign_Left                             ((uint32_t)0x00000800)
+
+/* ADC_channels */
+#define ADC_Channel_0                                  ((uint8_t)0x00)
+#define ADC_Channel_1                                  ((uint8_t)0x01)
+#define ADC_Channel_2                                  ((uint8_t)0x02)
+#define ADC_Channel_3                                  ((uint8_t)0x03)
+#define ADC_Channel_4                                  ((uint8_t)0x04)
+#define ADC_Channel_5                                  ((uint8_t)0x05)
+#define ADC_Channel_6                                  ((uint8_t)0x06)
+#define ADC_Channel_7                                  ((uint8_t)0x07)
+#define ADC_Channel_8                                  ((uint8_t)0x08)
+#define ADC_Channel_9                                  ((uint8_t)0x09)
+#define ADC_Channel_10                                 ((uint8_t)0x0A)
+#define ADC_Channel_11                                 ((uint8_t)0x0B)
+#define ADC_Channel_12                                 ((uint8_t)0x0C)
+#define ADC_Channel_13                                 ((uint8_t)0x0D)
+#define ADC_Channel_14                                 ((uint8_t)0x0E)
+#define ADC_Channel_15                                 ((uint8_t)0x0F)
+
+#define ADC_Channel_Vrefint                            ((uint8_t)ADC_Channel_15)
+
+/* ADC_sampling_time */
+#define ADC_SampleTime_4Cycles                         ((uint8_t)0x00)
+#define ADC_SampleTime_5Cycles                         ((uint8_t)0x01)
+#define ADC_SampleTime_6Cycles                         ((uint8_t)0x02)
+#define ADC_SampleTime_7Cycles                         ((uint8_t)0x03)
+#define ADC_SampleTime_8Cycles                         ((uint8_t)0x04)
+#define ADC_SampleTime_9Cycles                         ((uint8_t)0x05)
+#define ADC_SampleTime_10Cycles                        ((uint8_t)0x06)
+#define ADC_SampleTime_11Cycles                        ((uint8_t)0x07)
+
+/* ADC_external_trigger_sources_for_injected_channels_conversion */
+#define ADC_ExternalTrigInjecConv_T1_CC3               ((uint32_t)0x00000000)
+#define ADC_ExternalTrigInjecConv_T1_CC4               ((uint32_t)0x00001000)
+#define ADC_ExternalTrigInjecConv_T2_CC3               ((uint32_t)0x00002000)
+#define ADC_ExternalTrigInjecConv_T2_CC4               ((uint32_t)0x00003000)
+#define ADC_ExternalTrigInjecConv_T2_CC2               ((uint32_t)0x00004000)
+#define ADC_ExternalTrigInjecConv_T3_CC2               ((uint32_t)0x00005000)
+#define ADC_ExternalTrigInjecConv_Ext_IT15             ((uint32_t)0x00006000)
+#define ADC_ExternalTrigInjecConv_None                 ((uint32_t)0x00007000)
+
+/* ADC_injected_channel_selection */
+#define ADC_InjectedChannel_1                          ((uint8_t)0x14)
+#define ADC_InjectedChannel_2                          ((uint8_t)0x18)
+#define ADC_InjectedChannel_3                          ((uint8_t)0x1C)
+#define ADC_InjectedChannel_4                          ((uint8_t)0x20)
+
+/* ADC_analog_watchdog_selection */
+#define ADC_AnalogWatchdog_SingleRegEnable             ((uint32_t)0x00800200)
+#define ADC_AnalogWatchdog_SingleInjecEnable           ((uint32_t)0x00400200)
+#define ADC_AnalogWatchdog_SingleRegOrInjecEnable      ((uint32_t)0x00C00200)
+#define ADC_AnalogWatchdog_AllRegEnable                ((uint32_t)0x00800000)
+#define ADC_AnalogWatchdog_AllInjecEnable              ((uint32_t)0x00400000)
+#define ADC_AnalogWatchdog_AllRegAllInjecEnable        ((uint32_t)0x00C00000)
+#define ADC_AnalogWatchdog_None                        ((uint32_t)0x00000000)
+
+/* ADC_interrupts_definition */
+#define ADC_IT_EOC                                     ((uint16_t)0x0220)
+#define ADC_IT_AWD                                     ((uint16_t)0x0140)
+#define ADC_IT_JEOC                                    ((uint16_t)0x0480)
+
+/* ADC_flags_definition */
+#define ADC_FLAG_AWD                                   ((uint8_t)0x01)
+#define ADC_FLAG_EOC                                   ((uint8_t)0x02)
+#define ADC_FLAG_JEOC                                  ((uint8_t)0x04)
+#define ADC_FLAG_JSTRT                                 ((uint8_t)0x08)
+#define ADC_FLAG_STRT                                  ((uint8_t)0x10)
+
+
+/* ADC_external_trigger_sources_delay_channels_definition */
+#define ADC_ExternalTrigRegul_DLY                      ((uint32_t)0x00000000)
+
+/* ADC_analog_watchdog_reset_enable_selection */
+#define ADC_AnalogWatchdog_0_RST_EN                    ((uint32_t)0x00001000)
+#define ADC_AnalogWatchdog_1_RST_EN                    ((uint32_t)0x00002000)
+#define ADC_AnalogWatchdog_2_RST_EN                    ((uint32_t)0x00004000)
+#define ADC_AnalogWatchdog_3_RST_EN                    ((uint32_t)0x00008000)
+
+/* ADC_analog_watchdog_reset_flags_definition */
+#define ADC_AnalogWatchdogResetFLAG_0                  ((uint32_t)0x00010000)
+#define ADC_AnalogWatchdogResetFLAG_1                  ((uint32_t)0x00020000)
+#define ADC_AnalogWatchdogResetFLAG_2                  ((uint32_t)0x00040000)
+#define ADC_AnalogWatchdogResetFLAG_3                  ((uint32_t)0x00080000)
+
+/* ADC_clock */
+#define ADC_CLK_Div4                                   ((uint32_t)0x00000013)
+#define ADC_CLK_Div5                                   ((uint32_t)0x00000014)
+#define ADC_CLK_Div6                                   ((uint32_t)0x00000025)
+#define ADC_CLK_Div7                                   ((uint32_t)0x00000026)
+#define ADC_CLK_Div8                                   ((uint32_t)0x00000037)
+#define ADC_CLK_Div9                                   ((uint32_t)0x00000038)
+#define ADC_CLK_Div10                                  ((uint32_t)0x00000049)
+#define ADC_CLK_Div11                                  ((uint32_t)0x0000004A)
+#define ADC_CLK_Div12                                  ((uint32_t)0x0000005B)
+#define ADC_CLK_Div13                                  ((uint32_t)0x0000005C)
+#define ADC_CLK_Div14                                  ((uint32_t)0x0000006D)
+#define ADC_CLK_Div15                                  ((uint32_t)0x0000006E)
+#define ADC_CLK_Div16                                  ((uint32_t)0x0000007F)
+
+
+/* PWR_AWU_Prescaler */
+#define AWU_Prescaler_1       ((uint32_t)0x00000000)
+#define AWU_Prescaler_2       ((uint32_t)0x00000002)
+#define AWU_Prescaler_4       ((uint32_t)0x00000003)
+#define AWU_Prescaler_8       ((uint32_t)0x00000004)
+#define AWU_Prescaler_16      ((uint32_t)0x00000005)
+#define AWU_Prescaler_32      ((uint32_t)0x00000006)
+#define AWU_Prescaler_64      ((uint32_t)0x00000007)
+#define AWU_Prescaler_128     ((uint32_t)0x00000008)
+#define AWU_Prescaler_256     ((uint32_t)0x00000009)
+#define AWU_Prescaler_512     ((uint32_t)0x0000000A)
+#define AWU_Prescaler_1024    ((uint32_t)0x0000000B)
+#define AWU_Prescaler_2048    ((uint32_t)0x0000000C)
+#define AWU_Prescaler_4096    ((uint32_t)0x0000000D)
+#define AWU_Prescaler_10240   ((uint32_t)0x0000000E)
+#define AWU_Prescaler_61440   ((uint32_t)0x0000000F)
+
+
+/* ch32v00x_dbgmcu.h ---------------------------------------------------------*/
+/* CFGR0 Register */
+#define DBGMCU_SLEEP                 ((uint32_t)0x00000001)
+#define DBGMCU_STOP                  ((uint32_t)0x00000002)
+#define DBGMCU_STANDBY               ((uint32_t)0x00000004)
+#define DBGMCU_IWDG_STOP             ((uint32_t)0x00000100)
+#define DBGMCU_WWDG_STOP             ((uint32_t)0x00000200)
+#define DBGMCU_TIM1_STOP             ((uint32_t)0x00001000)
+#define DBGMCU_TIM2_STOP             ((uint32_t)0x00002000)
+#define DBGMCU_TIM3_STOP             ((uint32_t)0x00004000)
+
+/* ch32v00x_dma.h ------------------------------------------------------------*/
+
+/* DMA_data_transfer_direction */
+#define DMA_DIR_PeripheralDST              ((uint32_t)0x00000010)
+#define DMA_DIR_PeripheralSRC              ((uint32_t)0x00000000)
+
+/* DMA_peripheral_incremented_mode */
+#define DMA_PeripheralInc_Enable           ((uint32_t)0x00000040)
+#define DMA_PeripheralInc_Disable          ((uint32_t)0x00000000)
+
+/* DMA_memory_incremented_mode */
+#define DMA_MemoryInc_Enable               ((uint32_t)0x00000080)
+#define DMA_MemoryInc_Disable              ((uint32_t)0x00000000)
+
+/* DMA_peripheral_data_size */
+#define DMA_PeripheralDataSize_Byte        ((uint32_t)0x00000000)
+#define DMA_PeripheralDataSize_HalfWord    ((uint32_t)0x00000100)
+#define DMA_PeripheralDataSize_Word        ((uint32_t)0x00000200)
+
+/* DMA_memory_data_size */
+#define DMA_MemoryDataSize_Byte            ((uint32_t)0x00000000)
+#define DMA_MemoryDataSize_HalfWord        ((uint32_t)0x00000400)
+#define DMA_MemoryDataSize_Word            ((uint32_t)0x00000800)
+
+/* DMA_circular_normal_mode */
+#define DMA_Mode_Circular                  ((uint32_t)0x00000020)
+#define DMA_Mode_Normal                    ((uint32_t)0x00000000)
+
+/* DMA_priority_level */
+#define DMA_Priority_VeryHigh              ((uint32_t)0x00003000)
+#define DMA_Priority_High                  ((uint32_t)0x00002000)
+#define DMA_Priority_Medium                ((uint32_t)0x00001000)
+#define DMA_Priority_Low                   ((uint32_t)0x00000000)
+
+/* DMA_memory_to_memory */
+#define DMA_M2M_Enable                     ((uint32_t)0x00004000)
+#define DMA_M2M_Disable                    ((uint32_t)0x00000000)
+
+/* DMA_interrupts_definition */
+#define DMA_IT_TC                          ((uint32_t)0x00000002)
+#define DMA_IT_HT                          ((uint32_t)0x00000004)
+#define DMA_IT_TE                          ((uint32_t)0x00000008)
+
+#define DMA1_IT_GL1                        ((uint32_t)0x00000001)
+#define DMA1_IT_TC1                        ((uint32_t)0x00000002)
+#define DMA1_IT_HT1                        ((uint32_t)0x00000004)
+#define DMA1_IT_TE1                        ((uint32_t)0x00000008)
+#define DMA1_IT_GL2                        ((uint32_t)0x00000010)
+#define DMA1_IT_TC2                        ((uint32_t)0x00000020)
+#define DMA1_IT_HT2                        ((uint32_t)0x00000040)
+#define DMA1_IT_TE2                        ((uint32_t)0x00000080)
+#define DMA1_IT_GL3                        ((uint32_t)0x00000100)
+#define DMA1_IT_TC3                        ((uint32_t)0x00000200)
+#define DMA1_IT_HT3                        ((uint32_t)0x00000400)
+#define DMA1_IT_TE3                        ((uint32_t)0x00000800)
+#define DMA1_IT_GL4                        ((uint32_t)0x00001000)
+#define DMA1_IT_TC4                        ((uint32_t)0x00002000)
+#define DMA1_IT_HT4                        ((uint32_t)0x00004000)
+#define DMA1_IT_TE4                        ((uint32_t)0x00008000)
+#define DMA1_IT_GL5                        ((uint32_t)0x00010000)
+#define DMA1_IT_TC5                        ((uint32_t)0x00020000)
+#define DMA1_IT_HT5                        ((uint32_t)0x00040000)
+#define DMA1_IT_TE5                        ((uint32_t)0x00080000)
+#define DMA1_IT_GL6                        ((uint32_t)0x00100000)
+#define DMA1_IT_TC6                        ((uint32_t)0x00200000)
+#define DMA1_IT_HT6                        ((uint32_t)0x00400000)
+#define DMA1_IT_TE6                        ((uint32_t)0x00800000)
+#define DMA1_IT_GL7                        ((uint32_t)0x01000000)
+#define DMA1_IT_TC7                        ((uint32_t)0x02000000)
+#define DMA1_IT_HT7                        ((uint32_t)0x04000000)
+#define DMA1_IT_TE7                        ((uint32_t)0x08000000)
+#define DMA1_IT_GL8                        ((uint32_t)0x10000000)
+#define DMA1_IT_TC8                        ((uint32_t)0x20000000)
+#define DMA1_IT_HT8                        ((uint32_t)0x40000000)
+#define DMA1_IT_TE8                        ((uint32_t)0x80000000)
+
+
+/* DMA_flags_definition */
+#define DMA1_FLAG_GL1                      ((uint32_t)0x00000001)
+#define DMA1_FLAG_TC1                      ((uint32_t)0x00000002)
+#define DMA1_FLAG_HT1                      ((uint32_t)0x00000004)
+#define DMA1_FLAG_TE1                      ((uint32_t)0x00000008)
+#define DMA1_FLAG_GL2                      ((uint32_t)0x00000010)
+#define DMA1_FLAG_TC2                      ((uint32_t)0x00000020)
+#define DMA1_FLAG_HT2                      ((uint32_t)0x00000040)
+#define DMA1_FLAG_TE2                      ((uint32_t)0x00000080)
+#define DMA1_FLAG_GL3                      ((uint32_t)0x00000100)
+#define DMA1_FLAG_TC3                      ((uint32_t)0x00000200)
+#define DMA1_FLAG_HT3                      ((uint32_t)0x00000400)
+#define DMA1_FLAG_TE3                      ((uint32_t)0x00000800)
+#define DMA1_FLAG_GL4                      ((uint32_t)0x00001000)
+#define DMA1_FLAG_TC4                      ((uint32_t)0x00002000)
+#define DMA1_FLAG_HT4                      ((uint32_t)0x00004000)
+#define DMA1_FLAG_TE4                      ((uint32_t)0x00008000)
+#define DMA1_FLAG_GL5                      ((uint32_t)0x00010000)
+#define DMA1_FLAG_TC5                      ((uint32_t)0x00020000)
+#define DMA1_FLAG_HT5                      ((uint32_t)0x00040000)
+#define DMA1_FLAG_TE5                      ((uint32_t)0x00080000)
+#define DMA1_FLAG_GL6                      ((uint32_t)0x00100000)
+#define DMA1_FLAG_TC6                      ((uint32_t)0x00200000)
+#define DMA1_FLAG_HT6                      ((uint32_t)0x00400000)
+#define DMA1_FLAG_TE6                      ((uint32_t)0x00800000)
+#define DMA1_FLAG_GL7                      ((uint32_t)0x01000000)
+#define DMA1_FLAG_TC7                      ((uint32_t)0x02000000)
+#define DMA1_FLAG_HT7                      ((uint32_t)0x04000000)
+#define DMA1_FLAG_TE7                      ((uint32_t)0x08000000)
+#define DMA1_FLAG_GL8                      ((uint32_t)0x10000000)
+#define DMA1_FLAG_TC8                      ((uint32_t)0x20000000)
+#define DMA1_FLAG_HT8                      ((uint32_t)0x40000000)
+#define DMA1_FLAG_TE8                      ((uint32_t)0x80000000)
+
+
+
+/* ch32v00x_exti.h -----------------------------------------------------------*/
+
+#ifndef __ASSEMBLER__
+
+/* EXTI mode enumeration */
+typedef enum
+{
+    EXTI_Mode_Interrupt = 0x00,
+    EXTI_Mode_Event = 0x04
+} EXTIMode_TypeDef;
+
+/* EXTI Trigger enumeration */
+typedef enum
+{
+    EXTI_Trigger_Rising = 0x08,
+    EXTI_Trigger_Falling = 0x0C,
+    EXTI_Trigger_Rising_Falling = 0x10
+} EXTITrigger_TypeDef;
+
+#endif
+
+/* EXTI_Lines */
+#define EXTI_Line0                         ((uint32_t)0x00000001) /* External interrupt line 0 */
+#define EXTI_Line1                         ((uint32_t)0x00000002) /* External interrupt line 1 */
+#define EXTI_Line2                         ((uint32_t)0x00000004) /* External interrupt line 2 */
+#define EXTI_Line3                         ((uint32_t)0x00000008) /* External interrupt line 3 */
+#define EXTI_Line4                         ((uint32_t)0x00000010) /* External interrupt line 4 */
+#define EXTI_Line5                         ((uint32_t)0x00000020) /* External interrupt line 5 */
+#define EXTI_Line6                         ((uint32_t)0x00000040) /* External interrupt line 6 */
+#define EXTI_Line7                         ((uint32_t)0x00000080) /* External interrupt line 7 */
+#define EXTI_Line8                         ((uint32_t)0x00000100) /* External interrupt line 8 */
+#define EXTI_Line9                         ((uint32_t)0x00000200) /* External interrupt line 9 */
+#define EXTI_Line10                        ((uint32_t)0x00000400) /* External interrupt line 10 */
+#define EXTI_Line11                        ((uint32_t)0x00000800) /* External interrupt line 11 */
+#define EXTI_Line12                        ((uint32_t)0x00001000) /* External interrupt line 12 */
+#define EXTI_Line13                        ((uint32_t)0x00002000) /* External interrupt line 13 */
+#define EXTI_Line14                        ((uint32_t)0x00004000) /* External interrupt line 14 */
+#define EXTI_Line15                        ((uint32_t)0x00008000) /* External interrupt line 15 */
+#define EXTI_Line16                        ((uint32_t)0x00010000) /* External interrupt line 16 */
+#define EXTI_Line17                        ((uint32_t)0x00020000) /* External interrupt line 17 */
+#define EXTI_Line18                        ((uint32_t)0x00040000) /* External interrupt line 18 */
+#define EXTI_Line19                        ((uint32_t)0x00080000) /* External interrupt line 19 */
+#define EXTI_Line20                        ((uint32_t)0x00100000) /* External interrupt line 20 */
+#define EXTI_Line21                        ((uint32_t)0x00200000) /* External interrupt line 21 */
+#define EXTI_Line22                        ((uint32_t)0x00400000) /* External interrupt line 22 */
+#define EXTI_Line23                        ((uint32_t)0x00800000) /* External interrupt line 23 */
+#define EXTI_Line24                        ((uint32_t)0x01000000) /* External interrupt line 24 */
+#define EXTI_Line25                        ((uint32_t)0x02000000) /* External interrupt line 25 */
+#define EXTI_Line26                        ((uint32_t)0x04000000) /* External interrupt line 26 */
+#define EXTI_Line27                        ((uint32_t)0x08000000) /* External interrupt line 27 */
+#define EXTI_Line28                        ((uint32_t)0x10000000) /* External interrupt line 28 */
+#define EXTI_Line29                        ((uint32_t)0x20000000) /* External interrupt line 29 */
+
+/* ch32v00x_flash.h ----------------------------------------------------------*/
+
+
+#ifndef __ASSEMBLER__
+/* FLASH Status */
+typedef enum
+{
+    FLASH_BUSY = 1,
+    FLASH_ERROR_PG,
+    FLASH_ERROR_WRP,
+    FLASH_COMPLETE,
+    FLASH_TIMEOUT,
+    FLASH_RDP,
+    FLASH_OP_RANGE_ERROR = 0xFD,
+    FLASH_ALIGN_ERROR = 0xFE,
+    FLASH_ADR_RANGE_ERROR = 0xFF,
+} FLASH_Status;
+#endif
+
+/* Flash_Latency */
+#define FLASH_Latency_0                  ((uint32_t)0x00000000) /* FLASH Zero Latency cycle */
+#define FLASH_Latency_1                  ((uint32_t)0x00000001) /* FLASH One Latency cycle */
+#define FLASH_Latency_2                  ((uint32_t)0x00000002) /* FLASH Two Latency cycles */
+
+/* Values to be used with devices (1page = 256Byte) */
+#define FLASH_WRProt_Pages0to7           ((uint32_t)0x00000001) /* Write protection of page 0 to 7 */
+#define FLASH_WRProt_Pages8to15          ((uint32_t)0x00000002) /* Write protection of page 8 to 15 */
+#define FLASH_WRProt_Pages16to23         ((uint32_t)0x00000004) /* Write protection of page 16 to 23 */
+#define FLASH_WRProt_Pages24to31         ((uint32_t)0x00000008) /* Write protection of page 24 to 31 */
+#define FLASH_WRProt_Pages32to39         ((uint32_t)0x00000010) /* Write protection of page 32 to 39 */
+#define FLASH_WRProt_Pages40to47         ((uint32_t)0x00000020) /* Write protection of page 40 to 47 */
+#define FLASH_WRProt_Pages48to55         ((uint32_t)0x00000040) /* Write protection of page 48 to 55 */
+#define FLASH_WRProt_Pages56to63         ((uint32_t)0x00000080) /* Write protection of page 56 to 63 */
+#define FLASH_WRProt_Pages64to71         ((uint32_t)0x00000100) /* Write protection of page 64 to 71 */
+#define FLASH_WRProt_Pages72to79         ((uint32_t)0x00000200) /* Write protection of page 72 to 79 */
+#define FLASH_WRProt_Pages80to87         ((uint32_t)0x00000400) /* Write protection of page 80 to 87 */
+#define FLASH_WRProt_Pages88to95         ((uint32_t)0x00000800) /* Write protection of page 88 to 95 */
+#define FLASH_WRProt_Pages96to103        ((uint32_t)0x00001000) /* Write protection of page 96 to 103 */
+#define FLASH_WRProt_Pages104to111       ((uint32_t)0x00002000) /* Write protection of page 104 to 111 */
+#define FLASH_WRProt_Pages112to119       ((uint32_t)0x00004000) /* Write protection of page 112 to 119 */
+#define FLASH_WRProt_Pages120to127       ((uint32_t)0x00008000) /* Write protection of page 120 to 127 */
+#define FLASH_WRProt_Pages128to135       ((uint32_t)0x00010000) /* Write protection of page 128 to 135 */
+#define FLASH_WRProt_Pages136to143       ((uint32_t)0x00020000) /* Write protection of page 136 to 143 */
+#define FLASH_WRProt_Pages144to151       ((uint32_t)0x00040000) /* Write protection of page 144 to 151 */
+#define FLASH_WRProt_Pages152to159       ((uint32_t)0x00080000) /* Write protection of page 152 to 159 */
+#define FLASH_WRProt_Pages160to167       ((uint32_t)0x00100000) /* Write protection of page 160 to 167 */
+#define FLASH_WRProt_Pages168to175       ((uint32_t)0x00200000) /* Write protection of page 168 to 175 */
+#define FLASH_WRProt_Pages176to183       ((uint32_t)0x00400000) /* Write protection of page 176 to 183 */
+#define FLASH_WRProt_Pages184to191       ((uint32_t)0x00800000) /* Write protection of page 184 to 191 */
+#define FLASH_WRProt_Pages192to199       ((uint32_t)0x01000000) /* Write protection of page 192 to 199 */
+#define FLASH_WRProt_Pages200to207       ((uint32_t)0x02000000) /* Write protection of page 200 to 207 */
+#define FLASH_WRProt_Pages208to215       ((uint32_t)0x04000000) /* Write protection of page 208 to 215 */
+#define FLASH_WRProt_Pages216to223       ((uint32_t)0x08000000) /* Write protection of page 216 to 223 */
+#define FLASH_WRProt_Pages224to231       ((uint32_t)0x10000000) /* Write protection of page 224 to 231 */
+#define FLASH_WRProt_Pages232to239       ((uint32_t)0x20000000) /* Write protection of page 232 to 239 */
+#define FLASH_WRProt_Pages240to247       ((uint32_t)0x40000000) /* Write protection of page 240 to 247 */
+
+
+#define FLASH_WRProt_AllPages            ((uint32_t)0xFFFFFFFF) /* Write protection of all Pages */
+
+
+
+/* Option_Bytes_IWatchdog */
+#define OB_IWDG_SW                       ((uint16_t)0x0001) /* Software IWDG selected */
+#define OB_IWDG_HW                       ((uint16_t)0x0000) /* Hardware IWDG selected */
+
+/* Option_Bytes_nRST_STOP */
+#define OB_STOP_NoRST                    ((uint16_t)0x0002) /* No reset generated when entering in STOP */
+#define OB_STOP_RST                      ((uint16_t)0x0000) /* Reset generated when entering in STOP */
+
+/* Option_Bytes_nRST_STDBY */
+#define OB_STDBY_NoRST                   ((uint16_t)0x0004) /* No reset generated when entering in STANDBY */
+#define OB_STDBY_RST                     ((uint16_t)0x0000) /* Reset generated when entering in STANDBY */
+
+/* Option_Bytes_RST_ENandDT */
+#define OB_RST_NoEN                      ((uint8_t)0x18) /* Reset IO disable */
+#define OB_RST_EN_DT12ms                 ((uint8_t)0x10) /* Reset IO enable and  Ignore delay time 12ms */
+#define OB_RST_EN_DT1ms                  ((uint8_t)0x08) /* Reset IO enable and  Ignore delay time 1ms */
+#define OB_RST_EN_DT128us                ((uint8_t)0x00) /* Reset IO enable and  Ignore delay time 128us */
+
+
+/* FLASH_Interrupts */
+#define FLASH_IT_ERROR                   ((uint32_t)0x00000400) /* FPEC error interrupt source */
+#define FLASH_IT_EOP                     ((uint32_t)0x00001000) /* End of FLASH Operation Interrupt source */
+#define FLASH_IT_BANK1_ERROR             FLASH_IT_ERROR         /* FPEC BANK1 error interrupt source */
+#define FLASH_IT_BANK1_EOP               FLASH_IT_EOP           /* End of FLASH BANK1 Operation Interrupt source */
+
+/* FLASH_Flags */
+#define FLASH_FLAG_BSY                   ((uint32_t)0x00000001) /* FLASH Busy flag */
+#define FLASH_FLAG_EOP                   ((uint32_t)0x00000020) /* FLASH End of Operation flag */
+#define FLASH_FLAG_WRPRTERR              ((uint32_t)0x00000010) /* FLASH Write protected error flag */
+#define FLASH_FLAG_OPTERR                ((uint32_t)0x00000001) /* FLASH Option Byte error flag */
+
+#define FLASH_FLAG_BANK1_BSY             FLASH_FLAG_BSY       /* FLASH BANK1 Busy flag*/
+#define FLASH_FLAG_BANK1_EOP             FLASH_FLAG_EOP       /* FLASH BANK1 End of Operation flag */
+#define FLASH_FLAG_BANK1_WRPRTERR        FLASH_FLAG_WRPRTERR  /* FLASH BANK1 Write protected error flag */
+
+/* System_Reset_Start_Mode */
+#define Start_Mode_USER                  ((uint32_t)0x00000000)
+#define Start_Mode_BOOT                  ((uint32_t)0x00004000)
+
+
+/* ch32v00x_gpio.h ------------------------------------------------------------*/
+
+#ifndef __ASSEMBLER__
+
+/* Output Maximum frequency selection */
+typedef enum
+{
+	GPIO_Speed_In = 0,
+	GPIO_Speed_10MHz,
+	GPIO_Speed_2MHz,
+	GPIO_Speed_50MHz
+} GPIOSpeed_TypeDef;
+#define GPIO_Speed_30MHz               GPIO_Speed_50MHz
+#endif
+
+#define GPIO_CNF_IN_ANALOG   0
+#define GPIO_CNF_IN_FLOATING 4
+#define GPIO_CNF_IN_PUPD     8
+#define GPIO_CNF_OUT_PP      0
+#define GPIO_CNF_OUT_OD      4
+#define GPIO_CNF_OUT_PP_AF   8
+#define GPIO_CNF_OUT_OD_AF   12
+
+/* Configuration Mode enumeration */
+/*
+typedef enum
+{
+    GPIO_Mode_AIN = 0x0,
+    GPIO_Mode_IN_FLOATING = 0x04,
+    GPIO_Mode_IPD = 0x28,
+    GPIO_Mode_IPU = 0x48,
+    GPIO_Mode_Out_OD = 0x14,
+    GPIO_Mode_Out_PP = 0x10,
+    GPIO_Mode_AF_OD = 0x1C,
+    GPIO_Mode_AF_PP = 0x18
+} GPIOMode_TypeDef;
+*/
+
+#ifndef __ASSEMBLER__
+
+/* Bit_SET and Bit_RESET enumeration */
+typedef enum
+{
+    Bit_RESET = 0,
+    Bit_SET
+} BitAction;
+
+#endif
+
+/* GPIO_pins_define */
+#define GPIO_Pin_0                     ((uint16_t)0x0001) /* Pin 0 selected */
+#define GPIO_Pin_1                     ((uint16_t)0x0002) /* Pin 1 selected */
+#define GPIO_Pin_2                     ((uint16_t)0x0004) /* Pin 2 selected */
+#define GPIO_Pin_3                     ((uint16_t)0x0008) /* Pin 3 selected */
+#define GPIO_Pin_4                     ((uint16_t)0x0010) /* Pin 4 selected */
+#define GPIO_Pin_5                     ((uint16_t)0x0020) /* Pin 5 selected */
+#define GPIO_Pin_6                     ((uint16_t)0x0040) /* Pin 6 selected */
+#define GPIO_Pin_7                     ((uint16_t)0x0080) /* Pin 7 selected */
+#define GPIO_Pin_8                     ((uint16_t)0x0100) /* Pin 8 selected */
+#define GPIO_Pin_9                     ((uint16_t)0x0200) /* Pin 9 selected */
+#define GPIO_Pin_10                    ((uint16_t)0x0400) /* Pin 10 selected */
+#define GPIO_Pin_11                    ((uint16_t)0x0800) /* Pin 11 selected */
+#define GPIO_Pin_12                    ((uint16_t)0x1000) /* Pin 12 selected */
+#define GPIO_Pin_13                    ((uint16_t)0x2000) /* Pin 13 selected */
+#define GPIO_Pin_14                    ((uint16_t)0x4000) /* Pin 14 selected */
+#define GPIO_Pin_15                    ((uint16_t)0x8000) /* Pin 15 selected */
+#define GPIO_Pin_16                     ((uint32_t)0x010000) /* Pin 16 selected */
+#define GPIO_Pin_17                     ((uint32_t)0x020000) /* Pin 17 selected */
+#define GPIO_Pin_18                     ((uint32_t)0x040000) /* Pin 18 selected */
+#define GPIO_Pin_19                     ((uint32_t)0x080000) /* Pin 19 selected */
+#define GPIO_Pin_20                     ((uint32_t)0x100000) /* Pin 20 selected */
+#define GPIO_Pin_21                     ((uint32_t)0x200000) /* Pin 21 selected */
+#define GPIO_Pin_22                     ((uint32_t)0x400000) /* Pin 22 selected */
+#define GPIO_Pin_23                     ((uint32_t)0x800000) /* Pin 23 selected */
+
+#if defined(GPIO_Pin_23)
+#define GPIO_Pin_All                    ((uint32_t)0xFFFFFF) /* All pins selected */
+#else
+#define GPIO_Pin_All                    ((uint16_t)0xFFFF)  /* All pins selected */
+#endif
+
+/* GPIO_Remap_define */
+#define GPIO_PartialRemap1_SPI1         ((uint32_t)0x00100001) /* SPI1 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_SPI1         ((uint32_t)0x00100002) /* SPI1 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_SPI1             ((uint32_t)0x00100003) /* SPI1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_I2C1         ((uint32_t)0x08020004) /* I2C1 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_I2C1         ((uint32_t)0x08020008) /* I2C1 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_I2C1         ((uint32_t)0x0802000C) /* I2C1 Partial3 Alternate Function mapping */
+#define GPIO_PartialRemap4_I2C1         ((uint32_t)0x08020010) /* I2C1 Partial4 Alternate Function mapping */
+#define GPIO_FullRemap_I2C1             ((uint32_t)0x08020014) /* I2C1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_USART1       ((uint32_t)0x00150020) /* USART1 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_USART1       ((uint32_t)0x00150040) /* USART1 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_USART1           ((uint32_t)0x00150060) /* USART1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_USART2       ((uint32_t)0x08070080) /* USART2 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_USART2       ((uint32_t)0x08070100) /* USART2 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_USART2       ((uint32_t)0x08070180) /* USART2 Partial3 Alternate Function mapping */
+#define GPIO_FullRemap_USART2           ((uint32_t)0x08070200) /* USART2 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_USART3       ((uint32_t)0x001A0400) /* USART3 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_USART3       ((uint32_t)0x001A0800) /* USART3 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_USART3           ((uint32_t)0x001A0C00) /* USART3 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_USART4       ((uint32_t)0x080C1000) /* USART4 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_USART4       ((uint32_t)0x080C2000) /* USART4 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_USART4       ((uint32_t)0x080C3000) /* USART4 Partial3 Alternate Function mapping */
+#define GPIO_PartialRemap4_USART4       ((uint32_t)0x080C4000) /* USART4 Partial4 Alternate Function mapping */
+#define GPIO_FullRemap_USART4           ((uint32_t)0x080C7000) /* USART4 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_TIM1         ((uint32_t)0x084F0001) /* TIM1 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_TIM1         ((uint32_t)0x084F0002) /* TIM1 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_TIM1         ((uint32_t)0x084F0003) /* TIM1 Partial3 Alternate Function mapping */
+#define GPIO_FullRemap_TIM1             ((uint32_t)0x084F0004) /* TIM1 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_TIM2         ((uint32_t)0x08220004) /* TIM2 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_TIM2         ((uint32_t)0x08220008) /* TIM2 Partial2 Alternate Function mapping */
+#define GPIO_PartialRemap3_TIM2         ((uint32_t)0x0822000C) /* TIM2 Partial3 Alternate Function mapping */
+#define GPIO_PartialRemap4_TIM2         ((uint32_t)0x08220010) /* TIM2 Partial4 Alternate Function mapping */
+#define GPIO_PartialRemap5_TIM2         ((uint32_t)0x08220014) /* TIM2 Partial5 Alternate Function mapping */
+#define GPIO_FullRemap_TIM2             ((uint32_t)0x08220018) /* TIM2 Full Alternate Function mapping */
+#define GPIO_PartialRemap1_TIM3         ((uint32_t)0x00350020) /* TIM3 Partial1 Alternate Function mapping */
+#define GPIO_PartialRemap2_TIM3         ((uint32_t)0x00350040) /* TIM3 Partial2 Alternate Function mapping */
+#define GPIO_FullRemap_TIM3             ((uint32_t)0x00350060) /* TIM3 Full Alternate Function mapping */
+#define GPIO_Remap_PIOC                 ((uint32_t)0x00200080) /* PIOC Alternate Function mapping */
+#define GPIO_Remap_SWJ_Disable          ((uint32_t)0x08300400) /* SDI Disabled (SDI) */
+
+/* GPIO_Port_Sources */
+#define GPIO_PortSourceGPIOA           ((uint8_t)0x00)
+#define GPIO_PortSourceGPIOC           ((uint8_t)0x02)
+#define GPIO_PortSourceGPIOD           ((uint8_t)0x03)
+#define GPIO_PortSourceGPIOB            ((uint8_t)0x01)
+
+/* GPIO_Pin_sources */
+#define GPIO_PinSource0                ((uint8_t)0x00)
+#define GPIO_PinSource1                ((uint8_t)0x01)
+#define GPIO_PinSource2                ((uint8_t)0x02)
+#define GPIO_PinSource3                ((uint8_t)0x03)
+#define GPIO_PinSource4                ((uint8_t)0x04)
+#define GPIO_PinSource5                ((uint8_t)0x05)
+#define GPIO_PinSource6                ((uint8_t)0x06)
+#define GPIO_PinSource7                ((uint8_t)0x07)
+#define GPIO_PinSource8                 ((uint8_t)0x08)
+#define GPIO_PinSource9                 ((uint8_t)0x09)
+#define GPIO_PinSource10                ((uint8_t)0x0A)
+#define GPIO_PinSource11                ((uint8_t)0x0B)
+#define GPIO_PinSource12                ((uint8_t)0x0C)
+#define GPIO_PinSource13                ((uint8_t)0x0D)
+#define GPIO_PinSource14                ((uint8_t)0x0E)
+#define GPIO_PinSource15                ((uint8_t)0x0F)
+#define GPIO_PinSource16                ((uint8_t)0x10)
+#define GPIO_PinSource17                ((uint8_t)0x11)
+#define GPIO_PinSource18                ((uint8_t)0x12)
+#define GPIO_PinSource19                ((uint8_t)0x13)
+#define GPIO_PinSource20                ((uint8_t)0x14)
+#define GPIO_PinSource21                ((uint8_t)0x15)
+#define GPIO_PinSource22                ((uint8_t)0x16)
+#define GPIO_PinSource23                ((uint8_t)0x17)
+
+
+/* ch32v00x_i2c.h ------------------------------------------------------------*/
+
+/* I2C_mode */
+#define I2C_Mode_I2C                                         ((uint16_t)0x0000)
+
+/* I2C_duty_cycle_in_fast_mode */
+#define I2C_DutyCycle_16_9                                   ((uint16_t)0x4000) /* I2C fast mode Tlow/Thigh = 16/9 */
+#define I2C_DutyCycle_2                                      ((uint16_t)0xBFFF) /* I2C fast mode Tlow/Thigh = 2 */
+
+/* I2C_acknowledgement */
+#define I2C_Ack_Enable                                       ((uint16_t)0x0400)
+#define I2C_Ack_Disable                                      ((uint16_t)0x0000)
+
+/* I2C_transfer_direction */
+#define I2C_Direction_Transmitter                            ((uint8_t)0x00)
+#define I2C_Direction_Receiver                               ((uint8_t)0x01)
+
+/* I2C_acknowledged_address */
+#define I2C_AcknowledgedAddress_7bit                         ((uint16_t)0x4000)
+#define I2C_AcknowledgedAddress_10bit                        ((uint16_t)0xC000)
+
+/* I2C_registers */
+#define I2C_Register_CTLR1                                   ((uint8_t)0x00)
+#define I2C_Register_CTLR2                                   ((uint8_t)0x04)
+#define I2C_Register_OADDR1                                  ((uint8_t)0x08)
+#define I2C_Register_OADDR2                                  ((uint8_t)0x0C)
+#define I2C_Register_DATAR                                   ((uint8_t)0x10)
+#define I2C_Register_STAR1                                   ((uint8_t)0x14)
+#define I2C_Register_STAR2                                   ((uint8_t)0x18)
+#define I2C_Register_CKCFGR                                  ((uint8_t)0x1C)
+
+/* I2C_PEC_position */
+#define I2C_PECPosition_Next                                 ((uint16_t)0x0800)
+#define I2C_PECPosition_Current                              ((uint16_t)0xF7FF)
+
+/* I2C_NACK_position */
+#define I2C_NACKPosition_Next                                ((uint16_t)0x0800)
+#define I2C_NACKPosition_Current                             ((uint16_t)0xF7FF)
+
+/* I2C_interrupts_definition */
+#define I2C_IT_BUF                                           ((uint16_t)0x0400)
+#define I2C_IT_EVT                                           ((uint16_t)0x0200)
+#define I2C_IT_ERR                                           ((uint16_t)0x0100)
+
+/* I2C_interrupts_definition */
+#define I2C_IT_PECERR                                        ((uint32_t)0x01001000)
+#define I2C_IT_OVR                                           ((uint32_t)0x01000800)
+#define I2C_IT_AF                                            ((uint32_t)0x01000400)
+#define I2C_IT_ARLO                                          ((uint32_t)0x01000200)
+#define I2C_IT_BERR                                          ((uint32_t)0x01000100)
+#define I2C_IT_TXE                                           ((uint32_t)0x06000080)
+#define I2C_IT_RXNE                                          ((uint32_t)0x06000040)
+#define I2C_IT_STOPF                                         ((uint32_t)0x02000010)
+#define I2C_IT_ADD10                                         ((uint32_t)0x02000008)
+#define I2C_IT_BTF                                           ((uint32_t)0x02000004)
+#define I2C_IT_ADDR                                          ((uint32_t)0x02000002)
+#define I2C_IT_SB                                            ((uint32_t)0x02000001)
+
+/* SR2 register flags  */
+#define I2C_FLAG_DUALF                                       ((uint32_t)0x00800000)
+#define I2C_FLAG_GENCALL                                     ((uint32_t)0x00100000)
+#define I2C_FLAG_TRA                                         ((uint32_t)0x00040000)
+#define I2C_FLAG_BUSY                                        ((uint32_t)0x00020000)
+#define I2C_FLAG_MSL                                         ((uint32_t)0x00010000)
+
+/* SR1 register flags */
+#define I2C_FLAG_PECERR                                      ((uint32_t)0x10001000)
+#define I2C_FLAG_OVR                                         ((uint32_t)0x10000800)
+#define I2C_FLAG_AF                                          ((uint32_t)0x10000400)
+#define I2C_FLAG_ARLO                                        ((uint32_t)0x10000200)
+#define I2C_FLAG_BERR                                        ((uint32_t)0x10000100)
+#define I2C_FLAG_TXE                                         ((uint32_t)0x10000080)
+#define I2C_FLAG_RXNE                                        ((uint32_t)0x10000040)
+#define I2C_FLAG_STOPF                                       ((uint32_t)0x10000010)
+#define I2C_FLAG_ADD10                                       ((uint32_t)0x10000008)
+#define I2C_FLAG_BTF                                         ((uint32_t)0x10000004)
+#define I2C_FLAG_ADDR                                        ((uint32_t)0x10000002)
+#define I2C_FLAG_SB                                          ((uint32_t)0x10000001)
+
+/****************I2C Master Events (Events grouped in order of communication)********************/
+
+/******************************************************************************************************************** 
+  * @brief  Start communicate
+  * 
+  * After master use I2C_GenerateSTART() function sending the START condition,the master 
+  * has to wait for event 5(the Start condition has been correctly 
+  * released on the I2C bus ).
+  * 
+  */
+/* EVT5 */
+#define  I2C_EVENT_MASTER_MODE_SELECT                      ((uint32_t)0x00030001)  /* BUSY, MSL and SB flag */
+
+/********************************************************************************************************************
+  * @brief  Address Acknowledge
+  * 
+  * When start condition correctly released on the bus(check EVT5), the 
+  * master use I2C_Send7bitAddress() function sends the address of the slave(s) with which it will communicate 
+  * it also determines master as transmitter or Receiver. Then the master has to wait that a slave acknowledges 
+  * his address. If an acknowledge is sent on the bus, one of the following events will be set:
+  * 
+  *
+  * 
+  *  1) In case of Master Receiver (7-bit addressing): the I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED 
+  *     event is set.
+  *  
+  *  2) In case of Master Transmitter (7-bit addressing): the I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED 
+  *     is set
+  *  
+  *  3) In case of 10-Bit addressing mode, the master (after generating the START 
+  *  and checking on EVT5) use I2C_SendData() function send the header of 10-bit addressing mode.  
+  *  Then master wait EVT9. EVT9 means that the 10-bit addressing header has been correctly sent 
+  *  on the bus. Then master should use the function I2C_Send7bitAddress() to send the second part 
+  *  of the 10-bit address (LSB) . Then master should wait for event 6. 
+  *
+  *     
+  */
+
+/* EVT6 */
+#define  I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED        ((uint32_t)0x00070082)  /* BUSY, MSL, ADDR, TXE and TRA flags */
+#define  I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED           ((uint32_t)0x00030002)  /* BUSY, MSL and ADDR flags */
+/*EVT9 */
+#define  I2C_EVENT_MASTER_MODE_ADDRESS10                   ((uint32_t)0x00030008)  /* BUSY, MSL and ADD10 flags */
+
+/******************************************************************************************************************** 
+  * @brief Communication events
+  * 
+  * If START condition has generated and slave address 
+  * been acknowledged. then the master has to check one of the following events for 
+  * communication procedures:
+  *  
+  * 1) Master Receiver mode: The master has to wait on the event EVT7 then use  
+  *   I2C_ReceiveData() function to read the data received from the slave .
+  * 
+  * 2) Master Transmitter mode: The master use I2C_SendData() function to send data  
+  *     then to wait on event EVT8 or EVT8_2.
+  *    These two events are similar: 
+  *     - EVT8 means that the data has been written in the data register and is 
+  *       being shifted out.
+  *     - EVT8_2 means that the data has been physically shifted out and output 
+  *       on the bus.
+  *     In most cases, using EVT8 is sufficient for the application.
+  *     Using EVT8_2  will leads to a slower communication  speed but will more reliable .
+  *     EVT8_2 is also more suitable than EVT8 for testing on the last data transmission 
+  *    
+  *     
+  *  Note:
+  *  In case the  user software does not guarantee that this event EVT7 is managed before 
+  *  the current byte end of transfer, then user may check on I2C_EVENT_MASTER_BYTE_RECEIVED 
+  *  and I2C_FLAG_BTF flag at the same time .But in this case the communication may be slower.
+  *
+  * 
+  */
+
+/* Master Receive mode */ 
+/* EVT7 */
+#define  I2C_EVENT_MASTER_BYTE_RECEIVED                    ((uint32_t)0x00030040)  /* BUSY, MSL and RXNE flags */
+
+/* Master Transmitter mode*/
+/* EVT8 */
+#define I2C_EVENT_MASTER_BYTE_TRANSMITTING                 ((uint32_t)0x00070080) /* TRA, BUSY, MSL, TXE flags */
+/* EVT8_2 */
+#define  I2C_EVENT_MASTER_BYTE_TRANSMITTED                 ((uint32_t)0x00070084)  /* TRA, BUSY, MSL, TXE and BTF flags */
+
+/******************I2C Slave Events (Events grouped in order of communication)******************/
+
+/******************************************************************************************************************** 
+  * @brief  Start Communicate events
+  * 
+  * Wait on one of these events at the start of the communication. It means that 
+  * the I2C peripheral detected a start condition of master device generate on the bus.  
+  * If the acknowledge feature is enabled through function I2C_AcknowledgeConfig()),The peripheral generates an ACK condition on the bus. 
+  *    
+  *
+  *
+  * a) In normal case (only one address managed by the slave), when the address 
+  *   sent by the master matches the own address of the peripheral (configured by 
+  *   I2C_OwnAddress1 field) the I2C_EVENT_SLAVE_XXX_ADDRESS_MATCHED event is set 
+  *   (where XXX could be TRANSMITTER or RECEIVER).
+  *    
+  * b) In case the address sent by the master matches the second address of the 
+  *   peripheral (configured by the function I2C_OwnAddress2Config() and enabled 
+  *   by the function I2C_DualAddressCmd()) the events I2C_EVENT_SLAVE_XXX_SECONDADDRESS_MATCHED 
+  *   (where XXX could be TRANSMITTER or RECEIVER) are set.
+  *   
+  * c) In case the address sent by the master is General Call (address 0x00) and 
+  *   if the General Call is enabled for the peripheral (using function I2C_GeneralCallCmd()) 
+  *   the following event is set I2C_EVENT_SLAVE_GENERALCALLADDRESS_MATCHED.   
+  * 
+  */
+
+/* EVT1 */   
+/* a) Case of One Single Address managed by the slave */
+#define  I2C_EVENT_SLAVE_RECEIVER_ADDRESS_MATCHED          ((uint32_t)0x00020002) /* BUSY and ADDR flags */
+#define  I2C_EVENT_SLAVE_TRANSMITTER_ADDRESS_MATCHED       ((uint32_t)0x00060082) /* TRA, BUSY, TXE and ADDR flags */
+
+/* b) Case of Dual address managed by the slave */
+#define  I2C_EVENT_SLAVE_RECEIVER_SECONDADDRESS_MATCHED    ((uint32_t)0x00820000)  /* DUALF and BUSY flags */
+#define  I2C_EVENT_SLAVE_TRANSMITTER_SECONDADDRESS_MATCHED ((uint32_t)0x00860080)  /* DUALF, TRA, BUSY and TXE flags */
+
+/* c) Case of General Call enabled for the slave */
+#define  I2C_EVENT_SLAVE_GENERALCALLADDRESS_MATCHED        ((uint32_t)0x00120000)  /* GENCALL and BUSY flags */
+
+/******************************************************************************************************************** 
+  * @brief  Communication events
+  * 
+  * Wait on one of these events when EVT1 has already been checked : 
+  * 
+  * - Slave Receiver mode:
+  *     - EVT2--The device is expecting to receive a data byte . 
+  *     - EVT4--The device is expecting the end of the communication: master 
+  *       sends a stop condition and data transmission is stopped.
+  *    
+  * - Slave Transmitter mode:
+  *    - EVT3--When a byte has been transmitted by the slave and the Master is expecting 
+  *      the end of the byte transmission. The two events I2C_EVENT_SLAVE_BYTE_TRANSMITTED and
+  *      I2C_EVENT_SLAVE_BYTE_TRANSMITTING are similar. If the user software doesn't guarantee 
+  *      the EVT3 is managed before the current byte end of transfer The second one can optionally
+  *      be used. 
+  *    - EVT3_2--When the master sends a NACK  to tell slave device that data transmission 
+  *      shall end . The slave device has to stop sending 
+  *      data bytes and wait a Stop condition from bus.
+  *      
+  *  Note:
+  *  If the  user software does not guarantee that the event 2 is 
+  *  managed before the current byte end of transfer, User may check on I2C_EVENT_SLAVE_BYTE_RECEIVED 
+  *  and I2C_FLAG_BTF flag at the same time .
+  *  In this case the communication will be slower.
+  *
+  */
+
+/* Slave Receiver mode*/ 
+/* EVT2 */
+#define  I2C_EVENT_SLAVE_BYTE_RECEIVED                     ((uint32_t)0x00020040)  /* BUSY and RXNE flags */
+/* EVT4  */
+#define  I2C_EVENT_SLAVE_STOP_DETECTED                     ((uint32_t)0x00000010)  /* STOPF flag */
+
+/* Slave Transmitter mode -----------------------*/
+/* EVT3 */
+#define  I2C_EVENT_SLAVE_BYTE_TRANSMITTED                  ((uint32_t)0x00060084)  /* TRA, BUSY, TXE and BTF flags */
+#define  I2C_EVENT_SLAVE_BYTE_TRANSMITTING                 ((uint32_t)0x00060080)  /* TRA, BUSY and TXE flags */
+/*EVT3_2 */
+#define  I2C_EVENT_SLAVE_ACK_FAILURE                       ((uint32_t)0x00000400)  /* AF flag */
+
+
+/* ch32v00x_iwdg.h -----------------------------------------------------------*/
+
+/* IWDG_WriteAccess */
+#define IWDG_WriteAccess_Enable     ((uint16_t)0x5555)
+#define IWDG_WriteAccess_Disable    ((uint16_t)0x0000)
+
+/* IWDG_prescaler */
+#define IWDG_Prescaler_4            ((uint8_t)0x00)
+#define IWDG_Prescaler_8            ((uint8_t)0x01)
+#define IWDG_Prescaler_16           ((uint8_t)0x02)
+#define IWDG_Prescaler_32           ((uint8_t)0x03)
+#define IWDG_Prescaler_64           ((uint8_t)0x04)
+#define IWDG_Prescaler_128          ((uint8_t)0x05)
+#define IWDG_Prescaler_256          ((uint8_t)0x06)
+
+/* IWDG_Flag */
+#define IWDG_FLAG_PVU               ((uint16_t)0x0001)
+#define IWDG_FLAG_RVU               ((uint16_t)0x0002)
+
+
+/* ch32v00x_misc.h -----------------------------------------------------------*/
+
+/* Preemption_Priority_Group */
+#define NVIC_PriorityGroup_0           ((uint32_t)0x00)
+#define NVIC_PriorityGroup_1           ((uint32_t)0x01)
+#define NVIC_PriorityGroup_2           ((uint32_t)0x02)
+#define NVIC_PriorityGroup_3           ((uint32_t)0x03)
+#define NVIC_PriorityGroup_4           ((uint32_t)0x04)
+
+/* ch32v00x_opa.h ------------------------------------------------------------*/
+
+/* Editor's note: I don't know if this is actually useful */
+#ifndef __ASSEMBLER__
+
+
+/* OPA_member_enumeration */
+typedef enum
+{
+    OPA1 = 0,
+    OPA2
+} OPA_Num_TypeDef;
+
+/* OPA_out_channel_enumeration */
+typedef enum
+{
+    OUT_IO_OUT0 = 0,
+    OUT_IO_OUT1
+} OPA_Mode_TypeDef;
+
+
+/* OPA PSEL enumeration */
+typedef enum
+{
+    CHP0 = 0,
+    CHP1,
+    CHP2,
+    CHP_OFF
+} OPA_PSEL_TypeDef;
+
+/* OPA_FB_enumeration */
+typedef enum
+{
+    FB_OFF = 0,
+    FB_ON
+} OPA_FB_TypeDef;
+
+/* OPA NSEL enumeration */
+typedef enum
+{
+    CHN0 = 0,
+    CHN1,
+    CHN2_PGA_16xIN,
+    CHN_PGA_4xIN,
+    CHN_PGA_8xIN,
+    CHN_PGA_16xIN,
+    CHN_PGA_32xIN,
+    CHN_OFF
+} OPA_NSEL_TypeDef;
+
+/* OPA_PSEL_POLL_enumeration */
+typedef enum
+{
+    CHP_OPA1_OFF_OPA2_OFF = 0,
+    CHP_OPA1_ON_OPA2_OFF,
+    CHP_OPA1_OFF_OPA2_ON,
+    CHP_OPA1_ON_OPA2_ON
+} OPA_PSEL_POLL_TypeDef;
+
+/* OPA_BKIN_EN_enumeration */
+typedef enum
+{
+    BKIN_OPA1_OFF_OPA2_OFF = 0,
+    BKIN_OPA1_ON_OPA2_OFF,
+    BKIN_OPA1_OFF_OPA2_ON,
+    BKIN_OPA1_ON_OPA2_ON
+} OPA_BKIN_EN_TypeDef;
+
+/* OPA_RST_EN_enumeration */
+typedef enum
+{
+    RST_OPA1_OFF_OPA2_OFF = 0,
+    RST_OPA1_ON_OPA2_OFF,
+    RST_OPA1_OFF_OPA2_ON,
+    RST_OPA1_ON_OPA2_ON
+} OPA_RST_EN_TypeDef;
+
+/* OPA_BKIN_SEL_enumeration */
+typedef enum
+{
+    BKIN_OPA1_TIM1_OPA2_TIM2 = 0,
+    BKIN_OPA1_TIM2_OPA2_TIM1
+} OPA_BKIN_SEL_TypeDef;
+
+/* OPA_OUT_IE_enumeration */
+typedef enum
+{
+    OUT_IE_OPA1_OFF_OPA2_OFF = 0,
+    OUT_IE_OPA1_ON_OPA2_OFF,
+    OUT_IE_OPA1_OFF_OPA2_ON,
+    OUT_IE_OPA1_ON_OPA2_ON
+} OPA_OUT_IE_TypeDef;
+
+/* OPA_CNT_IE_enumeration */
+typedef enum
+{
+    CNT_IE_OFF = 0,
+    CNT_IE_ON,
+} OPA_CNT_IE_TypeDef;
+
+/* OPA_NMI_IE_enumeration */
+typedef enum
+{
+    NMI_IE_OFF = 0,
+    NMI_IE_ON,
+} OPA_NMI_IE_TypeDef;
+
+/* OPA_PSEL_POLL_NUM_enumeration */
+typedef enum
+{
+    CHP_POLL_NUM_1 = 0,
+    CHP_POLL_NUM_2,
+    CHP_POLL_NUM_3
+} OPA_PSEL_POLL_NUM_TypeDef;
+
+
+
+/* OPA Init Structure definition */
+typedef struct
+{
+    uint16_t                  OPA_POLL_Interval; /* OPA polling interval = (OPA_POLL_Interval+1)*1us
+                                                      This parameter must range from 0 to 0x1FF.*/
+    OPA_Num_TypeDef           OPA_NUM;  /* Specifies the members of OPA */
+    OPA_Mode_TypeDef          Mode;     /* Specifies the mode of OPA */
+    OPA_PSEL_TypeDef          PSEL;     /* Specifies the positive channel of OPA */
+    OPA_FB_TypeDef            FB;       /* Specifies the internal feedback resistor of OPA */
+    OPA_NSEL_TypeDef          NSEL;     /* Specifies the negative channel of OPA */
+    OPA_PSEL_POLL_TypeDef     PSEL_POLL; /* Specifies the positive channel poll of OPA */
+    OPA_BKIN_EN_TypeDef       BKIN_EN;  /* Specifies the brake input source of OPA */
+    OPA_RST_EN_TypeDef        RST_EN;   /* Specifies the reset source of OPA */
+    OPA_BKIN_SEL_TypeDef      BKIN_SEL; /* Specifies the brake input source selection of OPA */
+    OPA_OUT_IE_TypeDef        OUT_IE;   /* Specifies the out interrupt of OPA */
+    OPA_CNT_IE_TypeDef        CNT_IE;   /* Specifies the out interrupt rising edge of sampling data */
+    OPA_NMI_IE_TypeDef        NMI_IE;   /* Specifies the out NIM interrupt of OPA */
+    OPA_PSEL_POLL_NUM_TypeDef POLL_NUM; /* Specifies the number of forward inputs*/
+} OPA_InitTypeDef;
+
+/* CMP_member_enumeration */
+typedef enum
+{
+    CMP1 = 0,
+    CMP2,
+    CMP3
+} CMP_Num_TypeDef;
+
+/* CMP_out_channel_enumeration */
+typedef enum
+{
+    OUT_IO_TIM2 = 0,
+    OUT_IO0
+} CMP_Mode_TypeDef;
+
+/* CMP_NSEL_enumeration */
+typedef enum
+{
+    CMP_CHN0 = 0,
+    CMP_CHN1,
+} CMP_NSEL_TypeDef;
+
+/* CMP_PSEL_enumeration */
+typedef enum
+{
+    CMP_CHP1 = 0,
+    CMP_CHP2,
+} CMP_PSEL_TypeDef;
+
+/* CMP_HYEN_enumeration */
+typedef enum
+{
+    CMP_HYEN1 = 0,
+    CMP_HYEN2,
+} CMP_HYEN_TypeDef;
+
+/* CMP Init Structure definition */
+typedef struct
+{
+    CMP_Num_TypeDef    CMP_NUM;  /* Specifies the members of CMP */
+    CMP_Mode_TypeDef   Mode;     /* Specifies the mode of CMP */
+    CMP_NSEL_TypeDef   NSEL;     /* Specifies the negative channel of CMP */
+    CMP_PSEL_TypeDef   PSEL;     /* Specifies the positive channel of CMP */
+    CMP_HYEN_TypeDef   HYEN;     /* Specifies the hysteresis comparator of CMP */
+} CMP_InitTypeDef;
+
+/* OPA_flags_definition */
+#define OPA_FLAG_OUT_OPA1                  ((uint16_t)0x1000)
+#define OPA_FLAG_OUT_OPA2                  ((uint16_t)0x2000)
+#define OPA_FLAG_OUT_CNT                   ((uint16_t)0x4000)
+
+#endif
+
+/* ch32v00x_pwr.h ------------------------------------------------------------*/
+
+/* PVD_detection_level  */
+#define PWR_PVDLevel_0            ((uint32_t)0x00000000)
+#define PWR_PVDLevel_1            ((uint32_t)0x00000020)
+#define PWR_PVDLevel_2            ((uint32_t)0x00000040)
+#define PWR_PVDLevel_3            ((uint32_t)0x00000060)
+
+#define PWR_PVDLevel_2V1          PWR_PVDLevel_0
+#define PWR_PVDLevel_2V3          PWR_PVDLevel_1
+#define PWR_PVDLevel_3V0          PWR_PVDLevel_2
+#define PWR_PVDLevel_4V0          PWR_PVDLevel_3
+
+
+/* STOP_mode_entry */
+#define PWR_STOPEntry_WFI         ((uint8_t)0x01)
+#define PWR_STOPEntry_WFE         ((uint8_t)0x02)
+
+/* PWR_Flag */
+#define PWR_FLAG_PVDO             ((uint32_t)0x00000004)
+#define PWR_FLAG_FLASH            ((uint32_t)0x00000020)
+
+
+/* ch32v00x_rcc.h ------------------------------------------------------------*/
+
+
+/* HSE_configuration */
+#define RCC_HSE_OFF                      ((uint32_t)0x00000000)
+#define RCC_HSE_ON                       ((uint32_t)0x00010000)
+#define RCC_HSE_Bypass                   ((uint32_t)0x00040000)
+
+
+/* System_clock_source */
+#define RCC_SYSCLKSource_HSI             ((uint32_t)0x00000000)
+#define RCC_SYSCLKSource_HSE             ((uint32_t)0x00000001)
+#define RCC_SYSCLKSource_PLLCLK          ((uint32_t)0x00000002)
+
+
+/* AHB_clock_source */
+#define RCC_SYSCLK_Div1                  ((uint32_t)0x00000000)
+#define RCC_SYSCLK_Div2                  ((uint32_t)0x00000010)
+#define RCC_SYSCLK_Div3                  ((uint32_t)0x00000020)
+#define RCC_SYSCLK_Div4                  ((uint32_t)0x00000030)
+#define RCC_SYSCLK_Div5                  ((uint32_t)0x00000040)
+#define RCC_SYSCLK_Div6                  ((uint32_t)0x00000050)
+#define RCC_SYSCLK_Div7                  ((uint32_t)0x00000060)
+#define RCC_SYSCLK_Div8                  ((uint32_t)0x00000070)
+#define RCC_SYSCLK_Div16                 ((uint32_t)0x000000B0)
+#define RCC_SYSCLK_Div32                 ((uint32_t)0x000000C0)
+#define RCC_SYSCLK_Div64                 ((uint32_t)0x000000D0)
+#define RCC_SYSCLK_Div128                ((uint32_t)0x000000E0)
+#define RCC_SYSCLK_Div256                ((uint32_t)0x000000F0)
+
+/* RCC_Interrupt_source */
+#define RCC_IT_LSIRDY                    ((uint8_t)0x01)
+#define RCC_IT_HSIRDY                    ((uint8_t)0x04)
+#define RCC_IT_HSERDY                    ((uint8_t)0x08)
+#define RCC_IT_PLLRDY                    ((uint8_t)0x10)
+#define RCC_IT_CSS                       ((uint8_t)0x80)
+
+
+
+
+
+
+
+
+/* AHB_peripheral */
+#define RCC_AHBPeriph_DMA1               ((uint32_t)0x00000001)
+#define RCC_AHBPeriph_SRAM               ((uint32_t)0x00000004)
+#define RCC_AHBPeriph_USBFS              ((uint32_t)0x00001000)
+#define RCC_AHBPeriph_USBHD              RCC_AHBPeriph_USBFS
+#define RCC_AHBPeriph_IO2W               ((uint32_t)0x00002000)
+#define RCC_AHBPeriph_USBPD              ((uint32_t)0x00020000)
+
+/* APB2_peripheral */
+#define RCC_APB2Periph_AFIO              ((uint32_t)0x00000001)
+#define RCC_APB2Periph_GPIOA             ((uint32_t)0x00000004)
+#define RCC_APB2Periph_GPIOB             ((uint32_t)0x00000008)
+#define RCC_APB2Periph_GPIOC             ((uint32_t)0x00000010)
+#define RCC_APB2Periph_GPIOD             ((uint32_t)0x00000020)
+#define RCC_APB2Periph_ADC1              ((uint32_t)0x00000200)
+#define RCC_APB2Periph_TIM1              ((uint32_t)0x00000800)
+#define RCC_APB2Periph_SPI1              ((uint32_t)0x00001000)
+#define RCC_APB2Periph_USART1            ((uint32_t)0x00004000)
+
+/* APB1_peripheral */
+#define RCC_APB1Periph_TIM2              ((uint32_t)0x00000001)
+#define RCC_APB1Periph_TIM3              ((uint32_t)0x00000002)
+#define RCC_APB1Periph_WWDG              ((uint32_t)0x00000800)
+#define RCC_APB1Periph_USART2            ((uint32_t)0x00020000)
+#define RCC_APB1Periph_USART3            ((uint32_t)0x00040000)
+#define RCC_APB1Periph_USART4            ((uint32_t)0x00080000)
+#define RCC_APB1Periph_I2C1              ((uint32_t)0x00200000)
+#define RCC_APB1Periph_PWR               ((uint32_t)0x10000000)
+
+
+/* APB2_peripheral */
+#define RCC_APB2Periph_GPIOB             ((uint32_t)0x00000008)
+
+#define RCC_APB1Periph_TIM3              ((uint32_t)0x00000002)
+#define RCC_APB1Periph_USART2            ((uint32_t)0x00020000)
+#define RCC_APB1Periph_USART3            ((uint32_t)0x00040000)
+#define RCC_APB1Periph_USART4            ((uint32_t)0x00080000)
+
+
+
+/* Clock_source_to_output_on_MCO_pin */
+#define RCC_MCO_NoClock                  ((uint8_t)0x00)
+#define RCC_MCO_SYSCLK                   ((uint8_t)0x04)
+#define RCC_MCO_HSI                      ((uint8_t)0x05)
+#define RCC_MCO_HSE                      ((uint8_t)0x06)
+
+
+/* RCC_Flag */
+#define RCC_FLAG_HSIRDY                  ((uint8_t)0x21)
+#define RCC_FLAG_HSERDY                  ((uint8_t)0x31)
+#define RCC_FLAG_PLLRDY                  ((uint8_t)0x39)
+#define RCC_FLAG_LSIRDY                  ((uint8_t)0x61)
+#define RCC_FLAG_OPARST                  ((uint8_t)0x79)
+#define RCC_FLAG_PINRST                  ((uint8_t)0x7A)
+#define RCC_FLAG_PORRST                  ((uint8_t)0x7B)
+#define RCC_FLAG_SFTRST                  ((uint8_t)0x7C)
+#define RCC_FLAG_IWDGRST                 ((uint8_t)0x7D)
+#define RCC_FLAG_WWDGRST                 ((uint8_t)0x7E)
+#define RCC_FLAG_LPWRRST                 ((uint8_t)0x7F)
+
+
+
+/* SysTick_clock_source */
+#define SysTick_CLKSource_HCLK_Div8      ((uint32_t)0xFFFFFFFB)
+#define SysTick_CLKSource_HCLK           ((uint32_t)0x00000004)
+
+
+
+
+
+
+
+
+
+/* ch32v00x_spi.h ------------------------------------------------------------*/
+
+
+/* SPI_data_direction */
+#define SPI_Direction_2Lines_FullDuplex    ((uint16_t)0x0000)
+#define SPI_Direction_2Lines_RxOnly        ((uint16_t)0x0400)
+#define SPI_Direction_1Line_Rx             ((uint16_t)0x8000)
+#define SPI_Direction_1Line_Tx             ((uint16_t)0xC000)
+
+/* SPI_mode */
+#define SPI_Mode_Master                    ((uint16_t)0x0104) /* Sets MSTR, as well as SSI, which is required for Master Mode */
+#define SPI_Mode_Slave                     ((uint16_t)0x0000)
+
+/* SPI_data_size */
+#define SPI_DataSize_16b                   ((uint16_t)0x0800)
+#define SPI_DataSize_8b                    ((uint16_t)0x0000)
+
+/* SPI_Clock_Polarity */
+#define SPI_CPOL_Low                       ((uint16_t)0x0000)
+#define SPI_CPOL_High                      ((uint16_t)0x0002)
+
+/* SPI_Clock_Phase */
+#define SPI_CPHA_1Edge                     ((uint16_t)0x0000)
+#define SPI_CPHA_2Edge                     ((uint16_t)0x0001)
+
+/* SPI_Slave_Select_management */
+#define SPI_NSS_Soft                       ((uint16_t)0x0200)
+#define SPI_NSS_Hard                       ((uint16_t)0x0000)
+
+/* SPI_BaudRate_Prescaler */
+#define SPI_BaudRatePrescaler_2            ((uint16_t)0x0000)
+#define SPI_BaudRatePrescaler_4            ((uint16_t)0x0008)
+#define SPI_BaudRatePrescaler_8            ((uint16_t)0x0010)
+#define SPI_BaudRatePrescaler_16           ((uint16_t)0x0018)
+#define SPI_BaudRatePrescaler_32           ((uint16_t)0x0020)
+#define SPI_BaudRatePrescaler_64           ((uint16_t)0x0028)
+#define SPI_BaudRatePrescaler_128          ((uint16_t)0x0030)
+#define SPI_BaudRatePrescaler_256          ((uint16_t)0x0038)
+
+/* SPI_MSB transmission */
+#define SPI_FirstBit_MSB                   ((uint16_t)0x0000)
+#define SPI_FirstBit_LSB                   ((uint16_t)0x0080)//not support SPI slave mode
+
+/* SPI_I2S_DMA_transfer_requests */
+#define SPI_I2S_DMAReq_Tx                  ((uint16_t)0x0002)
+#define SPI_I2S_DMAReq_Rx                  ((uint16_t)0x0001)
+
+/* SPI_NSS_internal_software_management */
+#define SPI_NSSInternalSoft_Set            ((uint16_t)0x0100)
+#define SPI_NSSInternalSoft_Reset          ((uint16_t)0xFEFF)
+
+/* SPI_CRC_Transmit_Receive */
+#define SPI_CRC_Tx                         ((uint8_t)0x00)
+#define SPI_CRC_Rx                         ((uint8_t)0x01)
+
+/* SPI_direction_transmit_receive */
+#define SPI_Direction_Rx                   ((uint16_t)0xBFFF)
+#define SPI_Direction_Tx                   ((uint16_t)0x4000)
+
+/* SPI_I2S_interrupts_definition */
+#define SPI_I2S_IT_TXE                     ((uint8_t)0x71)
+#define SPI_I2S_IT_RXNE                    ((uint8_t)0x60)
+#define SPI_I2S_IT_ERR                     ((uint8_t)0x50)
+#define SPI_I2S_IT_OVR                     ((uint8_t)0x56)
+#define SPI_IT_MODF                        ((uint8_t)0x55)
+#define SPI_IT_CRCERR                      ((uint8_t)0x54)
+#define I2S_IT_UDR                         ((uint8_t)0x53)
+
+/* SPI_I2S_flags_definition */
+#define SPI_I2S_FLAG_RXNE                  ((uint16_t)0x0001)
+#define SPI_I2S_FLAG_TXE                   ((uint16_t)0x0002)
+#define I2S_FLAG_CHSIDE                    ((uint16_t)0x0004)
+#define I2S_FLAG_UDR                       ((uint16_t)0x0008)
+#define SPI_FLAG_CRCERR                    ((uint16_t)0x0010)
+#define SPI_FLAG_MODF                      ((uint16_t)0x0020)
+#define SPI_I2S_FLAG_OVR                   ((uint16_t)0x0040)
+#define SPI_I2S_FLAG_BSY                   ((uint16_t)0x0080)
+
+
+/* ch32v00x_tim.h ------------------------------------------------------------*/
+
+/* TIM_Output_Compare_and_PWM_modes */
+#define TIM_OCMode_Timing                  ((uint16_t)0x0000)
+#define TIM_OCMode_Active                  ((uint16_t)0x0010)
+#define TIM_OCMode_Inactive                ((uint16_t)0x0020)
+#define TIM_OCMode_Toggle                  ((uint16_t)0x0030)
+#define TIM_OCMode_PWM1                    ((uint16_t)0x0060)
+#define TIM_OCMode_PWM2                    ((uint16_t)0x0070)
+
+/* TIM_One_Pulse_Mode */
+#define TIM_OPMode_Single                  ((uint16_t)0x0008)
+#define TIM_OPMode_Repetitive              ((uint16_t)0x0000)
+
+/* TIM_Channel */
+#define TIM_Channel_1                      ((uint16_t)0x0000)
+#define TIM_Channel_2                      ((uint16_t)0x0004)
+#define TIM_Channel_3                      ((uint16_t)0x0008)
+#define TIM_Channel_4                      ((uint16_t)0x000C)
+
+/* TIM_Clock_Division_CKD */
+#define TIM_CKD_DIV1                       ((uint16_t)0x0000)
+#define TIM_CKD_DIV2                       ((uint16_t)0x0100)
+#define TIM_CKD_DIV4                       ((uint16_t)0x0200)
+
+/* TIM_Counter_Mode */
+#define TIM_CounterMode_Up                 ((uint16_t)0x0000)
+#define TIM_CounterMode_Down               ((uint16_t)0x0010)
+#define TIM_CounterMode_CenterAligned1     ((uint16_t)0x0020)
+#define TIM_CounterMode_CenterAligned2     ((uint16_t)0x0040)
+#define TIM_CounterMode_CenterAligned3     ((uint16_t)0x0060)
+
+/* TIM_Output_Compare_Polarity */
+#define TIM_OCPolarity_High                ((uint16_t)0x0000)
+#define TIM_OCPolarity_Low                 ((uint16_t)0x0002)
+
+/* TIM_Output_Compare_N_Polarity */
+#define TIM_OCNPolarity_High               ((uint16_t)0x0000)
+#define TIM_OCNPolarity_Low                ((uint16_t)0x0008)
+
+/* TIM_Output_Compare_state */
+#define TIM_OutputState_Disable            ((uint16_t)0x0000)
+#define TIM_OutputState_Enable             ((uint16_t)0x0001)
+
+/* TIM_Output_Compare_N_state */
+#define TIM_OutputNState_Disable           ((uint16_t)0x0000)
+#define TIM_OutputNState_Enable            ((uint16_t)0x0004)
+
+/* TIM_Capture_Compare_state */
+#define TIM_CCx_Enable                     ((uint16_t)0x0001)
+#define TIM_CCx_Disable                    ((uint16_t)0x0000)
+
+/* TIM_Capture_Compare_N_state */
+#define TIM_CCxN_Enable                    ((uint16_t)0x0004)
+#define TIM_CCxN_Disable                   ((uint16_t)0x0000)
+
+/* Break_Input_enable_disable */
+#define TIM_Break_Enable                   ((uint16_t)0x1000)
+#define TIM_Break_Disable                  ((uint16_t)0x0000)
+
+/* Break_Polarity */
+#define TIM_BreakPolarity_Low              ((uint16_t)0x0000)
+#define TIM_BreakPolarity_High             ((uint16_t)0x2000)
+
+/* TIM_AOE_Bit_Set_Reset */
+#define TIM_AutomaticOutput_Enable         ((uint16_t)0x4000)
+#define TIM_AutomaticOutput_Disable        ((uint16_t)0x0000)
+
+/* Lock_level */
+#define TIM_LOCKLevel_OFF                  ((uint16_t)0x0000)
+#define TIM_LOCKLevel_1                    ((uint16_t)0x0100)
+#define TIM_LOCKLevel_2                    ((uint16_t)0x0200)
+#define TIM_LOCKLevel_3                    ((uint16_t)0x0300)
+
+/* OSSI_Off_State_Selection_for_Idle_mode_state */
+#define TIM_OSSIState_Enable               ((uint16_t)0x0400)
+#define TIM_OSSIState_Disable              ((uint16_t)0x0000)
+
+/* OSSR_Off_State_Selection_for_Run_mode_state */
+#define TIM_OSSRState_Enable               ((uint16_t)0x0800)
+#define TIM_OSSRState_Disable              ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_Idle_State */
+#define TIM_OCIdleState_Set                ((uint16_t)0x0100)
+#define TIM_OCIdleState_Reset              ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_N_Idle_State */
+#define TIM_OCNIdleState_Set               ((uint16_t)0x0200)
+#define TIM_OCNIdleState_Reset             ((uint16_t)0x0000)
+
+/* TIM_Input_Capture_Polarity */
+#define TIM_ICPolarity_Rising              ((uint16_t)0x0000)
+#define TIM_ICPolarity_Falling             ((uint16_t)0x0002)
+#define TIM_ICPolarity_BothEdge            ((uint16_t)0x000A)
+
+/* TIM_Input_Capture_Selection */
+#define TIM_ICSelection_DirectTI           ((uint16_t)0x0001) /* TIM Input 1, 2, 3 or 4 is selected to be \
+                                                                 connected to IC1, IC2, IC3 or IC4, respectively */
+#define TIM_ICSelection_IndirectTI         ((uint16_t)0x0002) /* TIM Input 1, 2, 3 or 4 is selected to be \
+                                                                 connected to IC2, IC1, IC4 or IC3, respectively. */
+#define TIM_ICSelection_TRC                ((uint16_t)0x0003) /* TIM Input 1, 2, 3 or 4 is selected to be connected to TRC. */
+
+/* TIM_Input_Capture_Prescaler */
+#define TIM_ICPSC_DIV1                     ((uint16_t)0x0000) /* Capture performed each time an edge is detected on the capture input. */
+#define TIM_ICPSC_DIV2                     ((uint16_t)0x0004) /* Capture performed once every 2 events. */
+#define TIM_ICPSC_DIV4                     ((uint16_t)0x0008) /* Capture performed once every 4 events. */
+#define TIM_ICPSC_DIV8                     ((uint16_t)0x000C) /* Capture performed once every 8 events. */
+
+/* TIM_interrupt_sources */
+#define TIM_IT_Update                      ((uint16_t)0x0001)
+#define TIM_IT_CC1                         ((uint16_t)0x0002)
+#define TIM_IT_CC2                         ((uint16_t)0x0004)
+#define TIM_IT_CC3                         ((uint16_t)0x0008)
+#define TIM_IT_CC4                         ((uint16_t)0x0010)
+#define TIM_IT_COM                         ((uint16_t)0x0020)
+#define TIM_IT_Trigger                     ((uint16_t)0x0040)
+#define TIM_IT_Break                       ((uint16_t)0x0080)
+
+/* TIM_DMA_Base_address */
+#define TIM_DMABase_CR1                    ((uint16_t)0x0000)
+#define TIM_DMABase_CR2                    ((uint16_t)0x0001)
+#define TIM_DMABase_SMCR                   ((uint16_t)0x0002)
+#define TIM_DMABase_DIER                   ((uint16_t)0x0003)
+#define TIM_DMABase_SR                     ((uint16_t)0x0004)
+#define TIM_DMABase_EGR                    ((uint16_t)0x0005)
+#define TIM_DMABase_CCMR1                  ((uint16_t)0x0006)
+#define TIM_DMABase_CCMR2                  ((uint16_t)0x0007)
+#define TIM_DMABase_CCER                   ((uint16_t)0x0008)
+#define TIM_DMABase_CNT                    ((uint16_t)0x0009)
+#define TIM_DMABase_PSC                    ((uint16_t)0x000A)
+#define TIM_DMABase_ARR                    ((uint16_t)0x000B)
+#define TIM_DMABase_RCR                    ((uint16_t)0x000C)
+#define TIM_DMABase_CCR1                   ((uint16_t)0x000D)
+#define TIM_DMABase_CCR2                   ((uint16_t)0x000E)
+#define TIM_DMABase_CCR3                   ((uint16_t)0x000F)
+#define TIM_DMABase_CCR4                   ((uint16_t)0x0010)
+#define TIM_DMABase_BDTR                   ((uint16_t)0x0011)
+#define TIM_DMABase_DCR                    ((uint16_t)0x0012)
+
+/* TIM_DMA_Burst_Length */
+#define TIM_DMABurstLength_1Transfer       ((uint16_t)0x0000)
+#define TIM_DMABurstLength_2Transfers      ((uint16_t)0x0100)
+#define TIM_DMABurstLength_3Transfers      ((uint16_t)0x0200)
+#define TIM_DMABurstLength_4Transfers      ((uint16_t)0x0300)
+#define TIM_DMABurstLength_5Transfers      ((uint16_t)0x0400)
+#define TIM_DMABurstLength_6Transfers      ((uint16_t)0x0500)
+#define TIM_DMABurstLength_7Transfers      ((uint16_t)0x0600)
+#define TIM_DMABurstLength_8Transfers      ((uint16_t)0x0700)
+#define TIM_DMABurstLength_9Transfers      ((uint16_t)0x0800)
+#define TIM_DMABurstLength_10Transfers     ((uint16_t)0x0900)
+#define TIM_DMABurstLength_11Transfers     ((uint16_t)0x0A00)
+#define TIM_DMABurstLength_12Transfers     ((uint16_t)0x0B00)
+#define TIM_DMABurstLength_13Transfers     ((uint16_t)0x0C00)
+#define TIM_DMABurstLength_14Transfers     ((uint16_t)0x0D00)
+#define TIM_DMABurstLength_15Transfers     ((uint16_t)0x0E00)
+#define TIM_DMABurstLength_16Transfers     ((uint16_t)0x0F00)
+#define TIM_DMABurstLength_17Transfers     ((uint16_t)0x1000)
+#define TIM_DMABurstLength_18Transfers     ((uint16_t)0x1100)
+
+/* TIM_DMA_sources */
+#define TIM_DMA_Update                     ((uint16_t)0x0100)
+#define TIM_DMA_CC1                        ((uint16_t)0x0200)
+#define TIM_DMA_CC2                        ((uint16_t)0x0400)
+#define TIM_DMA_CC3                        ((uint16_t)0x0800)
+#define TIM_DMA_CC4                        ((uint16_t)0x1000)
+#define TIM_DMA_COM                        ((uint16_t)0x2000)
+#define TIM_DMA_Trigger                    ((uint16_t)0x4000)
+
+/* TIM_External_Trigger_Prescaler */
+#define TIM_ExtTRGPSC_OFF                  ((uint16_t)0x0000)
+#define TIM_ExtTRGPSC_DIV2                 ((uint16_t)0x1000)
+#define TIM_ExtTRGPSC_DIV4                 ((uint16_t)0x2000)
+#define TIM_ExtTRGPSC_DIV8                 ((uint16_t)0x3000)
+
+/* TIM_Internal_Trigger_Selection */
+#define TIM_TS_ITR0                        ((uint16_t)0x0000)
+#define TIM_TS_ITR1                        ((uint16_t)0x0010)
+#define TIM_TS_ITR2                        ((uint16_t)0x0020)
+#define TIM_TS_ITR3                        ((uint16_t)0x0030)
+#define TIM_TS_TI1F_ED                     ((uint16_t)0x0040)
+#define TIM_TS_TI1FP1                      ((uint16_t)0x0050)
+#define TIM_TS_TI2FP2                      ((uint16_t)0x0060)
+#define TIM_TS_ETRF                        ((uint16_t)0x0070)
+
+/* TIM_TIx_External_Clock_Source */
+#define TIM_TIxExternalCLK1Source_TI1      ((uint16_t)0x0050)
+#define TIM_TIxExternalCLK1Source_TI2      ((uint16_t)0x0060)
+#define TIM_TIxExternalCLK1Source_TI1ED    ((uint16_t)0x0040)
+
+/* TIM_External_Trigger_Polarity */
+#define TIM_ExtTRGPolarity_Inverted        ((uint16_t)0x8000)
+#define TIM_ExtTRGPolarity_NonInverted     ((uint16_t)0x0000)
+
+/* TIM_Prescaler_Reload_Mode */
+#define TIM_PSCReloadMode_Update           ((uint16_t)0x0000)
+#define TIM_PSCReloadMode_Immediate        ((uint16_t)0x0001)
+
+/* TIM_Forced_Action */
+#define TIM_ForcedAction_Active            ((uint16_t)0x0050)
+#define TIM_ForcedAction_InActive          ((uint16_t)0x0040)
+
+/* TIM_Encoder_Mode */
+#define TIM_EncoderMode_TI1                ((uint16_t)0x0001)
+#define TIM_EncoderMode_TI2                ((uint16_t)0x0002)
+#define TIM_EncoderMode_TI12               ((uint16_t)0x0003)
+
+/* TIM_Event_Source */
+#define TIM_EventSource_Update             ((uint16_t)0x0001)
+#define TIM_EventSource_CC1                ((uint16_t)0x0002)
+#define TIM_EventSource_CC2                ((uint16_t)0x0004)
+#define TIM_EventSource_CC3                ((uint16_t)0x0008)
+#define TIM_EventSource_CC4                ((uint16_t)0x0010)
+#define TIM_EventSource_COM                ((uint16_t)0x0020)
+#define TIM_EventSource_Trigger            ((uint16_t)0x0040)
+#define TIM_EventSource_Break              ((uint16_t)0x0080)
+
+/* TIM_Update_Source */
+#define TIM_UpdateSource_Global            ((uint16_t)0x0000) /* Source of update is the counter overflow/underflow \
+                                                                 or the setting of UG bit, or an update generation  \
+                                                                 through the slave mode controller. */
+#define TIM_UpdateSource_Regular           ((uint16_t)0x0001) /* Source of update is counter overflow/underflow. */
+
+/* TIM_Output_Compare_Preload_State */
+#define TIM_OCPreload_Enable               ((uint16_t)0x0008)
+#define TIM_OCPreload_Disable              ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_Fast_State */
+#define TIM_OCFast_Enable                  ((uint16_t)0x0004)
+#define TIM_OCFast_Disable                 ((uint16_t)0x0000)
+
+/* TIM_Output_Compare_Clear_State */
+#define TIM_OCClear_Enable                 ((uint16_t)0x0080)
+#define TIM_OCClear_Disable                ((uint16_t)0x0000)
+
+/* TIM_Trigger_Output_Source */
+#define TIM_TRGOSource_Reset               ((uint16_t)0x0000)
+#define TIM_TRGOSource_Enable              ((uint16_t)0x0010)
+#define TIM_TRGOSource_Update              ((uint16_t)0x0020)
+#define TIM_TRGOSource_OC1                 ((uint16_t)0x0030)
+#define TIM_TRGOSource_OC1Ref              ((uint16_t)0x0040)
+#define TIM_TRGOSource_OC2Ref              ((uint16_t)0x0050)
+#define TIM_TRGOSource_OC3Ref              ((uint16_t)0x0060)
+#define TIM_TRGOSource_OC4Ref              ((uint16_t)0x0070)
+
+/* TIM_Slave_Mode */
+#define TIM_SlaveMode_Reset                ((uint16_t)0x0004)
+#define TIM_SlaveMode_Gated                ((uint16_t)0x0005)
+#define TIM_SlaveMode_Trigger              ((uint16_t)0x0006)
+#define TIM_SlaveMode_External1            ((uint16_t)0x0007)
+
+/* TIM_Master_Slave_Mode */
+#define TIM_MasterSlaveMode_Enable         ((uint16_t)0x0080)
+#define TIM_MasterSlaveMode_Disable        ((uint16_t)0x0000)
+
+/* TIM_Flags */
+#define TIM_FLAG_Update                    ((uint16_t)0x0001)
+#define TIM_FLAG_CC1                       ((uint16_t)0x0002)
+#define TIM_FLAG_CC2                       ((uint16_t)0x0004)
+#define TIM_FLAG_CC3                       ((uint16_t)0x0008)
+#define TIM_FLAG_CC4                       ((uint16_t)0x0010)
+#define TIM_FLAG_COM                       ((uint16_t)0x0020)
+#define TIM_FLAG_Trigger                   ((uint16_t)0x0040)
+#define TIM_FLAG_Break                     ((uint16_t)0x0080)
+#define TIM_FLAG_CC1OF                     ((uint16_t)0x0200)
+#define TIM_FLAG_CC2OF                     ((uint16_t)0x0400)
+#define TIM_FLAG_CC3OF                     ((uint16_t)0x0800)
+#define TIM_FLAG_CC4OF                     ((uint16_t)0x1000)
+
+/* TIM_Legacy */
+#define TIM_DMABurstLength_1Byte           TIM_DMABurstLength_1Transfer
+#define TIM_DMABurstLength_2Bytes          TIM_DMABurstLength_2Transfers
+#define TIM_DMABurstLength_3Bytes          TIM_DMABurstLength_3Transfers
+#define TIM_DMABurstLength_4Bytes          TIM_DMABurstLength_4Transfers
+#define TIM_DMABurstLength_5Bytes          TIM_DMABurstLength_5Transfers
+#define TIM_DMABurstLength_6Bytes          TIM_DMABurstLength_6Transfers
+#define TIM_DMABurstLength_7Bytes          TIM_DMABurstLength_7Transfers
+#define TIM_DMABurstLength_8Bytes          TIM_DMABurstLength_8Transfers
+#define TIM_DMABurstLength_9Bytes          TIM_DMABurstLength_9Transfers
+#define TIM_DMABurstLength_10Bytes         TIM_DMABurstLength_10Transfers
+#define TIM_DMABurstLength_11Bytes         TIM_DMABurstLength_11Transfers
+#define TIM_DMABurstLength_12Bytes         TIM_DMABurstLength_12Transfers
+#define TIM_DMABurstLength_13Bytes         TIM_DMABurstLength_13Transfers
+#define TIM_DMABurstLength_14Bytes         TIM_DMABurstLength_14Transfers
+#define TIM_DMABurstLength_15Bytes         TIM_DMABurstLength_15Transfers
+#define TIM_DMABurstLength_16Bytes         TIM_DMABurstLength_16Transfers
+#define TIM_DMABurstLength_17Bytes         TIM_DMABurstLength_17Transfers
+#define TIM_DMABurstLength_18Bytes         TIM_DMABurstLength_18Transfers
+
+/* TIM_Supersede_Mode_OC1 */
+#define TIM_Supersede_Mode_OC1_H           ((uint16_t)0x0000)
+#define TIM_Supersede_Mode_OC1_L           ((uint16_t)0x0010)
+
+/* TIM_Supersede_Mode_OC2 */
+#define TIM_Supersede_Mode_OC2_H           ((uint16_t)0x0000)
+#define TIM_Supersede_Mode_OC2_L           ((uint16_t)0x0020)
+
+/* TIM_Supersede_Mode_OC3 */
+#define TIM_Supersede_Mode_OC3_H           ((uint16_t)0x0000)
+#define TIM_Supersede_Mode_OC3_L           ((uint16_t)0x0040)
+
+/* TIM_Supersede_Mode_OC4 */
+#define TIM_Supersede_Mode_OC4_H           ((uint16_t)0x0000)
+#define TIM_Supersede_Mode_OC4_L           ((uint16_t)0x0080)
+
+/* ch32v00x_usart.h ----------------------------------------------------------*/
+
+/* USART_Word_Length */
+#define USART_WordLength_8b                  ((uint16_t)0x0000)
+#define USART_WordLength_9b                  ((uint16_t)0x1000)
+
+/* USART_Stop_Bits */
+#define USART_StopBits_1                     ((uint16_t)0x0000)
+#define USART_StopBits_0_5                   ((uint16_t)0x1000)
+#define USART_StopBits_2                     ((uint16_t)0x2000)
+#define USART_StopBits_1_5                   ((uint16_t)0x3000)
+
+/* USART_Parity */
+#define USART_Parity_No                      ((uint16_t)0x0000)
+#define USART_Parity_Even                    ((uint16_t)0x0400)
+#define USART_Parity_Odd                     ((uint16_t)0x0600)
+
+/* USART_Mode */
+#define USART_Mode_Rx                        ((uint16_t)0x0004)
+#define USART_Mode_Tx                        ((uint16_t)0x0008)
+
+/* USART_Hardware_Flow_Control */
+#define USART_HardwareFlowControl_None       ((uint16_t)0x0000)
+#define USART_HardwareFlowControl_RTS        ((uint16_t)0x0100)
+#define USART_HardwareFlowControl_CTS        ((uint16_t)0x0200)
+#define USART_HardwareFlowControl_RTS_CTS    ((uint16_t)0x0300)
+
+/* USART_Clock */
+#define USART_Clock_Disable                  ((uint16_t)0x0000)
+#define USART_Clock_Enable                   ((uint16_t)0x0800)
+
+/* USART_Clock_Polarity */
+#define USART_CPOL_Low                       ((uint16_t)0x0000)
+#define USART_CPOL_High                      ((uint16_t)0x0400)
+
+/* USART_Clock_Phase */
+#define USART_CPHA_1Edge                     ((uint16_t)0x0000)
+#define USART_CPHA_2Edge                     ((uint16_t)0x0200)
+
+/* USART_Last_Bit */
+#define USART_LastBit_Disable                ((uint16_t)0x0000)
+#define USART_LastBit_Enable                 ((uint16_t)0x0100)
+
+/* USART_Interrupt_definition */
+#define USART_IT_PE                          ((uint16_t)0x0028)
+#define USART_IT_TXE                         ((uint16_t)0x0727)
+#define USART_IT_TC                          ((uint16_t)0x0626)
+#define USART_IT_RXNE                        ((uint16_t)0x0525)
+#define USART_IT_ORE_RX                      ((uint16_t)0x0325)
+#define USART_IT_IDLE                        ((uint16_t)0x0424)
+#define USART_IT_LBD                         ((uint16_t)0x0846)
+#define USART_IT_CTS                         ((uint16_t)0x096A)
+#define USART_IT_ERR                         ((uint16_t)0x0060)
+#define USART_IT_ORE_ER                      ((uint16_t)0x0360)
+#define USART_IT_NE                          ((uint16_t)0x0260)
+#define USART_IT_FE                          ((uint16_t)0x0160)
+
+#define USART_IT_ORE                         USART_IT_ORE_ER
+
+/* USART_DMA_Requests */
+#define USART_DMAReq_Tx                      ((uint16_t)0x0080)
+#define USART_DMAReq_Rx                      ((uint16_t)0x0040)
+
+/* USART_WakeUp_methods */
+#define USART_WakeUp_IdleLine                ((uint16_t)0x0000)
+#define USART_WakeUp_AddressMark             ((uint16_t)0x0800)
+
+/* USART_LIN_Break_Detection_Length */
+#define USART_LINBreakDetectLength_10b       ((uint16_t)0x0000)
+#define USART_LINBreakDetectLength_11b       ((uint16_t)0x0020)
+
+/* USART_IrDA_Low_Power */
+#define USART_IrDAMode_LowPower              ((uint16_t)0x0004)
+#define USART_IrDAMode_Normal                ((uint16_t)0x0000)
+
+/* USART_Flags */
+#define USART_FLAG_CTS                       ((uint16_t)0x0200)
+#define USART_FLAG_LBD                       ((uint16_t)0x0100)
+#define USART_FLAG_TXE                       ((uint16_t)0x0080)
+#define USART_FLAG_TC                        ((uint16_t)0x0040)
+#define USART_FLAG_RXNE                      ((uint16_t)0x0020)
+#define USART_FLAG_IDLE                      ((uint16_t)0x0010)
+#define USART_FLAG_ORE                       ((uint16_t)0x0008)
+#define USART_FLAG_NE                        ((uint16_t)0x0004)
+#define USART_FLAG_FE                        ((uint16_t)0x0002)
+#define USART_FLAG_PE                        ((uint16_t)0x0001)
+
+// While not truly CH32X035, we can re-use some of the USB register defs.
+/* ch32v10x_usb.h ------------------------------------------------------------*/
+
+#ifndef NULL
+  #define NULL    0
+#endif
+
+#ifndef VOID
+  #define VOID    void
+#endif
+#ifndef CONST
+  #define CONST    const
+#endif
+#ifndef BOOL
+typedef unsigned char BOOL;
+#endif
+#ifndef BOOLEAN
+typedef unsigned char BOOLEAN;
+#endif
+#ifndef CHAR
+typedef char CHAR;
+#endif
+#ifndef INT8
+typedef char INT8;
+#endif
+#ifndef INT16
+typedef short INT16;
+#endif
+#ifndef INT32
+typedef long INT32;
+#endif
+#ifndef UINT8
+typedef unsigned char UINT8;
+#endif
+#ifndef UINT16
+typedef unsigned short UINT16;
+#endif
+#ifndef UINT32
+typedef unsigned long UINT32;
+#endif
+#ifndef UINT8V
+typedef unsigned char volatile UINT8V;
+#endif
+#ifndef UINT16V
+typedef unsigned short volatile UINT16V;
+#endif
+#ifndef UINT32V
+typedef unsigned long volatile UINT32V;
+#endif
+
+#ifndef PVOID
+typedef void *PVOID;
+#endif
+#ifndef PCHAR
+typedef char *PCHAR;
+#endif
+#ifndef PCHAR
+typedef const char *PCCHAR;
+#endif
+#ifndef PINT8
+typedef char *PINT8;
+#endif
+#ifndef PINT16
+typedef short *PINT16;
+#endif
+#ifndef PINT32
+typedef long *PINT32;
+#endif
+#ifndef PUINT8
+typedef unsigned char *PUINT8;
+#endif
+#ifndef PUINT16
+typedef unsigned short *PUINT16;
+#endif
+#ifndef PUINT32
+typedef unsigned long *PUINT32;
+#endif
+#ifndef PUINT8V
+typedef volatile unsigned char *PUINT8V;
+#endif
+#ifndef PUINT16V
+typedef volatile unsigned short *PUINT16V;
+#endif
+#ifndef PUINT32V
+typedef volatile unsigned long *PUINT32V;
+#endif
+
+/******************************************************************************/
+/*                         Peripheral memory map                              */
+/******************************************************************************/
+/*       USB  */
+#define R32_USB_CONTROL      (*((PUINT32V)(0x40023400))) // USB control & interrupt enable & device address
+#define R8_USB_CTRL          (*((PUINT8V)(0x40023400)))  // USB base control
+#define RB_UC_HOST_MODE      0x80                        // enable USB host mode: 0=device mode, 1=host mode
+#define RB_UC_LOW_SPEED      0x40                        // enable USB low speed: 0=12Mbps, 1=1.5Mbps
+#define RB_UC_DEV_PU_EN      0x20                        // USB device enable and internal pullup resistance enable
+#define RB_UC_SYS_CTRL1      0x20                        // USB system control high bit
+#define RB_UC_SYS_CTRL0      0x10                        // USB system control low bit
+#define MASK_UC_SYS_CTRL     0x30                        // bit mask of USB system control
+// bUC_HOST_MODE & bUC_SYS_CTRL1 & bUC_SYS_CTRL0: USB system control
+//   0 00: disable USB device and disable internal pullup resistance
+//   0 01: enable USB device and disable internal pullup resistance, need external pullup resistance
+//   0 1x: enable USB device and enable internal pullup resistance
+//   1 00: enable USB host and normal status
+//   1 01: enable USB host and force UDP/UDM output SE0 state
+//   1 10: enable USB host and force UDP/UDM output J state
+//   1 11: enable USB host and force UDP/UDM output resume or K state
+#define RB_UC_INT_BUSY       0x08           // enable automatic responding busy for device mode or automatic pause for host mode during interrupt flag UIF_TRANSFER valid
+#define RB_UC_RESET_SIE      0x04           // force reset USB SIE, need software clear
+#define RB_UC_CLR_ALL        0x02           // force clear FIFO and count of USB
+#define RB_UC_DMA_EN         0x01           // DMA enable and DMA interrupt enable for USB
+
+#define R8_UDEV_CTRL         (*((PUINT8V)(0x40023401))) // USB device physical prot control
+#define RB_UD_PD_DIS         0x80                       // disable USB UDP/UDM pulldown resistance: 0=enable pulldown, 1=disable
+#define RB_UD_DP_PIN         0x20                       // ReadOnly: indicate current UDP pin level
+#define RB_UD_DM_PIN         0x10                       // ReadOnly: indicate current UDM pin level
+#define RB_UD_LOW_SPEED      0x04                       // enable USB physical port low speed: 0=full speed, 1=low speed
+#define RB_UD_GP_BIT         0x02                       // general purpose bit
+#define RB_UD_PORT_EN        0x01                       // enable USB physical port I/O: 0=disable, 1=enable
+
+#define R8_UHOST_CTRL        R8_UDEV_CTRL   // USB host physical prot control
+#define RB_UH_PD_DIS         0x80           // disable USB UDP/UDM pulldown resistance: 0=enable pulldown, 1=disable
+#define RB_UH_DP_PIN         0x20           // ReadOnly: indicate current UDP pin level
+#define RB_UH_DM_PIN         0x10           // ReadOnly: indicate current UDM pin level
+#define RB_UH_LOW_SPEED      0x04           // enable USB port low speed: 0=full speed, 1=low speed
+#define RB_UH_BUS_RESET      0x02           // control USB bus reset: 0=normal, 1=force bus reset
+#define RB_UH_PORT_EN        0x01           // enable USB port: 0=disable, 1=enable port, automatic disabled if USB device detached
+
+#define R8_USB_INT_EN        (*((PUINT8V)(0x40023402))) // USB interrupt enable
+#define RB_UIE_DEV_SOF       0x80                       // enable interrupt for SOF received for USB device mode
+#define RB_UIE_DEV_NAK       0x40                       // enable interrupt for NAK responded for USB device mode
+#define RB_UIE_FIFO_OV       0x10                       // enable interrupt for FIFO overflow
+#define RB_UIE_HST_SOF       0x08                       // enable interrupt for host SOF timer action for USB host mode
+#define RB_UIE_SUSPEND       0x04                       // enable interrupt for USB suspend or resume event
+#define RB_UIE_TRANSFER      0x02                       // enable interrupt for USB transfer completion
+#define RB_UIE_DETECT        0x01                       // enable interrupt for USB device detected event for USB host mode
+#define RB_UIE_BUS_RST       0x01                       // enable interrupt for USB bus reset event for USB device mode
+
+#define R8_USB_DEV_AD        (*((PUINT8V)(0x40023403))) // USB device address
+#define RB_UDA_GP_BIT        0x80                       // general purpose bit
+#define MASK_USB_ADDR        0x7F                       // bit mask for USB device address
+
+#define R32_USB_STATUS       (*((PUINT32V)(0x40023404))) // USB miscellaneous status & interrupt flag & interrupt status
+#define R8_USB_MIS_ST        (*((PUINT8V)(0x40023405)))  // USB miscellaneous status
+#define RB_UMS_SOF_PRES      0x80                        // RO, indicate host SOF timer presage status
+#define RB_UMS_SOF_ACT       0x40                        // RO, indicate host SOF timer action status for USB host
+#define RB_UMS_SIE_FREE      0x20                        // RO, indicate USB SIE free status
+#define RB_UMS_R_FIFO_RDY    0x10                        // RO, indicate USB receiving FIFO ready status (not empty)
+#define RB_UMS_BUS_RESET     0x08                        // RO, indicate USB bus reset status
+#define RB_UMS_SUSPEND       0x04                        // RO, indicate USB suspend status
+#define RB_UMS_DM_LEVEL      0x02                        // RO, indicate UDM level saved at device attached to USB host
+#define RB_UMS_DEV_ATTACH    0x01                        // RO, indicate device attached status on USB host
+
+#define R8_USB_INT_FG        (*((PUINT8V)(0x40023406))) // USB interrupt flag
+#define RB_U_IS_NAK          0x80                       // RO, indicate current USB transfer is NAK received
+#define RB_U_TOG_OK          0x40                       // RO, indicate current USB transfer toggle is OK
+#define RB_U_SIE_FREE        0x20                       // RO, indicate USB SIE free status
+#define RB_UIF_FIFO_OV       0x10                       // FIFO overflow interrupt flag for USB, direct bit address clear or write 1 to clear
+#define RB_UIF_HST_SOF       0x08                       // host SOF timer interrupt flag for USB host, direct bit address clear or write 1 to clear
+#define RB_UIF_SUSPEND       0x04                       // USB suspend or resume event interrupt flag, direct bit address clear or write 1 to clear
+#define RB_UIF_TRANSFER      0x02                       // USB transfer completion interrupt flag, direct bit address clear or write 1 to clear
+#define RB_UIF_DETECT        0x01                       // device detected event interrupt flag for USB host mode, direct bit address clear or write 1 to clear
+#define RB_UIF_BUS_RST       0x01                       // bus reset event interrupt flag for USB device mode, direct bit address clear or write 1 to clear
+
+#define R8_USB_INT_ST        (*((PUINT8V)(0x40023407))) // USB interrupt status
+#define RB_UIS_IS_NAK        0x80                       // RO, indicate current USB transfer is NAK received for USB device mode
+#define RB_UIS_TOG_OK        0x40                       // RO, indicate current USB transfer toggle is OK
+#define RB_UIS_TOKEN1        0x20                       // RO, current token PID code bit 1 received for USB device mode
+#define RB_UIS_TOKEN0        0x10                       // RO, current token PID code bit 0 received for USB device mode
+#define MASK_UIS_TOKEN       0x30                       // RO, bit mask of current token PID code received for USB device mode
+#define UIS_TOKEN_OUT        0x00
+#define UIS_TOKEN_SOF        0x10
+#define UIS_TOKEN_IN         0x20
+#define UIS_TOKEN_SETUP      0x30
+// bUIS_TOKEN1 & bUIS_TOKEN0: current token PID code received for USB device mode
+//   00: OUT token PID received
+//   01: SOF token PID received
+//   10: IN token PID received
+//   11: SETUP token PID received
+#define MASK_UIS_ENDP        0x0F           // RO, bit mask of current transfer endpoint number for USB device mode
+#define MASK_UIS_H_RES       0x0F           // RO, bit mask of current transfer handshake response for USB host mode: 0000=no response, time out from device, others=handshake response PID received
+
+#define R16_USB_RX_LEN       (*((PUINT16V)(0x40023408))) // USB receiving length
+#define MASK_UIS_RX_LEN      0x3FF                       // RO, bit mask of current receive length(10 bits for ch32v10x)
+#define R32_USB_BUF_MODE     (*((PUINT32V)(0x4002340c))) // USB endpoint buffer mode
+#define R8_UEP4_1_MOD        (*((PUINT8V)(0x4002340c)))  // endpoint 4/1 mode
+#define RB_UEP1_RX_EN        0x80                        // enable USB endpoint 1 receiving (OUT)
+#define RB_UEP1_TX_EN        0x40                        // enable USB endpoint 1 transmittal (IN)
+#define RB_UEP1_BUF_MOD      0x10                        // buffer mode of USB endpoint 1
+// bUEPn_RX_EN & bUEPn_TX_EN & bUEPn_BUF_MOD: USB endpoint 1/2/3 buffer mode, buffer start address is UEPn_DMA
+//   0 0 x:  disable endpoint and disable buffer
+//   1 0 0:  64 bytes buffer for receiving (OUT endpoint)
+//   1 0 1:  dual 64 bytes buffer by toggle bit bUEP_R_TOG selection for receiving (OUT endpoint), total=128bytes
+//   0 1 0:  64 bytes buffer for transmittal (IN endpoint)
+//   0 1 1:  dual 64 bytes buffer by toggle bit bUEP_T_TOG selection for transmittal (IN endpoint), total=128bytes
+//   1 1 0:  64 bytes buffer for receiving (OUT endpoint) + 64 bytes buffer for transmittal (IN endpoint), total=128bytes
+//   1 1 1:  dual 64 bytes buffer by bUEP_R_TOG selection for receiving (OUT endpoint) + dual 64 bytes buffer by bUEP_T_TOG selection for transmittal (IN endpoint), total=256bytes
+#define RB_UEP4_RX_EN        0x08           // enable USB endpoint 4 receiving (OUT)
+#define RB_UEP4_TX_EN        0x04           // enable USB endpoint 4 transmittal (IN)
+// bUEP4_RX_EN & bUEP4_TX_EN: USB endpoint 4 buffer mode, buffer start address is UEP0_DMA
+//   0 0:  single 64 bytes buffer for endpoint 0 receiving & transmittal (OUT & IN endpoint)
+//   1 0:  single 64 bytes buffer for endpoint 0 receiving & transmittal (OUT & IN endpoint) + 64 bytes buffer for endpoint 4 receiving (OUT endpoint), total=128bytes
+//   0 1:  single 64 bytes buffer for endpoint 0 receiving & transmittal (OUT & IN endpoint) + 64 bytes buffer for endpoint 4 transmittal (IN endpoint), total=128bytes
+//   1 1:  single 64 bytes buffer for endpoint 0 receiving & transmittal (OUT & IN endpoint)
+//           + 64 bytes buffer for endpoint 4 receiving (OUT endpoint) + 64 bytes buffer for endpoint 4 transmittal (IN endpoint), total=192bytes
+
+#define R8_UEP2_3_MOD        (*((PUINT8V)(0x4002340d))) // endpoint 2/3 mode
+#define RB_UEP3_RX_EN        0x80                       // enable USB endpoint 3 receiving (OUT)
+#define RB_UEP3_TX_EN        0x40                       // enable USB endpoint 3 transmittal (IN)
+#define RB_UEP3_BUF_MOD      0x10                       // buffer mode of USB endpoint 3
+#define RB_UEP2_RX_EN        0x08                       // enable USB endpoint 2 receiving (OUT)
+#define RB_UEP2_TX_EN        0x04                       // enable USB endpoint 2 transmittal (IN)
+#define RB_UEP2_BUF_MOD      0x01                       // buffer mode of USB endpoint 2
+
+#define R8_UH_EP_MOD         R8_UEP2_3_MOD  //host endpoint mode
+#define RB_UH_EP_TX_EN       0x40           // enable USB host OUT endpoint transmittal
+#define RB_UH_EP_TBUF_MOD    0x10           // buffer mode of USB host OUT endpoint
+// bUH_EP_TX_EN & bUH_EP_TBUF_MOD: USB host OUT endpoint buffer mode, buffer start address is UH_TX_DMA
+//   0 x:  disable endpoint and disable buffer
+//   1 0:  64 bytes buffer for transmittal (OUT endpoint)
+//   1 1:  dual 64 bytes buffer by toggle bit bUH_T_TOG selection for transmittal (OUT endpoint), total=128bytes
+#define RB_UH_EP_RX_EN       0x08           // enable USB host IN endpoint receiving
+#define RB_UH_EP_RBUF_MOD    0x01           // buffer mode of USB host IN endpoint
+// bUH_EP_RX_EN & bUH_EP_RBUF_MOD: USB host IN endpoint buffer mode, buffer start address is UH_RX_DMA
+//   0 x:  disable endpoint and disable buffer
+//   1 0:  64 bytes buffer for receiving (IN endpoint)
+//   1 1:  dual 64 bytes buffer by toggle bit bUH_R_TOG selection for receiving (IN endpoint), total=128bytes
+
+#define R8_UEP5_6_MOD        (*((PUINT8V)(0x4002340e))) // endpoint 5/6 mode
+#define RB_UEP6_RX_EN        0x80                       // enable USB endpoint 6 receiving (OUT)
+#define RB_UEP6_TX_EN        0x40                       // enable USB endpoint 6 transmittal (IN)
+#define RB_UEP6_BUF_MOD      0x10                       // buffer mode of USB endpoint 6
+#define RB_UEP5_RX_EN        0x08                       // enable USB endpoint 5 receiving (OUT)
+#define RB_UEP5_TX_EN        0x04                       // enable USB endpoint 5 transmittal (IN)
+#define RB_UEP5_BUF_MOD      0x01                       // buffer mode of USB endpoint 5
+
+#define R8_UEP7_MOD          (*((PUINT8V)(0x4002340f))) // endpoint 7 mode
+#define RB_UEP7_RX_EN        0x08                       // enable USB endpoint 7 receiving (OUT)
+#define RB_UEP7_TX_EN        0x04                       // enable USB endpoint 7 transmittal (IN)
+#define RB_UEP7_BUF_MOD      0x01                       // buffer mode of USB endpoint 7
+
+#define R16_UEP0_DMA         (*((PUINT16V)(0x40023410))) // endpoint 0 DMA buffer address
+#define R16_UEP1_DMA         (*((PUINT16V)(0x40023414))) // endpoint 1 DMA buffer address
+#define R16_UEP2_DMA         (*((PUINT16V)(0x40023418))) // endpoint 2 DMA buffer address
+#define R16_UH_RX_DMA        R16_UEP2_DMA                // host rx endpoint buffer high address
+#define R16_UEP3_DMA         (*((PUINT16V)(0x4002341c))) // endpoint 3 DMA buffer address
+
+#define R16_UEP4_DMA         (*((PUINT16V)(0x40023420))) // endpoint 4 DMA buffer address
+#define R16_UEP5_DMA         (*((PUINT16V)(0x40023424))) // endpoint 5 DMA buffer address
+#define R16_UEP6_DMA         (*((PUINT16V)(0x40023428))) // endpoint 6 DMA buffer address
+#define R16_UEP7_DMA         (*((PUINT16V)(0x4002342c))) // endpoint 7 DMA buffer address
+
+#define R16_UH_TX_DMA        R16_UEP3_DMA                // host tx endpoint buffer high address
+#define R32_USB_EP0_CTRL     (*((PUINT32V)(0x40023430))) // endpoint 0 control & transmittal length
+#define R8_UEP0_T_LEN        (*((PUINT8V)(0x40023430)))  // endpoint 0 transmittal length
+#define R8_UEP0_CTRL         (*((PUINT8V)(0x40023432)))  // endpoint 0 control
+#define R32_USB_EP1_CTRL     (*((PUINT32V)(0x40023434))) // endpoint 1 control & transmittal length
+#define R16_UEP1_T_LEN       (*((PUINT16V)(0x40023434))) // endpoint 1 transmittal length(16-bits for ch32v10x)
+#define R8_UEP1_CTRL         (*((PUINT8V)(0x40023436)))  // endpoint 1 control
+#define RB_UEP_R_TOG         0x80                        // expected data toggle flag of USB endpoint X receiving (OUT): 0=DATA0, 1=DATA1
+#define RB_UEP_T_TOG         0x40                        // prepared data toggle flag of USB endpoint X transmittal (IN): 0=DATA0, 1=DATA1
+#define RB_UEP_AUTO_TOG      0x10                        // enable automatic toggle after successful transfer completion on endpoint 1/2/3: 0=manual toggle, 1=automatic toggle
+#define RB_UEP_R_RES1        0x08                        // handshake response type high bit for USB endpoint X receiving (OUT)
+#define RB_UEP_R_RES0        0x04                        // handshake response type low bit for USB endpoint X receiving (OUT)
+#define MASK_UEP_R_RES       0x0C                        // bit mask of handshake response type for USB endpoint X receiving (OUT)
+#define UEP_R_RES_ACK        0x00
+#define UEP_R_RES_TOUT       0x04
+#define UEP_R_RES_NAK        0x08
+#define UEP_R_RES_STALL      0x0C
+// RB_UEP_R_RES1 & RB_UEP_R_RES0: handshake response type for USB endpoint X receiving (OUT)
+//   00: ACK (ready)
+//   01: no response, time out to host, for non-zero endpoint isochronous transactions
+//   10: NAK (busy)
+//   11: STALL (error)
+#define RB_UEP_T_RES1        0x02           // handshake response type high bit for USB endpoint X transmittal (IN)
+#define RB_UEP_T_RES0        0x01           // handshake response type low bit for USB endpoint X transmittal (IN)
+#define MASK_UEP_T_RES       0x03           // bit mask of handshake response type for USB endpoint X transmittal (IN)
+#define UEP_T_RES_ACK        0x00
+#define UEP_T_RES_TOUT       0x01
+#define UEP_T_RES_NAK        0x02
+#define UEP_T_RES_STALL      0x03
+// bUEP_T_RES1 & bUEP_T_RES0: handshake response type for USB endpoint X transmittal (IN)
+//   00: DATA0 or DATA1 then expecting ACK (ready)
+//   01: DATA0 or DATA1 then expecting no response, time out from host, for non-zero endpoint isochronous transactions
+//   10: NAK (busy)
+//   11: STALL (error)
+
+#define R8_UH_SETUP          R8_UEP1_CTRL   // host aux setup
+#define RB_UH_PRE_PID_EN     0x80           // USB host PRE PID enable for low speed device via hub
+#define RB_UH_SOF_EN         0x40           // USB host automatic SOF enable
+
+#define R32_USB_EP2_CTRL     (*((PUINT32V)(0x40023438))) // endpoint 2 control & transmittal length
+#define R16_UEP2_T_LEN       (*((PUINT16V)(0x40023438))) // endpoint 2 transmittal length(16-bits for ch32v10x)
+#define R8_UEP2_CTRL         (*((PUINT8V)(0x4002343a)))  // endpoint 2 control
+
+#define R8_UH_EP_PID         (*((PUINT8V)(0x40023438)))  // host endpoint and PID
+#define MASK_UH_TOKEN        0xF0           // bit mask of token PID for USB host transfer
+#define MASK_UH_ENDP         0x0F           // bit mask of endpoint number for USB host transfer
+
+#define R8_UH_RX_CTRL        R8_UEP2_CTRL   // host receiver endpoint control
+#define RB_UH_R_TOG          0x80           // expected data toggle flag of host receiving (IN): 0=DATA0, 1=DATA1
+#define RB_UH_R_AUTO_TOG     0x10           // enable automatic toggle after successful transfer completion: 0=manual toggle, 1=automatic toggle
+#define RB_UH_R_RES          0x04           // prepared handshake response type for host receiving (IN): 0=ACK (ready), 1=no response, time out to device, for isochronous transactions
+
+#define R32_USB_EP3_CTRL     (*((PUINT32V)(0x4002343c))) // endpoint 3 control & transmittal length
+#define R16_UEP3_T_LEN       (*((PUINT16V)(0x4002343c))) // endpoint 3 transmittal length(16-bits for ch32v10x)
+#define R8_UEP3_CTRL         (*((PUINT8V)(0x4002343e)))  // endpoint 3 control
+#define R8_UH_TX_LEN         (*((PUINT16V)(0x4002343c))) //R8_UEP3_T_LEN				// host transmittal endpoint transmittal length
+
+#define R8_UH_TX_CTRL        R8_UEP3_CTRL   // host transmittal endpoint control
+#define RB_UH_T_TOG          0x40           // prepared data toggle flag of host transmittal (SETUP/OUT): 0=DATA0, 1=DATA1
+#define RB_UH_T_AUTO_TOG     0x10           // enable automatic toggle after successful transfer completion: 0=manual toggle, 1=automatic toggle
+#define RB_UH_T_RES          0x01           // expected handshake response type for host transmittal (SETUP/OUT): 0=ACK (ready), 1=no response, time out from device, for isochronous transactions
+
+#define R32_USB_EP4_CTRL     (*((PUINT32V)(0x40023440))) // endpoint 4 control & transmittal length
+#define R16_UEP4_T_LEN       (*((PUINT16V)(0x40023440))) // endpoint 4 transmittal length(16-bits for ch32v10x)
+#define R8_UEP4_CTRL         (*((PUINT8V)(0x40023442)))  // endpoint 4 control
+
+#define R32_USB_EP5_CTRL     (*((PUINT32V)(0x40023444))) // endpoint 5 control & transmittal length
+#define R16_UEP5_T_LEN       (*((PUINT16V)(0x40023444))) // endpoint 5 transmittal length(16-bits for ch32v10x)
+#define R8_UEP5_CTRL         (*((PUINT8V)(0x40023446)))  // endpoint 5 control
+
+#define R32_USB_EP6_CTRL     (*((PUINT32V)(0x40023448))) // endpoint 6 control & transmittal length
+#define R16_UEP6_T_LEN       (*((PUINT16V)(0x40023448))) // endpoint 6 transmittal length(16-bits for ch32v10x)
+#define R8_UEP6_CTRL         (*((PUINT8V)(0x4002344a)))  // endpoint 6 control
+
+#define R32_USB_EP7_CTRL     (*((PUINT32V)(0x4002344c))) // endpoint 7 control & transmittal length
+#define R16_UEP7_T_LEN       (*((PUINT16V)(0x4002344c))) // endpoint 7 transmittal length(16-bits for ch32v10x)
+#define R8_UEP7_CTRL         (*((PUINT8V)(0x4002344e)))  // endpoint 7 control
+
+/* ch32v10x_usb_host.h -----------------------------------------------------------*/
+
+#define ERR_SUCCESS            0x00
+#define ERR_USB_CONNECT        0x15
+#define ERR_USB_DISCON         0x16
+#define ERR_USB_BUF_OVER       0x17
+#define ERR_USB_DISK_ERR       0x1F
+#define ERR_USB_TRANSFER       0x20
+#define ERR_USB_UNSUPPORT      0xFB
+#define ERR_USB_UNKNOWN        0xFE
+#define ERR_AOA_PROTOCOL       0x41
+
+#define ROOT_DEV_DISCONNECT    0
+#define ROOT_DEV_CONNECTED     1
+#define ROOT_DEV_FAILED        2
+#define ROOT_DEV_SUCCESS       3
+#define DEV_TYPE_KEYBOARD      (USB_DEV_CLASS_HID | 0x20)
+#define DEV_TYPE_MOUSE         (USB_DEV_CLASS_HID | 0x30)
+#define DEF_AOA_DEVICE         0xF0
+#define DEV_TYPE_UNKNOW        0xFF
+
+#define HUB_MAX_PORTS          4
+#define WAIT_USB_TOUT_200US    3000
+
+
+/* ch32v30x_usb.h ------------------------------------------------------------*/
+
+
+/* ch32x035_usbpd.h ----------------------------------------------------------*/
+
+/* Register Bit Definition */
+/* USBPD->CONFIG */
+#define PD_FILT_EN          (1<<0)             /* PD pin input filter enable */
+#define PD_ALL_CLR          (1<<1)             /* Clear all interrupt flags */
+#define CC_SEL              (1<<2)             /* Select PD communication port */
+#define PD_DMA_EN           (1<<3)             /* Enable DMA for USBPD */
+#define PD_RST_EN           (1<<4)             /* PD mode reset command enable */
+#define WAKE_POLAR          (1<<5)             /* PD port wake-up level */
+#define IE_PD_IO            (1<<10)            /* PD IO interrupt enable */
+#define IE_RX_BIT           (1<<11)            /* Receive bit interrupt enable */
+#define IE_RX_BYTE          (1<<12)            /* Receive byte interrupt enable */
+#define IE_RX_ACT           (1<<13)            /* Receive completion interrupt enable */
+#define IE_RX_RESET         (1<<14)            /* Reset interrupt enable */
+#define IE_TX_END           (1<<15)            /* Transfer completion interrupt enable */
+
+/* USBPD->CONTROL */
+#define PD_TX_EN            (1<<0)             /* USBPD transceiver mode and transmit enable */
+#define BMC_START           (1<<1)             /* BMC send start signal */
+#define RX_STATE_0          (1<<2)             /* PD received state bit 0 */
+#define RX_STATE_1          (1<<3)             /* PD received state bit 1 */
+#define RX_STATE_2          (1<<4)             /* PD received state bit 2 */
+#define DATA_FLAG           (1<<5)             /* Cache data valid flag bit */
+#define TX_BIT_BACK         (1<<6)             /* Indicates the current bit status of the BMC when sending the code */
+#define BMC_BYTE_HI         (1<<7)             /* Indicates the current half-byte status of the PD data being sent and received */
+
+/* USBPD->TX_SEL */
+#define TX_SEL1             (0<<0)
+#define TX_SEL1_SYNC1       (0<<0)             /* 0-SYNC1 */
+#define TX_SEL1_RST1        (1<<0)             /* 1-RST1 */
+#define TX_SEL2_MASK        (3<<2)
+#define TX_SEL2_SYNC1       (0<<2)             /* 00-SYNC1 */
+#define TX_SEL2_SYNC3       (1<<2)             /* 01-SYNC3 */
+#define TX_SEL2_RST1        (2<<2)             /* 1x-RST1 */
+#define TX_SEL3_MASK        (3<<4)
+#define TX_SEL3_SYNC1       (0<<4)             /* 00-SYNC1 */
+#define TX_SEL3_SYNC3       (1<<4)             /* 01-SYNC3 */
+#define TX_SEL3_RST1        (2<<4)             /* 1x-RST1 */
+#define TX_SEL4_MASK        (3<<6)
+#define TX_SEL4_SYNC2       (0<<6)             /* 00-SYNC2 */
+#define TX_SEL4_SYNC3       (1<<6)             /* 01-SYNC3 */
+#define TX_SEL4_RST2        (2<<6)             /* 1x-RST2 */
+
+/* USBPD->STATUS */
+#define BMC_AUX_MASK        (3<<0)              /* Clear BMC auxiliary information */
+#define BMC_AUX_INVALID     (0<<0)              /* 00-Invalid */
+#define BMC_AUX_SOP0        (1<<0)              /* 01-SOP0 */
+#define BMC_AUX_SOP1_HRST   (2<<0)              /* 10-SOP1 hard reset */
+#define BMC_AUX_SOP2_CRST   (3<<0)              /* 11-SOP2 cable reset */
+#define BUF_ERR             (1<<2)              /* BUFFER or DMA error interrupt flag */
+#define IF_RX_BIT           (1<<3)              /* Receive bit or 5bit interrupt flag */
+#define IF_RX_BYTE          (1<<4)              /* Receive byte or SOP interrupt flag */
+#define IF_RX_ACT           (1<<5)              /* Receive completion interrupt flag */
+#define IF_RX_RESET         (1<<6)              /* Receive reset interrupt flag */
+#define IF_TX_END           (1<<7)              /* Transfer completion interrupt flag */
+
+/* USBPD->PORT_CC1 */
+/* USBPD->PORT_CC2 */
+#define PA_CC_AI            (1<<0)               /* CC port comparator analogue input */
+#define CC_PD               (1<<1)               /* CC port pull-down resistor enable */
+#define CC_PU_MASK          (3<<2)               /* Clear CC port pull-up current */
+#define CC_NO_PU            (0<<2)               /* 00-Prohibit pull-up current */
+#define CC_PU_330           (1<<2)               /* 01-330uA */
+#define CC_PU_180           (2<<2)               /* 10-180uA */
+#define CC_PU_80            (3<<2)               /* 11-80uA */
+#define CC_LVE              (1<<4)               /* CC port output low voltage enable */
+#define CC_CMP_MASK         (7<<5)               /* Clear CC_CMP*/
+#define CC_NO_CMP           (0<<5)               /* 000-closed */
+#define CC_CMP_22           (2<<5)               /* 010-0.22V */
+#define CC_CMP_45           (3<<5)               /* 011-0.45V */
+#define CC_CMP_55           (4<<5)               /* 100-0.55V */
+#define CC_CMP_66           (5<<5)               /* 101-0.66V */
+#define CC_CMP_95           (6<<5)               /* 110-0.95V */
+#define CC_CMP_123          (7<<5)               /* 111-1.23V */
+#define USBPD_IN_HVT        (1<<9)
+
+
+/*********************************************************
+ * PD pin PC14/PC15 high threshold input mode:
+ * 1-High threshold input (2.2V typical), to reduce the I/O power consumption during PD communication
+ * 0-Normal GPIO threshold input
+ * *******************************************************/
+#define USBPD_PHY_V33       (1<<8)
+/**********************************************************
+* PD transceiver PHY pull-up limit configuration bits:
+* 1-Direct use of VDD for GPIO applications or PD applications with VDD voltage of 3.3V
+* 0-LDO buck enabled, limited to approx 3.3V, for PD applications with VDD more than 4V
+* ********************************************************/
+
+#define PIN_CC1                    GPIO_Pin_14
+#define PIN_CC2                    GPIO_Pin_15
+
+/******************************************************************************/
+
+#define UPD_TMR_TX (FUNCONF_SYSTEM_CORE_CLOCK / 600000 - 1)
+#define UPD_TMR_RX (FUNCONF_SYSTEM_CORE_CLOCK / 400000 - 1)
+
+#define MASK_PD_STAT      0x03                                               /* Bit mask for current PD status */
+#define PD_RX_SOP0        0x01                                               /* SOP0 received */
+#define PD_RX_SOP1_HRST   0x02                                               /* SOP1 or Hard Reset received */
+#define PD_RX_SOP2_CRST   0x03                                               /* SOP2 or Cable Reset received */
+
+#define UPD_SOP0          ( TX_SEL1_SYNC1 | TX_SEL2_SYNC1 | TX_SEL3_SYNC1 | TX_SEL4_SYNC2 )     /* SOP1 */
+#define UPD_SOP1          ( TX_SEL1_SYNC1 | TX_SEL2_SYNC1 | TX_SEL3_SYNC3 | TX_SEL4_SYNC3 )     /* SOP2 */
+#define UPD_SOP2          ( TX_SEL1_SYNC1 | TX_SEL2_SYNC3 | TX_SEL3_SYNC1 | TX_SEL4_SYNC3 )     /* SOP3 */
+#define UPD_HARD_RESET    ( TX_SEL1_RST1  | TX_SEL2_RST1  | TX_SEL3_RST1  | TX_SEL4_RST2  )     /* Hard Reset*/
+#define UPD_CABLE_RESET   ( TX_SEL1_RST1  | TX_SEL2_SYNC1 | TX_SEL3_RST1  | TX_SEL4_SYNC3 )     /* Cable Reset*/
+
+/* ch32v00x_wwdg.h -----------------------------------------------------------*/
+
+
+/* WWDG_Prescaler */
+#define WWDG_Prescaler_1    ((uint32_t)0x00000000)
+#define WWDG_Prescaler_2    ((uint32_t)0x00000080)
+#define WWDG_Prescaler_4    ((uint32_t)0x00000100)
+#define WWDG_Prescaler_8    ((uint32_t)0x00000180)
+
+#ifdef __cplusplus
+};
+#endif
+
+
+// For debug writing to the debug interface.
+	#define DMDATA0 ((volatile uint32_t*)0xe0000380)
+	#define DMDATA1 ((volatile uint32_t*)0xe0000384)
+	#define DMSTATUS_SENTINEL ((volatile uint32_t*)0xe0000388)// Reads as 0x00000000 if debugger is attached.
+
+// Determination of PLL multiplication factor for non-V003 chips
+
+
+
+
+// Applies to all processors
+
+
+/* some bit definitions for systick regs */
+#define SYSTICK_SR_CNTIF (1<<0)
+#define SYSTICK_CTLR_STE (1<<0)
+#define SYSTICK_CTLR_STIE (1<<1)
+#define SYSTICK_CTLR_STCLK (1<<2)
+#define SYSTICK_CTLR_STRE (1<<3)
+#define SYSTICK_CTLR_SWIE (1<<31)
+
+#define PFIC            ((PFIC_Type *) PFIC_BASE )
+#define NVIC            PFIC
+#define NVIC_KEY1       ((uint32_t)0xFA050000)
+#define	NVIC_KEY2	    ((uint32_t)0xBCAF0000)
+#define	NVIC_KEY3		((uint32_t)0xBEEF0000)
+
+
+#define SysTick         ((SysTick_Type *) SysTick_BASE)
+
+
+#define PA1 1
+#define PA2 2
+#define PC0 32
+#define PC1 33
+#define PC2 34
+#define PC3 35
+#define PC4 36
+#define PC5 37
+#define PC6 38
+#define PC7 39
+#define PD0 48
+#define PD1 49
+#define PD2 50
+#define PD3 51
+#define PD4 52
+#define PD5 53
+#define PD6 54
+#define PD7 55
+
+#define PA0 0
+#define PA3 3
+#define PA4 4
+#define PA5 5
+#define PA6 6
+#define PA7 7
+#define PA8 8
+#define PA9 9
+#define PA10 10
+#define PA11 11
+#define PA12 12
+#define PA13 13
+#define PA14 14
+#define PA15 15
+#define PB0 16
+#define PB1 17
+#define PB2 18
+#define PB3 19
+#define PB4 20
+#define PB5 21
+#define PB6 22
+#define PB7 23
+#define PB8 24
+#define PB9 25
+#define PB10 26
+#define PB11 27
+#define PB12 28
+#define PB13 29
+#define PB14 30
+#define PB15 31
+#define PC8 40
+#define PC9 41
+#define PC10 42
+#define PC11 43
+#define PC12 44
+#define PC13 45
+#define PC14 46
+#define PC15 47
+#define PD8 56
+#define PD9 57
+#define PD10 58
+#define PD11 59
+#define PD12 60
+#define PD13 61
+#define PD14 62
+#define PD15 63
+
+/*
+ * This file contains various parts of the official WCH EVT Headers which
+ * were originally under a restrictive license.
+ * 
+ * The collection of this file was generated by 
+ * cnlohr, 2023-02-18 and
+ * AlexanderMandera, 2023-06-23
+ * It was significantly reworked into several files cnlohr, 2025-01-29
+ *
+ * While originally under a restrictive copyright, WCH has approved use
+ * under MIT-licensed use, because of inclusion in Zephyr, as well as other
+ * open-source licensed projects.
+ *
+ * These copies of the headers from WCH are available now under:
+ *
+ * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#endif // Header guard

--- a/examples_m03x/blink/Makefile
+++ b/examples_m03x/blink/Makefile
@@ -1,0 +1,10 @@
+all : flash
+
+TARGET:=blink
+TARGET_MCU:=CH32M030
+TARGET_MCU_PACKAGE:=CH32M030G8R7
+
+include ../../ch32fun/ch32fun.mk
+
+flash : cv_flash
+clean : cv_clean

--- a/examples_m03x/blink/blink.c
+++ b/examples_m03x/blink/blink.c
@@ -1,0 +1,26 @@
+#include "ch32fun.h"
+#include <stdio.h>
+
+// CH32M030G8R7-PMSM dev board:
+//   - PB0 (pin 28) is the middle pin of one of the JP1-3 hall-sensor
+//     jumpers. With the jumper unbridged (default), PB0 is a free GPIO.
+//     Confirmed via DMM beep-test and microscope inspection.
+//   - LED wired with series resistor from PB0 to the adjacent GND pin
+//     on the JP2-2 header. No soldering required.
+#define LED_PIN PB0
+
+int main()
+{
+	SystemInit();
+	funGpioInitAll();   // Enable APB2 clock for GPIOA, GPIOB, GPIOC
+
+	funPinMode( LED_PIN, GPIO_Speed_10MHz | GPIO_CNF_OUT_PP );
+
+	while(1)
+	{
+		funDigitalWrite( LED_PIN, FUN_HIGH );
+		Delay_Ms( 250 );
+		funDigitalWrite( LED_PIN, FUN_LOW );
+		Delay_Ms( 250 );
+	}
+}

--- a/examples_m03x/blink/funconfig.h
+++ b/examples_m03x/blink/funconfig.h
@@ -1,0 +1,15 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+// CH32M030 configuration
+// HSI 8 MHz -> PLL x18 / HPRE/2 -> SYSCLK 72 MHz (PLL multiplier is hardware-fixed on M030)
+#define FUNCONF_USE_HSI                  1
+#define FUNCONF_USE_HSE                  0
+#define FUNCONF_USE_PLL                  1
+#define FUNCONF_SYSTEM_CORE_CLOCK        72000000
+
+// Disable hardware-prologue/epilogue extension for safety on first bring-up
+// (QingKeV3B core; can be enabled later once confirmed stable)
+#define FUNCONF_ENABLE_HPE               0
+
+#endif


### PR DESCRIPTION

## Summary

Adds first-class support for the **CH32M030** (QingKeV3B, RV32IMC) to the ch32fun
framework. Validated on a **CH32M030G8R7-PMSM** board: the included `blink`
example runs from a cold power-on and toggles PB0 at a steady 2 Hz (scope-measured
2.0033 Hz).

> Flashing support for the M030 lives in a companion minichlink PR (see below) —
> this PR is framework-only and doesn't touch minichlink.

## What's in it

`ch32fun/`:
- `ch32fun.mk` — CH32M030 build dispatch (rv32imc/ilp32, `TARGET_MCU_LD=12`, default package `CH32M030G8R7`).
- `ch32fun.ld` — 64 KB flash / 12 KB RAM memory layout.
- `ch32m030hw.h` — per-chip register map (RM v1.2), following the per-chip-header convention.
- `ch32fun.h` — header selection + HSI/PLL/clock defines.
- `ch32fun.c`:
  - `handle_reset`: M030 uses the V003/X03x/V00x reset variant and sets the QingKeV3B
    core CSRs after vector setup (`corecfgr 0xBC0=0x21`, `intsyscr 0x804=0x03`,
    `inestcr 0xBC1=0x01`, per WCH `startup_ch32m030.S`). Without `corecfgr` the core
    traps in early startup and never reaches `main`.
  - `SystemInit`: dedicated read-modify-write clock bring-up (HSI 8 MHz → fixed-×18
    PLL → HPRE/2 → 72 MHz) that **preserves the factory HSICAL trim** in
    `RCC_CTLR[15:8]`; a wholesale `RCC->CTLR` write wipes it and the PLL never locks.
  - `DelaySysTick`: M030 SysTick is 32-bit compare-mode (`CNT`@0x08 / `CMP`@0x10 are
    32-bit, 0x0C/0x14 reserved); the generic 64-bit `CNT/CMP` access bus-faults. Uses
    the `*L` fields and counts at full HCLK.

`examples_m03x/blink/` — minimal PB0 bring-up demo in a chip-specific example dir
(matching `examples_x00x`, `examples_h41x`, etc.); has `funconfig.h`, so the build CI discovers it.
`README.md` — move ch32m030 to the supported list.

## Testing

- Cold power-on blink at 2 Hz on PB0 (CH32M030G8R7-PMSM), scope-verified (2.0033 Hz).
- Clock state cross-checked against WCH MRS ground truth: `RCC_CTLR=0x03004E83`
  (PLLON+PLLRDY, HSICAL preserved), `RCC_CFGR0=0x1A` (SWS=PLL, HPRE/2), `FLASH_ACTLR=3`.
- `examples/blink` (default ch32v003) still builds — all M030 code is `#if defined(CH32M030)`-guarded.

## Known limitations

- Validated on the **G8R7** package; other M030 packages share the layout but are untested.

## Companion

Flashing the M030 needs the minichlink support in the companion PR: #919 
Companion: #919

<img width="1019" height="599" alt="Proof_Scope" src="https://github.com/user-attachments/assets/a5c16257-216b-4ae7-b472-1b07c87d3397" />