### PR TITLE
fix USB-PD implementation

### DIFF
--- a/examples_x035/usbpd_sink/usbpd.h
+++ b/examples_x035/usbpd_sink/usbpd.h
@@ -553,7 +553,7 @@ typedef struct
 	USBPD_CC_e lastCCLine;
 	USBPD_SPR_CapabilitiesMessage_t caps;
 	uint8_t messageID;
-	uint8_t pdoCount;
+	volatile uint8_t pdoCount;
 	bool gotSourceGoodCRC;
 } USBPD_Instance_t;
 
@@ -641,11 +641,21 @@ USBPD_Result_e USBPD_SinkNegotiate( void )
 			break;
 
 		case eSTATE_SOURCE_CAP:
+			// Wait for the GoodCRC TX (started inside ParsePacket) to finish before
+			// sending the Request. Without this, SelectPDO's SendMessage races with
+			// the in-progress GoodCRC transmission (~450 µs at 300 kHz BMC), causing
+			// strict chargers to reject or ignore the request.
+			while ( USBPD->CONTROL & PD_TX_EN );
 			USBPD_SelectPDO( 0, 0 ); // Select the first PDO by default
 			s_instance.state = eSTATE_WAIT_ACCEPT;
 			break;
 
-		case eSTATE_PS_RDY: return eUSBPD_OK;
+		case eSTATE_PS_RDY:
+			// Barrier: ensure IRQ-written fields (caps, pdVersion, …) are visible to the
+			// caller before eUSBPD_OK is returned. Without this, LTO may propagate
+			// pre-negotiate stale values into subsequent USBPD_GetCapabilities() reads.
+			__asm volatile( "" ::: "memory" );
+			return eUSBPD_OK;
 
 		default: break;
 	}
@@ -872,6 +882,8 @@ static void ParsePacket( void )
 
 			case eUSBPD_CTRL_MSG_PS_RDY: nextState = eSTATE_PS_RDY; break;
 
+			case eUSBPD_CTRL_MSG_WAIT: nextState = eSTATE_CABLE_DETECT; break;
+
 			default: break;
 		}
 	}
@@ -931,6 +943,7 @@ void USBPD_IRQHandler( void )
 	if ( USBPD->STATUS & IF_RX_RESET )
 	{
 		USBPD->STATUS |= IF_RX_RESET;
+		SwitchRXMode();
 	}
 }
 

--- a/examples_x035/usbpd_sink/usbpd.h
+++ b/examples_x035/usbpd_sink/usbpd.h
@@ -650,12 +650,7 @@ USBPD_Result_e USBPD_SinkNegotiate( void )
 			s_instance.state = eSTATE_WAIT_ACCEPT;
 			break;
 
-		case eSTATE_PS_RDY:
-			// Barrier: ensure IRQ-written fields (caps, pdVersion, …) are visible to the
-			// caller before eUSBPD_OK is returned. Without this, LTO may propagate
-			// pre-negotiate stale values into subsequent USBPD_GetCapabilities() reads.
-			__asm volatile( "" ::: "memory" );
-			return eUSBPD_OK;
+		case eSTATE_PS_RDY: return eUSBPD_OK;
 
 		default: break;
 	}
@@ -780,6 +775,12 @@ USBPD_Result_e USBPD_SelectPDO( uint8_t index, uint32_t voltageIn100mV )
  */
 size_t USBPD_GetCapabilities( USBPD_SPR_CapabilitiesMessage_t **capabilities )
 {
+	// Barrier: caps is written by the IRQ via memcpy; without this, LTO can
+	// prove the main-thread call chain never writes caps and fold all reads to
+	// zero. The barrier is placed here so every caller gets correct data
+	// regardless of which state the negotiation exited through.
+	__asm volatile( "" ::: "memory" );
+
 	if ( s_instance.pdoCount == 0 )
 	{
 		return 0;


### PR DESCRIPTION
Hey! This PR fixes `usbpd.h` in `examples_x035/usbpd_sink`.
What I wanted to get working was just a simple PD sink requesting 12V or 9V from a charger, but no chargers successfully negotiated.
With these fixes, negotiation works. I tested this on an iPad Pro charger and a ThinkPad T14 power brick.

Disclosure: This PR was assisted by Claude Code. Should be reviewed by someone familiar with the PD protocol.