### PR TITLE
Add support for all four channels to tim1_capture_dma example

### DIFF
--- a/examples/tim1_capture_dma/tim1_capture_dma.c
+++ b/examples/tim1_capture_dma/tim1_capture_dma.c
@@ -1,8 +1,17 @@
-// Example using Timer 1 capture to look for down-going events
-// on PD2.  Then using DMA to capture that event and write it
-// to a circular queue that can be read out later.
+// Example using Timer 1 capture to look for down or up-going events
+// on PD2/PA1/PC3/PC4.  Then using DMA to capture that event and to 
+// write it to a circular queue that can be read out later.
 //
-// For it to produce interesting output, you can wire PD2 to PD3.
+// For it to produce interesting output, you can wire 
+// PD2/PA1/PC3/PC4 to PD3.
+//
+// TIM1CH1 is PD2
+// TIM1CH2 is PA1
+// TIM1CH3 is PC3
+// TIM1CH4 is PC4
+//
+// Uncomment/comment the correct lines in the example to pick the 
+// desired channel
 
 #include "ch32fun.h"
 #include <stdio.h>
@@ -15,29 +24,46 @@ int main()
 	SystemInit();
 	funGpioInitAll();
 
-	// Enable GPIOs
+	// Remap GPIOs
 	RCC->APB2PCENR |= RCC_APB2Periph_TIM1 | RCC_APB2Periph_AFIO;
 	RCC->AHBPCENR |= RCC_AHBPeriph_DMA1;
 
-	// TIM2_CH1 -> PD2 -> DMA1_CH2
-	#define DMA_IN  DMA1_Channel2
+#define DMA_IN  DMA1_Channel2 // TIM2_CH1 -> PD2 -> DMA1_CH2
+//#define DMA_IN  DMA1_Channel3 // TIM2_CH2 -> PA1 -> DMA1_CH3
+//#define DMA_IN  DMA1_Channel6 // TIM2_CH3 -> PC3 -> DMA1_CH6
+//#define DMA_IN  DMA1_Channel4 // TIM2_CH4 -> PC4 -> DMA1_CH4
 
-	// T1C1 -> What we are sampling.
-	funPinMode( PD2, GPIO_CFGLR_IN_PUPD );
-	funDigitalWrite( PD2, 1 );
+//	funPinMode( PD2, GPIO_CFGLR_IN_PUPD );
+//	funDigitalWrite( PD2, 0 );
+//	funPinMode( PA1, GPIO_CFGLR_IN_PUPD );
+//	funDigitalWrite( PA1, 1 );
+//	funPinMode( PC3, GPIO_CFGLR_IN_PUPD );
+//	funDigitalWrite( PC3, 1 );
+//	funPinMode( PC4, GPIO_CFGLR_IN_PUPD );
+//	funDigitalWrite( PC4, 1 );
 
-	// PD3 output to send something back into PD2.
+	// PD3 output to send something back into timer input
+	// Remember to connect this to PD2/PA1/PC3/PD4 as an example signal
+	// to capture.
 	funPinMode( PD3, GPIO_CFGLR_OUT_2Mhz_PP );
 
-	// Enable TIM2
+	// Enable TIM1
 	TIM1->CTLR1 = TIM_ARPE | TIM_CEN;
+
 	TIM1->DMAINTENR = TIM_CC1DE | TIM_UDE; // Enable DMA for T1CC1
+//	TIM1->DMAINTENR = TIM_CC2DE | TIM_UDE; // Enable DMA for T1CC2
+//	TIM1->DMAINTENR = TIM_CC3DE | TIM_UDE; // Enable DMA for T1CC3
+//	TIM1->DMAINTENR = TIM_CC4DE | TIM_UDE; // Enable DMA for T1CC4
 
 	int samples_in_buffer = sizeof(reply_buffer) / sizeof(reply_buffer[0]);
 
-	// TIM1_TRIG/TIM1_COM/TIM1_CH4
 	DMA_IN->MADDR = (uint32_t)reply_buffer;
+
 	DMA_IN->PADDR = (uint32_t)&TIM1->CH1CVR; // Input
+//	DMA_IN->PADDR = (uint32_t)&TIM1->CH2CVR; // Input
+//	DMA_IN->PADDR = (uint32_t)&TIM1->CH3CVR; // Input
+//	DMA_IN->PADDR = (uint32_t)&TIM1->CH4CVR; // Input
+//
 	DMA_IN->CFGR = 
 		0                 |                  // PERIPHERAL to MEMORY
 		0                 |                  // Low priority.
@@ -53,11 +79,17 @@ int main()
 	TIM1->PSC = 0x0fff;		// set TIM1 clock prescaler divider (Massive prescaler)
 	TIM1->ATRLR = 65535;	// set PWM total cycle width
 
-	// Tim 1 input / capture (CC1S = 01)
+	// Tim 1 input / capture (CCxS = 01)
 	TIM1->CHCTLR1 = TIM_CC1S_0;
+//	TIM1->CHCTLR1 = TIM_CC2S_0;
+//	TIM1->CHCTLR2 = TIM_CC3S_0;
+//	TIM1->CHCTLR2 = TIM_CC4S_0;
 
-	// Add here CC1P to switch from UP->GOING to DOWN->GOING log times.
+	// Add here CCxP to switch from UP->GOING to DOWN->GOING log times.
 	TIM1->CCER = TIM_CC1E;// | TIM_CC1P;
+//	TIM1->CCER = TIM_CC2E;// | TIM_CC2P;
+//	TIM1->CCER = TIM_CC3E;// | TIM_CC3P;
+//	TIM1->CCER = TIM_CC4E;// | TIM_CC4P;
 	
 	// initialize counter
 	TIM1->SWEVGR = TIM_UG;


### PR DESCRIPTION
Added the ability to use any of the four channels of timer1 on the CH32V003's advanced timer TIM1 to the tim1_capture_dma example.