### PR TITLE
Add chip_id check for b003 programmer

### DIFF
--- a/minichlink/pgm-b003fun.c
+++ b/minichlink/pgm-b003fun.c
@@ -734,7 +734,7 @@ int B003DetermineChipType( void * dev )
 
 	if( (one & 2) || two != -1 ) read_protection = 1;
 
-	if( chip_id == 0xffffffff )
+	if( chip_id == 0xffffffff || chip_id == 0xe339e339 )
 	{
 		MCF.ReadWord( dev, 0x1ffff704, &chip_id );
 		switch (chip_id>>20)


### PR DESCRIPTION
When reading memory address 0x1ffff7c4 on the ch32v203, the chip returns 0xe339e339. As this isn't 0xffffffff, the programmer takes the else branch and mistakes the chip as a v003.