### PR TITLE
Fix SysTick interpretation for H41x

### DIFF
--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -1888,10 +1888,10 @@ void DelaySysTick( uint32_t n )
 #if defined(CH32V003) || defined(CH32V00x)
 	uint32_t targend = SysTick->CNT + n;
 	while( ((int32_t)( SysTick->CNT - targend )) < 0 );
-#elif defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x) || defined(CH32L103) || defined(CH582_CH583) || defined(CH591_CH592) || defined(CH32H41x)
+#elif defined(CH32V20x) || defined(CH32V30x) || defined(CH32X03x) || defined(CH32L103) || defined(CH582_CH583) || defined(CH591_CH592)
 	uint64_t targend = SysTick->CNT + n;
 	while( ((int64_t)( SysTick->CNT - targend )) < 0 );
-#elif defined(CH32V10x) || defined(CH570_CH572) || defined(CH584_CH585)
+#elif defined(CH32V10x) || defined(CH570_CH572) || defined(CH584_CH585) || defined(CH32H41x)
 	uint32_t targend = SysTick->CNTL + n;
 	while( ((int32_t)( SysTick->CNTL - targend )) < 0 );
 #elif defined(CH571_CH573)


### PR DESCRIPTION
Fixes the bug that the blinky example just crashes after about 5 minutes.

The H41x chip series is a dual-core QingKe V3F and V5F. The V3F starts up first and can release the V5F to run something later.

Technically, each core has its own independent SysTick, but this is not touched here. Both the V3F and V5F have a only 32-bit SYSTICK counter.

<img width="789" height="231" alt="grafik" src="https://github.com/user-attachments/assets/ca3118bb-2c78-4f80-bd8e-6d8f1ca76ae4" />
<img width="730" height="483" alt="grafik" src="https://github.com/user-attachments/assets/b78cdcf8-7235-488a-bc8a-ad908a6b0132" />
<img width="733" height="194" alt="grafik" src="https://github.com/user-attachments/assets/9d34214c-fb7b-4f94-8a28-f200e605149a" />

Hence they need to be in the codepath for a 32-bit CNT(L).

Without it, and HCLK running at 100 MHz and SYSTICK running at HCKL / 8, a 32-bit overflow occurs after `2^32 / (100_000_000 / 8) seconds = 5 min 44s` which then gets hung up in the delay function.

Runtime discrimination for HartID 0 or 1 and using the core-specific SYSTICK will be an additional improvement, but right now it doesn't break anything.
