### PR TITLE
warning: suppress file-level warning when building headers with Zephyr

### DIFF
--- a/ch32fun/ch32h41xhw.h
+++ b/ch32fun/ch32h41xhw.h
@@ -13646,7 +13646,11 @@ typedef enum
 #ifndef __ASSEMBLER__
 
 /* Output Maximum frequency selection */
+
+#ifndef __ZEPHYR__
 #warning "Speeds on H41x have their own register, dont concat in CFGLR"
+#endif
+
 typedef enum
 {
 	GPIO_Speed_10MHz = 0,


### PR DESCRIPTION
Zephyr support for the CH32H417 is being added to zephyr: https://github.com/zephyrproject-rtos/zephyr/pull/111725

A requirement of the zephyr's CI is that warnings are treated as errors.
This PR guards an unconditional warning with the `__ZEPHYR__` macro that all zephyr files are built with.

I'm upstreaming it here as ideally `hal_wch` will exactly follow these upstream files.
Alternatively the entire warning statement could be removed if it's deemed unecessary.