### PR TITLE
ch5xx.c: pwm: add 16-bit register aliases for CH570/CH572 PWM data registers

### DIFF
--- a/ch32fun/ch5xxhw.h
+++ b/ch32fun/ch5xxhw.h
@@ -326,20 +326,38 @@ typedef struct {
     __IO uint8_t CONFIG;         // 2H
 #ifdef CH570_CH572
     __IO uint8_t DMA_CTRL;       // 3H
-    __IO uint8_t PWM1_DATA;      // 4H
-    __IO uint8_t PWM2_DATA;      // 5H
-    __IO uint8_t PWM3_DATA;      // 6H
-    uint8_t RESERVED0[5];        // 7H
+    __packed union {
+        __packed struct {
+            __IO uint8_t PWM1_R8_DATA;   // 4H
+            __IO uint8_t PWM2_R8_DATA;   // 5H
+            __IO uint8_t PWM3_R8_DATA;   // 6H
+            uint8_t RESERVED0[3];        // 7H
+        };
+        __packed struct {
+            __IO uint16_t PWM1_R16_DATA; // 4H
+            __IO uint16_t PWM2_R16_DATA; // 6H
+            __IO uint16_t PWM3_R16_DATA; // 8H
+        };
+    };
+    uint16_t RESERVED1;          // AH
     __IO uint8_t INT_EN;         // CH
     __IO uint8_t INT_FLAG;       // DH
-    uint16_t RESERVED1;          // EH
-    __IO uint8_t PWM4_DATA;      // 10H
-    __IO uint8_t PWM5_DATA;      // 11H
-    uint16_t RESERVED2;          // 12H
+    uint16_t RESERVED2;          // EH
+    __packed union {
+        __packed struct {
+            __IO uint8_t PWM4_R8_DATA; // 10H
+            __IO uint8_t PWM5_R8_DATA; // 11H
+            uint16_t RESERVED3;        // 12H
+        };
+        __packed struct {
+            __IO uint16_t PWM4_R16_DATA; // 10H
+            __IO uint16_t PWM5_R16_DATA; // 12H
+        };
+    };
     __IO uint16_t CYC_VALUE;     // 14H
     __IO uint16_t CYC1_VALUE;    // 16H
     __IO uint16_t CLOCK_DIV;     // 18H
-    uint16_t RESERVED3;          // 1AH
+    uint16_t RESERVED4;          // 1AH
     __IO uint32_t DMA_NOW;       // 1CH
     __IO uint32_t DMA_BEG;       // 20H
     __IO uint32_t DMA_END;       // 24H
@@ -355,7 +373,7 @@ typedef struct {
     __IO uint8_t PWM11_DATA;     // BH
     __IO uint8_t INT_CTRL;       // CH
 #if defined(CH584_CH585) || defined(CH591_CH592)
-    uint8_t RESERVED0[3];        // DH
+    uint8_t RESERVED5[3];        // DH
     __IO uint32_t REG_DATA8;     // 10H
     __IO uint32_t REG_CYCLE;     // 14H
 #endif


### PR DESCRIPTION
**Motivation**

Some PWM channels on the CH570/CH572 support two data register modes: 8-bit and 16-bit, depending on the value of `RB_PWM_CYC_MOD`. The current `PWM_TypeDef` only exposes the registers for 8-bit mode. This PR adds support for the 16-bit mode.

**Changes**

- Replace individual PWMx_DATA 8-bit register definitions with packed unions providing:
  - PWMx_R8_DATA for 8-bit register access.
  - PWMx_R16_DATA for 16-bit register access where supported by the hardware.
- Preserve the original memory layout and register offsets by using packed structs/unions and updating reserved fields accordingly.
- Rename reserved fields (RESERVED0–RESERVED5) to avoid duplicate member names after introducing the unions.