### PR TITLE
fix: undefine host putchar macro for all toolchains

### DIFF
--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -92,10 +92,10 @@ void __libc_init_array(void)
 #include <stdint.h>
 #include <ch32fun.h>
 
-#if defined(__FreeBSD__)
 #ifdef putchar
+// Host stdio headers may define putchar as a macro. The firmware provides its
+// own weak implementation below, so remove the host macro on every toolchain.
 #undef putchar
-#endif
 #endif
 
 #if defined(CH32H41x)


### PR DESCRIPTION
Fixes #939.

## What changed

The firmware source now undefines a host-provided `putchar` macro whenever one is present, instead of doing so only for `__FreeBSD__`. This keeps the weak firmware implementation from colliding with stdio macros in other toolchains, including the Debian RISC-V toolchain reported in the issue.

## Verification

- `git diff --check` passes.
- The source change is limited to the host-macro guard.
- I could not run the documented example build because this Windows environment has no `make` or RISC-V cross compiler installed.

The existing FreeBSD behavior is preserved, and other toolchains now receive the same protection.