### PR TITLE
Update CH570/CH572 CMP_TypeDef register mapping

### DIFF
--- a/ch32fun/ch5xxhw.h
+++ b/ch32fun/ch5xxhw.h
@@ -243,7 +243,15 @@ typedef struct
 
 #ifdef CH570_CH572
 typedef struct {
-    __IO uint32_t CTRL;
+	union {
+		__IO uint32_t CTRL;
+		struct {
+			__IO uint8_t CTRL0;
+			__IO uint8_t CTRL1;
+			__IO uint8_t CTRL2;
+			__IO uint8_t CTRL3;
+		};
+	};
 } CMP_TypeDef;
 #endif
 


### PR DESCRIPTION
This PR updates the CH570/CH572 comparator register structure to expose both byte-wise and 32-bit access to the `CTRL` register.

The structure now provides `CTRL0` to `CTRL3` fields matching the register definitions (`R8_CMP_CTRL_0` to `R8_CMP_CTRL_3`) while keeping the existing `CTRL` 32-bit access for compatibility.
